### PR TITLE
Introduce dev/prod configuration

### DIFF
--- a/dnd5esheets/config/__init__.py
+++ b/dnd5esheets/config/__init__.py
@@ -1,0 +1,12 @@
+import os
+from functools import lru_cache
+
+from .dev import DevSettings
+from .prod import ProdSettings
+
+
+@lru_cache
+def get_settings():
+    if os.getenv("5ESHEETS_ENV") == "prod":
+        return ProdSettings()
+    return DevSettings()

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -1,0 +1,6 @@
+from pydantic import BaseSettings
+
+
+class CommonSettings(BaseSettings):
+    JWT_ENCODING_ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # in mins

--- a/dnd5esheets/config/dev.py
+++ b/dnd5esheets/config/dev.py
@@ -1,0 +1,5 @@
+from .base import CommonSettings
+
+
+class DevSettings(CommonSettings):
+    SECRET_KEY: str = "6ba4e05e642a4124ffb4a60435e37832296b74aefd078c45b4466d90684522d8"

--- a/dnd5esheets/config/prod.py
+++ b/dnd5esheets/config/prod.py
@@ -1,0 +1,8 @@
+from .base import CommonSettings
+
+
+class ProdSettings(CommonSettings):
+    SECRET_KEY: str
+
+    class Config:
+        env_file = ".env"


### PR DESCRIPTION
The prod configuration relies on a `.env` file that will need to be populated
with the app secret key.

Fixes #63
