### PR TITLE
Generate the 5esheets typescript API client from the API spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@ $(wildcard dnd5esheets/translations/*/*/messages.mo): $(wildcard dnd5esheets/tra
 dnd5esheets/templates/spellbook.html:
 	python3 scripts/generate_spellbook.py > dnd5esheets/templates/spellbook.html
 
-dnd5esheets/client/openapi.json:
-	curl http://localhost:8000/openapi.json | python3 -m json.tool > dnd5esheets/client/openapi.json
+dnd5esheets/client/openapi.json: dnd5esheets/api.py dnd5esheets/schemas.py
+	curl http://localhost:8000/openapi.json > dnd5esheets/client/openapi.json
+	python3 scripts/preprocess_openapi_json.py
 
 dnd5esheets/schemas.py:
+
+dnd5esheets/api.py:
 
 api-doc:  ## Open the 5esheets API documentation
 	open http://localhost:8000/redoc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL = help
-.PHONY: api-doc api-explorer black check dev dnd5esheets/templates/spellbook.html docker-build docker-run init mypy ruff run help
+.PHONY: api-doc api-explorer black check dev dnd5esheets/templates/spellbook.html \
+	docker-build docker-run init mypy ruff run svelte-check svelte-build \
+	svelte-generate-api-client help
 
 dnd5esheets/translations/messages.pot: dnd5esheets/templates/*.html
 	poetry run pybabel extract --omit-header -F babel.cfg -o dnd5esheets/translations/messages.pot .
@@ -12,6 +14,11 @@ $(wildcard dnd5esheets/translations/*/*/messages.mo): $(wildcard dnd5esheets/tra
 
 dnd5esheets/templates/spellbook.html:
 	python3 scripts/generate_spellbook.py > dnd5esheets/templates/spellbook.html
+
+dnd5esheets/client/openapi.json:
+	curl http://localhost:8000/openapi.json | python3 -m json.tool > dnd5esheets/client/openapi.json
+
+dnd5esheets/schemas.py:
 
 api-doc:  ## Open the 5esheets API documentation
 	open http://localhost:8000/redoc
@@ -61,6 +68,9 @@ svelte-build:
 svelte-check:
 	cd dnd5esheets/client && npm run check
 
+svelte-generate-api-client: dnd5esheets/client/openapi.json  ## Generate the typescript client for the 5esheet API
+	cd dnd5esheets/client && npm run generate-client
+
 ruff:
 	poetry run ruff --fix dnd5esheets/
 
@@ -76,4 +86,4 @@ translations-compile: $(wildcard dnd5esheets/translations/*/*/messages.mo)  ## C
 
 
 help:  ## Display help
-	@grep -E '^[%a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[%a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-26s\033[0m %s\n", $$1, $$2}'

--- a/dnd5esheets/api.py
+++ b/dnd5esheets/api.py
@@ -1,16 +1,20 @@
-from fastapi import Depends, APIRouter
-
+from fastapi import APIRouter, Depends
+from fastapi.routing import APIRoute
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .db import create_scoped_session
-
-from .schemas import ListCharacterSchema, CharacterSchema, UpdateCharacterSchema
 from .repositories import CharacterRepository
+from .schemas import CharacterSchema, ListCharacterSchema, UpdateCharacterSchema
 
-api = APIRouter(prefix="/api")
+
+def custom_generate_unique_id(route: APIRoute):
+    return f"{route.tags[0]}-{route.name}"
 
 
-@api.get("/characters/", response_model=list[ListCharacterSchema])
+api = APIRouter(prefix="/api", generate_unique_id_function=custom_generate_unique_id)
+
+
+@api.get("/characters/", response_model=list[ListCharacterSchema], tags=["character"])
 async def list_characters(
     session: AsyncSession = Depends(create_scoped_session),
 ):
@@ -22,7 +26,7 @@ async def list_characters(
     return await CharacterRepository.list_all(session)
 
 
-@api.get("/characters/{slug}", response_model=CharacterSchema)
+@api.get("/characters/{slug}", response_model=CharacterSchema, tags=["character"])
 async def display_character(
     slug: str, session: AsyncSession = Depends(create_scoped_session)
 ):
@@ -30,7 +34,7 @@ async def display_character(
     return await CharacterRepository.get_by_slug(session, slug=slug)
 
 
-@api.put("/characters/{slug}")
+@api.put("/characters/{slug}", tags=["character"])
 async def update_character(
     slug: str,
     character_data: UpdateCharacterSchema,

--- a/dnd5esheets/client/openapi.json
+++ b/dnd5esheets/client/openapi.json
@@ -1,0 +1,354 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "FastAPI",
+        "version": "0.1.0"
+    },
+    "paths": {
+        "/api/characters/": {
+            "get": {
+                "summary": "List Characters",
+                "description": "List all characters.\n\nThe returned payload will not include the character sheet details.",
+                "operationId": "list_characters_api_characters__get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Response List Characters Api Characters  Get",
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ListCharacterSchema"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/characters/{slug}": {
+            "get": {
+                "summary": "Display Character",
+                "description": "Display all details of a given character.",
+                "operationId": "display_character_api_characters__slug__get",
+                "parameters": [
+                    {
+                        "required": true,
+                        "schema": {
+                            "title": "Slug",
+                            "type": "string"
+                        },
+                        "name": "slug",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CharacterSchema"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update Character",
+                "description": "Update a character details.\n\nExamples of JSON body paylods:\n\n- `{\"level\": 5 }`\n- `{\"name\": \"Toto\"}`\n- `{\"class_\": \"Guerrier\", \"data\": {\"background\": \"Folk Hero\"}}`\n\nIn the last example, we update both a direct character attribute\nas well as an attribute nested in the character JSON data.",
+                "operationId": "update_character_api_characters__slug__put",
+                "parameters": [
+                    {
+                        "required": true,
+                        "schema": {
+                            "title": "Slug",
+                            "type": "string"
+                        },
+                        "name": "slug",
+                        "in": "path"
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateCharacterSchema"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Response Update Character Api Characters  Slug  Put",
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CharacterSchema": {
+                "title": "CharacterSchema",
+                "required": [
+                    "id",
+                    "name",
+                    "slug",
+                    "class_",
+                    "level",
+                    "data",
+                    "player",
+                    "party"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "title": "The character primary key in database",
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "The character name",
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "slug": {
+                        "title": "The character slug, used to identify it in the API",
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "class_": {
+                        "title": "The character class",
+                        "maxLength": 80,
+                        "type": "string"
+                    },
+                    "level": {
+                        "title": "The character level",
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "data": {
+                        "title": "Data",
+                        "type": "object",
+                        "description": "The embdedded character sheet JSON data"
+                    },
+                    "player": {
+                        "title": "The embedded character's player schema",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PlayerSchema"
+                            }
+                        ]
+                    },
+                    "party": {
+                        "title": "The embedded character's party schema",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PartySchema"
+                            }
+                        ]
+                    }
+                }
+            },
+            "HTTPValidationError": {
+                "title": "HTTPValidationError",
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "title": "Detail",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        }
+                    }
+                }
+            },
+            "ListCharacterSchema": {
+                "title": "ListCharacterSchema",
+                "required": [
+                    "id",
+                    "name",
+                    "slug",
+                    "class_",
+                    "level",
+                    "player",
+                    "party"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "title": "The character primary key in database",
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "The character name",
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "slug": {
+                        "title": "The character slug, used to identify it in the API",
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "class_": {
+                        "title": "The character class",
+                        "maxLength": 80,
+                        "type": "string"
+                    },
+                    "level": {
+                        "title": "The character level",
+                        "maximum": 20.0,
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "player": {
+                        "title": "The embedded character's player schema",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PlayerSchema"
+                            }
+                        ]
+                    },
+                    "party": {
+                        "title": "The embedded character's party schema",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PartySchema"
+                            }
+                        ]
+                    }
+                }
+            },
+            "PartySchema": {
+                "title": "PartySchema",
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "title": "The party primary key in database",
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "The party name",
+                        "maxLength": 255,
+                        "type": "string"
+                    }
+                }
+            },
+            "PlayerSchema": {
+                "title": "PlayerSchema",
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "title": "The player primary key in database",
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "The player name",
+                        "maxLength": 255,
+                        "type": "string"
+                    }
+                }
+            },
+            "UpdateCharacterSchema": {
+                "title": "UpdateCharacterSchema",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "title": "A new character name (Optional)",
+                        "type": "string"
+                    },
+                    "class_": {
+                        "title": "A new character class (Optional)",
+                        "maxLength": 80,
+                        "type": "string"
+                    },
+                    "level": {
+                        "title": "A new character level (Optional)",
+                        "minimum": 1.0,
+                        "type": "integer"
+                    },
+                    "data": {
+                        "title": "Updates to the character sheet fields (Optional)",
+                        "type": "object"
+                    }
+                }
+            },
+            "ValidationError": {
+                "title": "ValidationError",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "loc": {
+                        "title": "Location",
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        }
+                    },
+                    "msg": {
+                        "title": "Message",
+                        "type": "string"
+                    },
+                    "type": {
+                        "title": "Error Type",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dnd5esheets/client/openapi.json
+++ b/dnd5esheets/client/openapi.json
@@ -1,354 +1,363 @@
 {
-    "openapi": "3.0.2",
-    "info": {
-        "title": "FastAPI",
-        "version": "0.1.0"
-    },
-    "paths": {
-        "/api/characters/": {
-            "get": {
-                "summary": "List Characters",
-                "description": "List all characters.\n\nThe returned payload will not include the character sheet details.",
-                "operationId": "list_characters_api_characters__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response List Characters Api Characters  Get",
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ListCharacterSchema"
-                                    }
-                                }
-                            }
-                        }
-                    }
+  "openapi": "3.0.2",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/characters/": {
+      "get": {
+        "tags": [
+          "character"
+        ],
+        "summary": "List Characters",
+        "description": "List all characters.\n\nThe returned payload will not include the character sheet details.",
+        "operationId": "list_characters",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Character-List Characters",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ListCharacterSchema"
+                  }
                 }
+              }
             }
+          }
+        }
+      }
+    },
+    "/api/characters/{slug}": {
+      "get": {
+        "tags": [
+          "character"
+        ],
+        "summary": "Display Character",
+        "description": "Display all details of a given character.",
+        "operationId": "display_character",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "name": "slug",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharacterSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "character"
+        ],
+        "summary": "Update Character",
+        "description": "Update a character details.\n\nExamples of JSON body paylods:\n\n- `{\"level\": 5 }`\n- `{\"name\": \"Toto\"}`\n- `{\"class_\": \"Guerrier\", \"data\": {\"background\": \"Folk Hero\"}}`\n\nIn the last example, we update both a direct character attribute\nas well as an attribute nested in the character JSON data.",
+        "operationId": "update_character",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "name": "slug",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCharacterSchema"
+              }
+            }
+          },
+          "required": true
         },
-        "/api/characters/{slug}": {
-            "get": {
-                "summary": "Display Character",
-                "description": "Display all details of a given character.",
-                "operationId": "display_character_api_characters__slug__get",
-                "parameters": [
-                    {
-                        "required": true,
-                        "schema": {
-                            "title": "Slug",
-                            "type": "string"
-                        },
-                        "name": "slug",
-                        "in": "path"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CharacterSchema"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Character-Update Character",
+                  "type": "object"
                 }
-            },
-            "put": {
-                "summary": "Update Character",
-                "description": "Update a character details.\n\nExamples of JSON body paylods:\n\n- `{\"level\": 5 }`\n- `{\"name\": \"Toto\"}`\n- `{\"class_\": \"Guerrier\", \"data\": {\"background\": \"Folk Hero\"}}`\n\nIn the last example, we update both a direct character attribute\nas well as an attribute nested in the character JSON data.",
-                "operationId": "update_character_api_characters__slug__put",
-                "parameters": [
-                    {
-                        "required": true,
-                        "schema": {
-                            "title": "Slug",
-                            "type": "string"
-                        },
-                        "name": "slug",
-                        "in": "path"
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateCharacterSchema"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Update Character Api Characters  Slug  Put",
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
+              }
             }
-        }
-    },
-    "components": {
-        "schemas": {
-            "CharacterSchema": {
-                "title": "CharacterSchema",
-                "required": [
-                    "id",
-                    "name",
-                    "slug",
-                    "class_",
-                    "level",
-                    "data",
-                    "player",
-                    "party"
-                ],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "title": "The character primary key in database",
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "title": "The character name",
-                        "maxLength": 255,
-                        "type": "string"
-                    },
-                    "slug": {
-                        "title": "The character slug, used to identify it in the API",
-                        "maxLength": 255,
-                        "type": "string"
-                    },
-                    "class_": {
-                        "title": "The character class",
-                        "maxLength": 80,
-                        "type": "string"
-                    },
-                    "level": {
-                        "title": "The character level",
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "data": {
-                        "title": "Data",
-                        "type": "object",
-                        "description": "The embdedded character sheet JSON data"
-                    },
-                    "player": {
-                        "title": "The embedded character's player schema",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PlayerSchema"
-                            }
-                        ]
-                    },
-                    "party": {
-                        "title": "The embedded character's party schema",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PartySchema"
-                            }
-                        ]
-                    }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationError"
-                        }
-                    }
-                }
-            },
-            "ListCharacterSchema": {
-                "title": "ListCharacterSchema",
-                "required": [
-                    "id",
-                    "name",
-                    "slug",
-                    "class_",
-                    "level",
-                    "player",
-                    "party"
-                ],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "title": "The character primary key in database",
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "title": "The character name",
-                        "maxLength": 255,
-                        "type": "string"
-                    },
-                    "slug": {
-                        "title": "The character slug, used to identify it in the API",
-                        "maxLength": 255,
-                        "type": "string"
-                    },
-                    "class_": {
-                        "title": "The character class",
-                        "maxLength": 80,
-                        "type": "string"
-                    },
-                    "level": {
-                        "title": "The character level",
-                        "maximum": 20.0,
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "player": {
-                        "title": "The embedded character's player schema",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PlayerSchema"
-                            }
-                        ]
-                    },
-                    "party": {
-                        "title": "The embedded character's party schema",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PartySchema"
-                            }
-                        ]
-                    }
-                }
-            },
-            "PartySchema": {
-                "title": "PartySchema",
-                "required": [
-                    "id",
-                    "name"
-                ],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "title": "The party primary key in database",
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "title": "The party name",
-                        "maxLength": 255,
-                        "type": "string"
-                    }
-                }
-            },
-            "PlayerSchema": {
-                "title": "PlayerSchema",
-                "required": [
-                    "id",
-                    "name"
-                ],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "title": "The player primary key in database",
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "title": "The player name",
-                        "maxLength": 255,
-                        "type": "string"
-                    }
-                }
-            },
-            "UpdateCharacterSchema": {
-                "title": "UpdateCharacterSchema",
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "title": "A new character name (Optional)",
-                        "type": "string"
-                    },
-                    "class_": {
-                        "title": "A new character class (Optional)",
-                        "maxLength": 80,
-                        "type": "string"
-                    },
-                    "level": {
-                        "title": "A new character level (Optional)",
-                        "minimum": 1.0,
-                        "type": "integer"
-                    },
-                    "data": {
-                        "title": "Updates to the character sheet fields (Optional)",
-                        "type": "object"
-                    }
-                }
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": [
-                    "loc",
-                    "msg",
-                    "type"
-                ],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "integer"
-                                }
-                            ]
-                        }
-                    },
-                    "msg": {
-                        "title": "Message",
-                        "type": "string"
-                    },
-                    "type": {
-                        "title": "Error Type",
-                        "type": "string"
-                    }
-                }
+              }
             }
+          }
         }
+      }
     }
+  },
+  "components": {
+    "schemas": {
+      "CharacterSchema": {
+        "title": "CharacterSchema",
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "class_",
+          "level",
+          "data",
+          "player",
+          "party"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "The character primary key in database",
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "name": {
+            "title": "The character name",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "slug": {
+            "title": "The character slug, used to identify it in the API",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "class_": {
+            "title": "The character class",
+            "maxLength": 80,
+            "type": "string"
+          },
+          "level": {
+            "title": "The character level",
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "data": {
+            "title": "Data",
+            "type": "object",
+            "description": "The embdedded character sheet JSON data"
+          },
+          "player": {
+            "title": "The embedded character's player schema",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PlayerSchema"
+              }
+            ]
+          },
+          "party": {
+            "title": "The embedded character's party schema",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartySchema"
+              }
+            ]
+          }
+        }
+      },
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "ListCharacterSchema": {
+        "title": "ListCharacterSchema",
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "class_",
+          "level",
+          "player",
+          "party"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "The character primary key in database",
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "name": {
+            "title": "The character name",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "slug": {
+            "title": "The character slug, used to identify it in the API",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "class_": {
+            "title": "The character class",
+            "maxLength": 80,
+            "type": "string"
+          },
+          "level": {
+            "title": "The character level",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "player": {
+            "title": "The embedded character's player schema",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PlayerSchema"
+              }
+            ]
+          },
+          "party": {
+            "title": "The embedded character's party schema",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartySchema"
+              }
+            ]
+          }
+        }
+      },
+      "PartySchema": {
+        "title": "PartySchema",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "The party primary key in database",
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "name": {
+            "title": "The party name",
+            "maxLength": 255,
+            "type": "string"
+          }
+        }
+      },
+      "PlayerSchema": {
+        "title": "PlayerSchema",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "The player primary key in database",
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "name": {
+            "title": "The player name",
+            "maxLength": 255,
+            "type": "string"
+          }
+        }
+      },
+      "UpdateCharacterSchema": {
+        "title": "UpdateCharacterSchema",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "A new character name (Optional)",
+            "type": "string"
+          },
+          "class_": {
+            "title": "A new character class (Optional)",
+            "maxLength": 80,
+            "type": "string"
+          },
+          "level": {
+            "title": "A new character level (Optional)",
+            "minimum": 1.0,
+            "type": "integer"
+          },
+          "data": {
+            "title": "Updates to the character sheet fields (Optional)",
+            "type": "object"
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
 }

--- a/dnd5esheets/client/package-lock.json
+++ b/dnd5esheets/client/package-lock.json
@@ -7,14 +7,30 @@
     "": {
       "name": "client",
       "version": "0.0.0",
+      "dependencies": {
+        "axios": "^1.4.0"
+      },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.0.4",
         "@tsconfig/svelte": "^4.0.1",
+        "openapi-typescript-codegen": "^0.24.0",
         "svelte": "^3.58.0",
         "svelte-check": "^3.3.1",
         "tslib": "^2.5.0",
         "typescript": "^5.0.2",
         "vite": "^4.3.9"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -400,6 +416,12 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -480,6 +502,12 @@
       "integrity": "sha512-B+XlGpmuAQzJqDoBATNCvEPqQg0HkO7S8pM14QDI5NsmtymzRexQ1N+nX2H6RTtFbuFgaZD4I8AAi8voGg0GLg==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
     "node_modules/@types/pug": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
@@ -497,6 +525,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -545,6 +594,12 @@
         "node": "*"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -552,6 +607,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chokidar": {
@@ -579,6 +646,26 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/concat-map": {
@@ -611,6 +698,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-indent": {
@@ -702,6 +797,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -759,6 +900,27 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -834,6 +996,43 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "deprecated": "Please switch to @apidevtools/json-schema-ref-parser",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -875,6 +1074,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -952,6 +1170,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -968,6 +1192,22 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-typescript-codegen": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.24.0.tgz",
+      "integrity": "sha512-rSt8t1XbMWhv6Db7GUI24NNli7FU5kzHLxcE8BpzgGWRdWyWt9IB2YoLyPahxNrVA7yOaVgnXPkrcTDRMQtJYg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "commander": "^10.0.0",
+        "fs-extra": "^11.1.1",
+        "handlebars": "^4.7.7",
+        "json-schema-ref-parser": "^9.0.9"
+      },
+      "bin": {
+        "openapi": "bin/index.js"
       }
     },
     "node_modules/parent-module": {
@@ -1036,6 +1276,11 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1176,6 +1421,15 @@
       },
       "bin": {
         "sorcery": "bin/sorcery"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -1347,6 +1601,28 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "4.3.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
@@ -1408,6 +1684,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/dnd5esheets/client/package.json
+++ b/dnd5esheets/client/package.json
@@ -7,15 +7,20 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "generate-client": "openapi --input ./openapi.json --output ./src/5esheet-client --client axios"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.0.4",
     "@tsconfig/svelte": "^4.0.1",
+    "openapi-typescript-codegen": "^0.24.0",
     "svelte": "^3.58.0",
     "svelte-check": "^3.3.1",
     "tslib": "^2.5.0",
     "typescript": "^5.0.2",
     "vite": "^4.3.9"
+  },
+  "dependencies": {
+    "axios": "^1.4.0"
   }
 }

--- a/dnd5esheets/client/src/5esheet-client/core/ApiError.ts
+++ b/dnd5esheets/client/src/5esheet-client/core/ApiError.ts
@@ -1,0 +1,24 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}

--- a/dnd5esheets/client/src/5esheet-client/core/ApiRequestOptions.ts
+++ b/dnd5esheets/client/src/5esheet-client/core/ApiRequestOptions.ts
@@ -1,0 +1,16 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};

--- a/dnd5esheets/client/src/5esheet-client/core/ApiResult.ts
+++ b/dnd5esheets/client/src/5esheet-client/core/ApiResult.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};

--- a/dnd5esheets/client/src/5esheet-client/core/CancelablePromise.ts
+++ b/dnd5esheets/client/src/5esheet-client/core/CancelablePromise.ts
@@ -1,0 +1,130 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                this.#resolve?.(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                this.#reject?.(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+     get [Symbol.toStringTag]() {
+            return "Cancellable Promise";
+     }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        this.#reject?.(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}

--- a/dnd5esheets/client/src/5esheet-client/core/OpenAPI.ts
+++ b/dnd5esheets/client/src/5esheet-client/core/OpenAPI.ts
@@ -1,0 +1,31 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string>;
+    USERNAME?: string | Resolver<string>;
+    PASSWORD?: string | Resolver<string>;
+    HEADERS?: Headers | Resolver<Headers>;
+    ENCODE_PATH?: (path: string) => string;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: '',
+    VERSION: '0.1.0',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};

--- a/dnd5esheets/client/src/5esheet-client/core/request.ts
+++ b/dnd5esheets/client/src/5esheet-client/core/request.ts
@@ -1,0 +1,304 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import axios from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import FormData from 'form-data';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+};
+
+const isString = (value: any): value is string => {
+    return typeof value === 'string';
+};
+
+const isStringWithValue = (value: any): value is string => {
+    return isString(value) && value !== '';
+};
+
+const isBlob = (value: any): value is Blob => {
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
+};
+
+const isFormData = (value: any): value is FormData => {
+    return value instanceof FormData;
+};
+
+const isSuccess = (status: number): boolean => {
+    return status >= 200 && status < 300;
+};
+
+const base64 = (str: string): string => {
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
+};
+
+const getQueryString = (params: Record<string, any>): string => {
+    const qs: string[] = [];
+
+    const append = (key: string, value: any) => {
+        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    };
+
+    const process = (key: string, value: any) => {
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(`${key}[${k}]`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
+
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
+
+    if (qs.length > 0) {
+        return `?${qs.join('&')}`;
+    }
+
+    return '';
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+    const encoder = config.ENCODE_PATH || encodeURI;
+
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
+
+    const url = `${config.BASE}${path}`;
+    if (options.query) {
+        return `${url}${getQueryString(options.query)}`;
+    }
+    return url;
+};
+
+const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+    if (options.formData) {
+        const formData = new FormData();
+
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
+
+        Object.entries(options.formData)
+            .filter(([_, value]) => isDefined(value))
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
+
+        return formData;
+    }
+    return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+};
+
+const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+    const token = await resolve(options, config.TOKEN);
+    const username = await resolve(options, config.USERNAME);
+    const password = await resolve(options, config.PASSWORD);
+    const additionalHeaders = await resolve(options, config.HEADERS);
+    const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+        ...formHeaders,
+    })
+    .filter(([_, value]) => isDefined(value))
+    .reduce((headers, [key, value]) => ({
+        ...headers,
+        [key]: String(value),
+    }), {} as Record<string, string>);
+
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(`${username}:${password}`);
+        headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (options.body) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+
+    return headers;
+};
+
+const getRequestBody = (options: ApiRequestOptions): any => {
+    if (options.body) {
+        return options.body;
+    }
+    return undefined;
+};
+
+const sendRequest = async <T>(
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Record<string, string>,
+    onCancel: OnCancel
+): Promise<AxiosResponse<T>> => {
+    const source = axios.CancelToken.source();
+
+    const requestConfig: AxiosRequestConfig = {
+        url,
+        headers,
+        data: body ?? formData,
+        method: options.method,
+        withCredentials: config.WITH_CREDENTIALS,
+        cancelToken: source.token,
+    };
+
+    onCancel(() => source.cancel('The user aborted a request.'));
+
+    try {
+        return await axios.request(requestConfig);
+    } catch (error) {
+        const axiosError = error as AxiosError<T>;
+        if (axiosError.response) {
+            return axiosError.response;
+        }
+        throw error;
+    }
+};
+
+const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+    if (responseHeader) {
+        const content = response.headers[responseHeader];
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
+};
+
+const getResponseBody = (response: AxiosResponse<any>): any => {
+    if (response.status !== 204) {
+        return response.data;
+    }
+    return undefined;
+};
+
+const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
+
+    if (!result.ok) {
+        throw new ApiError(options, result, 'Generic Error');
+    }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options, formData);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel);
+                const responseBody = getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: isSuccess(response.status),
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
+
+                catchErrorCodes(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};

--- a/dnd5esheets/client/src/5esheet-client/index.ts
+++ b/dnd5esheets/client/src/5esheet-client/index.ts
@@ -14,4 +14,4 @@ export type { PlayerSchema } from './models/PlayerSchema';
 export type { UpdateCharacterSchema } from './models/UpdateCharacterSchema';
 export type { ValidationError } from './models/ValidationError';
 
-export { DefaultService } from './services/DefaultService';
+export { CharacterService } from './services/CharacterService';

--- a/dnd5esheets/client/src/5esheet-client/index.ts
+++ b/dnd5esheets/client/src/5esheet-client/index.ts
@@ -1,0 +1,17 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { CharacterSchema } from './models/CharacterSchema';
+export type { HTTPValidationError } from './models/HTTPValidationError';
+export type { ListCharacterSchema } from './models/ListCharacterSchema';
+export type { PartySchema } from './models/PartySchema';
+export type { PlayerSchema } from './models/PlayerSchema';
+export type { UpdateCharacterSchema } from './models/UpdateCharacterSchema';
+export type { ValidationError } from './models/ValidationError';
+
+export { DefaultService } from './services/DefaultService';

--- a/dnd5esheets/client/src/5esheet-client/models/CharacterSchema.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/CharacterSchema.ts
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { PartySchema } from './PartySchema';
+import type { PlayerSchema } from './PlayerSchema';
+
+export type CharacterSchema = {
+    id: number;
+    name: string;
+    slug: string;
+    class_: string;
+    level: number;
+    /**
+     * The embdedded character sheet JSON data
+     */
+    data: Record<string, any>;
+    player: PlayerSchema;
+    party: PartySchema;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/models/HTTPValidationError.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/HTTPValidationError.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ValidationError } from './ValidationError';
+
+export type HTTPValidationError = {
+    detail?: Array<ValidationError>;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/models/ListCharacterSchema.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/ListCharacterSchema.ts
@@ -1,0 +1,17 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { PartySchema } from './PartySchema';
+import type { PlayerSchema } from './PlayerSchema';
+
+export type ListCharacterSchema = {
+    id: number;
+    name: string;
+    slug: string;
+    class_: string;
+    level: number;
+    player: PlayerSchema;
+    party: PartySchema;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/models/PartySchema.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/PartySchema.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PartySchema = {
+    id: number;
+    name: string;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/models/PlayerSchema.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/PlayerSchema.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PlayerSchema = {
+    id: number;
+    name: string;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/models/UpdateCharacterSchema.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/UpdateCharacterSchema.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UpdateCharacterSchema = {
+    name?: string;
+    class_?: string;
+    level?: number;
+    data?: Record<string, any>;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/models/ValidationError.ts
+++ b/dnd5esheets/client/src/5esheet-client/models/ValidationError.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ValidationError = {
+    loc: Array<(string | number)>;
+    msg: string;
+    type: string;
+};
+

--- a/dnd5esheets/client/src/5esheet-client/services/CharacterService.ts
+++ b/dnd5esheets/client/src/5esheet-client/services/CharacterService.ts
@@ -9,7 +9,7 @@ import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 
-export class DefaultService {
+export class CharacterService {
 
     /**
      * List Characters
@@ -19,7 +19,7 @@ export class DefaultService {
      * @returns ListCharacterSchema Successful Response
      * @throws ApiError
      */
-    public static listCharactersApiCharactersGet(): CancelablePromise<Array<ListCharacterSchema>> {
+    public static listCharacters(): CancelablePromise<Array<ListCharacterSchema>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/characters/',
@@ -33,7 +33,7 @@ export class DefaultService {
      * @returns CharacterSchema Successful Response
      * @throws ApiError
      */
-    public static displayCharacterApiCharactersSlugGet(
+    public static displayCharacter(
         slug: string,
     ): CancelablePromise<CharacterSchema> {
         return __request(OpenAPI, {
@@ -65,7 +65,7 @@ export class DefaultService {
      * @returns any Successful Response
      * @throws ApiError
      */
-    public static updateCharacterApiCharactersSlugPut(
+    public static updateCharacter(
         slug: string,
         requestBody: UpdateCharacterSchema,
     ): CancelablePromise<Record<string, any>> {

--- a/dnd5esheets/client/src/5esheet-client/services/DefaultService.ts
+++ b/dnd5esheets/client/src/5esheet-client/services/DefaultService.ts
@@ -1,0 +1,86 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CharacterSchema } from '../models/CharacterSchema';
+import type { ListCharacterSchema } from '../models/ListCharacterSchema';
+import type { UpdateCharacterSchema } from '../models/UpdateCharacterSchema';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+
+export class DefaultService {
+
+    /**
+     * List Characters
+     * List all characters.
+     *
+     * The returned payload will not include the character sheet details.
+     * @returns ListCharacterSchema Successful Response
+     * @throws ApiError
+     */
+    public static listCharactersApiCharactersGet(): CancelablePromise<Array<ListCharacterSchema>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/characters/',
+        });
+    }
+
+    /**
+     * Display Character
+     * Display all details of a given character.
+     * @param slug
+     * @returns CharacterSchema Successful Response
+     * @throws ApiError
+     */
+    public static displayCharacterApiCharactersSlugGet(
+        slug: string,
+    ): CancelablePromise<CharacterSchema> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/characters/{slug}',
+            path: {
+                'slug': slug,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Update Character
+     * Update a character details.
+     *
+     * Examples of JSON body paylods:
+     *
+     * - `{"level": 5 }`
+     * - `{"name": "Toto"}`
+     * - `{"class_": "Guerrier", "data": {"background": "Folk Hero"}}`
+     *
+     * In the last example, we update both a direct character attribute
+     * as well as an attribute nested in the character JSON data.
+     * @param slug
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static updateCharacterApiCharactersSlugPut(
+        slug: string,
+        requestBody: UpdateCharacterSchema,
+    ): CancelablePromise<Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/characters/{slug}',
+            path: {
+                'slug': slug,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+}

--- a/dnd5esheets/client/src/App.svelte
+++ b/dnd5esheets/client/src/App.svelte
@@ -2,6 +2,9 @@
   import svelteLogo from "./assets/svelte.svg";
   import viteLogo from "/vite.svg";
   import Counter from "./lib/Counter.svelte";
+  import { CharacterService } from "./5esheet-client";
+
+  CharacterService.displayCharacter();
 </script>
 
 <main>

--- a/scripts/preprocess_openapi_json.py
+++ b/scripts/preprocess_openapi_json.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+openapi_json_fileppath = (
+    Path(__file__).parent.parent / "dnd5esheets" / "client" / "openapi.json"
+)
+
+openapi_content = json.loads(openapi_json_fileppath.read_text())
+
+for path_data in openapi_content["paths"].values():
+    for operation in path_data.values():
+        tag = operation["tags"][0]
+        operation_id = operation["operationId"]
+        to_remove = f"{tag}-"
+        new_operation_id = operation_id[len(to_remove) :]
+        operation["operationId"] = new_operation_id
+
+openapi_json_fileppath.write_text(json.dumps(openapi_content, indent=2))


### PR DESCRIPTION

We followed https://fastapi.tiangolo.com/advanced/generate-clients/#fastapi-app-with-tags to generate the 5ehseets API Typescript client, with types, interfaces and services.

The `make svelte-api-generate-api-client` target automatically fetches the `openapi.json` spec from the app itself, and [preprocesses](https://fastapi.tiangolo.com/advanced/generate-clients/#preprocess-the-openapi-specification-for-the-client-generator) to make sure we get consise method names. It then generates the typescript client code through `openapi-typescript-codegen`.

Autocompletion on method and arguments works like a charm:


<img width="100%" alt="Screenshot 2023-06-23 at 14 21 41" src="https://github.com/brouberol/5esheets/assets/480131/57234e75-28ff-4829-8d67-be10363295cf">
<img width="100%" alt="Screenshot 2023-06-23 at 14 21 48" src="https://github.com/brouberol/5esheets/assets/480131/3225753b-6d92-427f-8b73-d89e93015bd8">

Fixes #40
