### PR TITLE
Allow the live rendering of the markdown content of textareas

### DIFF
--- a/5esheets/static/css/regular.css
+++ b/5esheets/static/css/regular.css
@@ -701,3 +701,7 @@ input.custom-resource-header {
   text-transform: uppercase;
   overflow-wrap: break-word;
 }
+
+.markdown-rendered li {
+  margin-left: 1.5rem;
+}

--- a/5esheets/static/css/style.css
+++ b/5esheets/static/css/style.css
@@ -8,6 +8,6 @@
 @import url(phone.css) screen and (max-width: 500px);
 
 
-.hide {
+.hidden {
   display: none !important;
 }

--- a/5esheets/static/js/index.js
+++ b/5esheets/static/js/index.js
@@ -134,6 +134,24 @@ const sortSkillsElements = () => {
 }
 
 
+const hideRawTextareaShowRenderedDiv = (id) => {
+  textarea = document.getElementById(`${id}-raw`);
+  neighbourDiv = document.getElementById(`${id}-rendered`);
+  textarea.textContent = textarea.value;
+  rendered = marked.parse(textarea.value, {mangle: false, headerIds: false});
+  neighbourDiv.innerHTML = DOMPurify.sanitize(rendered);
+  textarea.classList.add('hidden');
+  neighbourDiv.classList.remove('hidden');
+}
+
+const showRawTextareHideRenderedDiv = (id) => {
+  textarea = document.getElementById(`${id}-raw`);
+  neighbourDiv = document.getElementById(`${id}-rendered`);
+  textarea.classList.remove("hidden");
+  textarea.focus({preventScroll: true});
+  neighbourDiv.classList.add("hidden");
+}
+
 caracs.forEach((carac) => {
   let caracScoreItem = document.getElementsByName(`${carac}score`)[0];
   caracScoreItem.addEventListener('change', () => {
@@ -199,5 +217,8 @@ document.onreadystatechange = function () {
     updateRemainingDailyPreparedSpells();
     replaceCaracModMacroByValue();
     sortSkillsElements();
+    ['features', 'equipment', 'otherprofs'].forEach((id) => {
+      hideRawTextareaShowRenderedDiv(id);
+    })
   }
 }

--- a/5esheets/templates/character.html
+++ b/5esheets/templates/character.html
@@ -345,7 +345,10 @@
                 <div class="box-subtitle">
                     <label class="subtitle" for="otherprofs">{{ _("other_proficiencies_and_languages") }}</label>
                 </div>
-                <textarea name="otherprofs">{{ character.data['otherprofs'] }}</textarea>
+                <textarea id="otherprofs-raw" class="hidden" onfocusout="hideRawTextareaShowRenderedDiv('otherprofs')"
+                    name="otherprofs">{{ character.data['otherprofs'] }}</textarea>
+                <div class="markdown-rendered" id="otherprofs-rendered"
+                    onclick="showRawTextareHideRenderedDiv('otherprofs')"></div>
             </div>
         </section>
         <section id="combatcol">
@@ -516,8 +519,10 @@
             </section>
             <section class="equipment box roundedbox box-textarea">
                 <div>
-                    <textarea placeholder="Equipment list here"
-                        name="equipment">{{ character.data['equipment'] }}</textarea>
+                    <textarea id="equipment-raw" class="hidden" onfocusout="hideRawTextareaShowRenderedDiv('equipment')"
+                        placeholder="Equipment list here" name="equipment">{{ character.data['equipment'] }}</textarea>
+                    <div class="markdown-rendered" id="equipment-rendered"
+                        onclick="showRawTextareHideRenderedDiv('equipment')"></div>
                     <div class="money">
                         <ul>
                             <li class="coin-type">
@@ -572,7 +577,11 @@
                     <div class="box-subtitle">
                         <label class="subtitle" for="features">{{ _("features_&_traits") }}</label>
                     </div>
-                    <textarea name="features">{{ character.data['features'] }}</textarea>
+                    <textarea id="features-raw" class="hidden" onfocusout="hideRawTextareaShowRenderedDiv('features')"
+                        name="features">{{ character.data['features'] }}</textarea>
+                    <div class="markdown-rendered" id="features-rendered"
+                        onclick="showRawTextareHideRenderedDiv('features')">
+                        {{ character.data['features'] }}</div>
                 </div>
             </section>
         </section>

--- a/5esheets/templates/sheet.html
+++ b/5esheets/templates/sheet.html
@@ -2,6 +2,8 @@
 
 
 {% block head %}
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script async src="static/js/index.js" rel="text/javascript"></script>
 <title>{{ character.name }}</title>
 {% endblock %}


### PR DESCRIPTION
We leverage https://github.com/markedjs/marked to render the markdown textarea content. The content is split between a textarea (markdown) and a div (rendered). By default, we hide the textearea and only show the rendered text. When we click on the div, we toggle the visibility of both elements, and once again when we leave focus.

Fixes #5