### PR TITLE
Introduce a way to scope resources to the owner of the provided JWT

### DIFF
--- a/dnd5esheets/api/character.py
+++ b/dnd5esheets/api/character.py
@@ -8,6 +8,7 @@ from dnd5esheets.schemas import (
     ListCharacterSchema,
     UpdateCharacterSchema,
 )
+from dnd5esheets.security.user import get_current_user
 
 character_api = APIRouter(prefix="/character", tags=["character"])
 
@@ -15,13 +16,14 @@ character_api = APIRouter(prefix="/character", tags=["character"])
 @character_api.get("/", response_model=list[ListCharacterSchema])
 async def list_characters(
     session: AsyncSession = Depends(create_scoped_session),
+    current_player=Depends(get_current_user),
 ):
     """List all characters.
 
     The returned payload will not include the character sheet details.
 
     """
-    return await CharacterRepository.list_all(session)
+    return await CharacterRepository.list_all(session, player=current_player)
 
 
 @character_api.get("/{slug}", response_model=CharacterSchema)

--- a/dnd5esheets/api/character.py
+++ b/dnd5esheets/api/character.py
@@ -2,14 +2,13 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.db import create_scoped_session
-from dnd5esheets.models import Player
 from dnd5esheets.repositories.character import CharacterRepository
 from dnd5esheets.schemas import (
     CharacterSchema,
     ListCharacterSchema,
     UpdateCharacterSchema,
 )
-from dnd5esheets.security.user import get_current_user
+from dnd5esheets.security.user import get_current_user_id
 
 character_api = APIRouter(prefix="/character", tags=["character"])
 
@@ -17,25 +16,25 @@ character_api = APIRouter(prefix="/character", tags=["character"])
 @character_api.get("/", response_model=list[ListCharacterSchema])
 async def list_characters(
     session: AsyncSession = Depends(create_scoped_session),
-    current_player: Player = Depends(get_current_user),
+    current_player_id: int | None = Depends(get_current_user_id),
 ):
     """List all characters.
 
     The returned payload will not include the character sheet details.
 
     """
-    return await CharacterRepository.list_all(session, player=current_player)
+    return await CharacterRepository.list_all(session, owner_id=current_player_id)
 
 
 @character_api.get("/{slug}", response_model=CharacterSchema)
 async def display_character(
     slug: str,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player: Player = Depends(get_current_user),
+    current_player_id: int | None = Depends(get_current_user_id),
 ):
     """Display all details of a given character."""
     return await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player.id
+        session, slug=slug, owner_id=current_player_id
     )
 
 
@@ -44,7 +43,7 @@ async def update(
     slug: str,
     character_data: UpdateCharacterSchema,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player: Player = Depends(get_current_user),
+    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Update a character details.
 
@@ -59,7 +58,7 @@ async def update(
 
     """
     await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player.id
+        session, slug=slug, owner_id=current_player_id
     )
     await CharacterRepository.update(session, slug, character_data)
     return {"status": "ok"}

--- a/dnd5esheets/api/login.py
+++ b/dnd5esheets/api/login.py
@@ -10,7 +10,7 @@ from dnd5esheets.db import create_scoped_session
 from dnd5esheets.models import Player
 from dnd5esheets.repositories import ModelNotFound
 from dnd5esheets.repositories.player import PlayerRepository
-from dnd5esheets.schemas import JsonWebToken
+from dnd5esheets.schemas import JsonWebToken, JsonWebTokenData
 from dnd5esheets.security.hashing import verify_password
 from dnd5esheets.security.jwt import create_access_token
 

--- a/dnd5esheets/api/party.py
+++ b/dnd5esheets/api/party.py
@@ -2,18 +2,33 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.db import create_scoped_session
+from dnd5esheets.models import Player
 from dnd5esheets.repositories.party import PartyRepository
-from dnd5esheets.schemas import DisplayPartySchema, UpdatePartySchema
+from dnd5esheets.schemas import DisplayPartySchema, PartySchema, UpdatePartySchema
+from dnd5esheets.security.user import get_current_user
 
 party_api = APIRouter(prefix="/party", tags=["party"])
 
 
+@party_api.get("/", response_model=list[PartySchema])
+async def list_all_parties(
+    session: AsyncSession = Depends(create_scoped_session),
+    current_player: Player = Depends(get_current_user),
+):
+    """List all parties the current player has characters in"""
+    return await PartyRepository.list_all(session=session, owner_id=current_player.id)
+
+
 @party_api.get("/{id}", response_model=DisplayPartySchema)
 async def display_party(
-    id: int, session: AsyncSession = Depends(create_scoped_session)
+    id: int,
+    session: AsyncSession = Depends(create_scoped_session),
+    current_player: Player = Depends(get_current_user),
 ):
     """Display all details of a given party."""
-    return await PartyRepository.get_by_id(session, id=id)
+    return await PartyRepository.get_by_id_if_member_of(
+        session=session, id=id, member_id=current_player.id
+    )
 
 
 @party_api.put("/{id}")
@@ -21,6 +36,7 @@ async def update_party(
     id: int,
     player_data: UpdatePartySchema,
     session: AsyncSession = Depends(create_scoped_session),
+    current_player: Player = Depends(get_current_user),
 ) -> dict:
     """Update a party details.
 
@@ -28,5 +44,7 @@ async def update_party(
 
 
     """
-    await PartyRepository.update(session, id, player_data)
+    await PartyRepository.update_if_member_of(
+        session=session, id=id, body=player_data, member_id=current_player.id
+    )
     return {"status": "ok"}

--- a/dnd5esheets/api/player.py
+++ b/dnd5esheets/api/player.py
@@ -1,18 +1,24 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.db import create_scoped_session
+from dnd5esheets.models import Player
 from dnd5esheets.repositories.player import PlayerRepository
 from dnd5esheets.schemas import DisplayPlayerSchema, UpdatePlayerSchema
+from dnd5esheets.security.user import get_current_user
 
 player_api = APIRouter(prefix="/player", tags=["player"])
 
 
 @player_api.get("/{id}", response_model=DisplayPlayerSchema)
 async def display_player(
-    id: int, session: AsyncSession = Depends(create_scoped_session)
+    id: int,
+    session: AsyncSession = Depends(create_scoped_session),
+    current_player: Player = Depends(get_current_user),
 ):
     """Display all details of a given player."""
+    if id != current_player.id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     return await PlayerRepository.get_by_id(session, id=id)
 
 
@@ -21,6 +27,7 @@ async def update_player(
     id: int,
     player_data: UpdatePlayerSchema,
     session: AsyncSession = Depends(create_scoped_session),
+    current_player: Player = Depends(get_current_user),
 ) -> dict:
     """Update a player details.
 
@@ -28,5 +35,7 @@ async def update_player(
 
 
     """
+    if id != current_player.id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     await PlayerRepository.update(session, id, player_data)
     return {"status": "ok"}

--- a/dnd5esheets/api/player.py
+++ b/dnd5esheets/api/player.py
@@ -2,10 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.db import create_scoped_session
-from dnd5esheets.models import Player
 from dnd5esheets.repositories.player import PlayerRepository
 from dnd5esheets.schemas import DisplayPlayerSchema, UpdatePlayerSchema
-from dnd5esheets.security.user import get_current_user
+from dnd5esheets.security.user import get_current_user_id
 
 player_api = APIRouter(prefix="/player", tags=["player"])
 
@@ -14,10 +13,10 @@ player_api = APIRouter(prefix="/player", tags=["player"])
 async def display_player(
     id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player: Player = Depends(get_current_user),
+    current_player_id: int | None = Depends(get_current_user_id),
 ):
     """Display all details of a given player."""
-    if id != current_player.id:
+    if current_player_id and id != current_player_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     return await PlayerRepository.get_by_id(session, id=id)
 
@@ -27,7 +26,7 @@ async def update_player(
     id: int,
     player_data: UpdatePlayerSchema,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player: Player = Depends(get_current_user),
+    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Update a player details.
 
@@ -35,7 +34,7 @@ async def update_player(
 
 
     """
-    if id != current_player.id:
+    if current_player_id and id != current_player_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     await PlayerRepository.update(session, id, player_data)
     return {"status": "ok"}

--- a/dnd5esheets/config/__init__.py
+++ b/dnd5esheets/config/__init__.py
@@ -7,6 +7,6 @@ from .prod import ProdSettings
 
 @lru_cache
 def get_settings():
-    if os.getenv("5ESHEETS_ENV") == "prod":
+    if os.getenv("DND5ESHEETS_ENV") == "prod":
         return ProdSettings()
     return DevSettings()

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -3,4 +3,5 @@ from pydantic import BaseSettings
 
 class CommonSettings(BaseSettings):
     JWT_ENCODING_ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # in mins
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 12 * 60  # in mins
+    MULTITENANT_ENABLED: bool = False

--- a/dnd5esheets/config/prod.py
+++ b/dnd5esheets/config/prod.py
@@ -3,6 +3,7 @@ from .base import CommonSettings
 
 class ProdSettings(CommonSettings):
     SECRET_KEY: str
+    MULTITENANT_ENABLED: bool = True
 
     class Config:
         env_file = ".env"

--- a/dnd5esheets/db/fixtures/dev.json
+++ b/dnd5esheets/db/fixtures/dev.json
@@ -29,6 +29,10 @@
         {
             "id": 1,
             "name": "Famille McTrickfoot"
+        },
+        {
+            "id": 2,
+            "name": "La Compagnie des Gourmands"
         }
     ],
     "characters": [

--- a/dnd5esheets/front/openapi.json
+++ b/dnd5esheets/front/openapi.json
@@ -31,7 +31,7 @@
         },
         "security": [
           {
-            "OAuth2PasswordBearer": []
+            "OptionalOAuth2PasswordBearer": []
           }
         ]
       }
@@ -79,7 +79,7 @@
         },
         "security": [
           {
-            "OAuth2PasswordBearer": []
+            "OptionalOAuth2PasswordBearer": []
           }
         ]
       },
@@ -136,7 +136,38 @@
         },
         "security": [
           {
-            "OAuth2PasswordBearer": []
+            "OptionalOAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/party/": {
+      "get": {
+        "tags": [
+          "party"
+        ],
+        "summary": "List All Parties",
+        "description": "List all parties the current player has characters in",
+        "operationId": "list_all_parties",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Party-List All Parties",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PartySchema"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OptionalOAuth2PasswordBearer": []
           }
         ]
       }
@@ -181,7 +212,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OptionalOAuth2PasswordBearer": []
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -233,7 +269,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OptionalOAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/player/{id}": {
@@ -276,7 +317,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OptionalOAuth2PasswordBearer": []
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -328,7 +374,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OptionalOAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/login/token": {
@@ -859,7 +910,7 @@
       }
     },
     "securitySchemes": {
-      "OAuth2PasswordBearer": {
+      "OptionalOAuth2PasswordBearer": {
         "type": "oauth2",
         "flows": {
           "password": {

--- a/dnd5esheets/front/openapi.json
+++ b/dnd5esheets/front/openapi.json
@@ -28,7 +28,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/character/{slug}": {
@@ -839,6 +844,17 @@
           "type": {
             "title": "Error Type",
             "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "type": "oauth2",
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "token"
           }
         }
       }

--- a/dnd5esheets/front/openapi.json
+++ b/dnd5esheets/front/openapi.json
@@ -76,7 +76,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -128,7 +133,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/party/{id}": {

--- a/dnd5esheets/front/src/5esheets-client/services/PartyService.ts
+++ b/dnd5esheets/front/src/5esheets-client/services/PartyService.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { DisplayPartySchema } from '../models/DisplayPartySchema';
+import type { PartySchema } from '../models/PartySchema';
 import type { UpdatePartySchema } from '../models/UpdatePartySchema';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -9,6 +10,19 @@ import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 
 export class PartyService {
+
+    /**
+     * List All Parties
+     * List all parties the current player has characters in
+     * @returns PartySchema Successful Response
+     * @throws ApiError
+     */
+    public static listAllParties(): CancelablePromise<Array<PartySchema>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/party/',
+        });
+    }
 
     /**
      * Display Party

--- a/dnd5esheets/repositories/character.py
+++ b/dnd5esheets/repositories/character.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer
 
-from dnd5esheets.models import Character
+from dnd5esheets.models import Character, Player
 from dnd5esheets.repositories import BaseRepository
 from dnd5esheets.schemas import UpdateCharacterSchema
 
@@ -13,10 +13,12 @@ class CharacterRepository(BaseRepository):
     model = Character
 
     @classmethod
-    async def list_all(cls, session: AsyncSession) -> Sequence[Character]:
+    async def list_all(
+        cls, session: AsyncSession, player: Player
+    ) -> Sequence[Character]:
         """List all existing characters, with their associated related data"""
         result = await session.execute(
-            select(Character)
+            select(Character).filter(Character.player_id == player.id)
             # exclude the large json payload
             .options(defer(Character.data))
         )

--- a/dnd5esheets/repositories/character.py
+++ b/dnd5esheets/repositories/character.py
@@ -28,11 +28,24 @@ class CharacterRepository(BaseRepository):
     async def get_by_slug(cls, session: AsyncSession, slug: str) -> Character:
         """Return a Character given an argument slug"""
         result = await session.execute(select(Character).filter(Character.slug == slug))
-        return cls.one_or_raise(result)  # type: ignore
+        return cls.one_or_raise_model_not_found(result)  # type: ignore
+
+    @classmethod
+    async def get_by_slug_if_owned(
+        cls, session: AsyncSession, slug: str, owner_id: int
+    ) -> Character:
+        """Return a Character given an argument slug"""
+        character = await cls.get_by_slug(session, slug)
+        if character.player_id != owner_id:
+            cls.raise_model_not_found()
+        return character
 
     @classmethod
     async def update(
-        cls, session: AsyncSession, slug: str, body: UpdateCharacterSchema
+        cls,
+        session: AsyncSession,
+        slug: str,
+        body: UpdateCharacterSchema,
     ) -> Character:
         character = await cls.get_by_slug(session, slug)
 

--- a/dnd5esheets/repositories/player.py
+++ b/dnd5esheets/repositories/player.py
@@ -13,13 +13,13 @@ class PlayerRepository(BaseRepository):
     async def get_by_id(cls, session: AsyncSession, id: int) -> Player:
         """Return a Player given an argument id"""
         result = await session.execute(select(Player).filter(Player.id == id))
-        return cls.one_or_raise(result)  # type: ignore
+        return cls.one_or_raise_model_not_found(result)  # type: ignore
 
     @classmethod
     async def get_by_email(cls, session: AsyncSession, email: str) -> Player:
         """Return a Player given an argument email"""
         result = await session.execute(select(Player).filter(Player.email == email))
-        return cls.one_or_raise(result)  # type: ignore
+        return cls.one_or_raise_model_not_found(result)  # type: ignore
 
     @classmethod
     async def update(

--- a/dnd5esheets/schemas.py
+++ b/dnd5esheets/schemas.py
@@ -11,6 +11,10 @@ class JsonWebToken(BaseSchema):
     token_type: str
 
 
+class JsonWebTokenData(BaseSchema):
+    username: str | None = None
+
+
 class BaseORMSchema(BaseSchema):
     class Config:
         orm_mode = True

--- a/dnd5esheets/security/user.py
+++ b/dnd5esheets/security/user.py
@@ -2,20 +2,34 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
 
 from dnd5esheets.config import get_settings
 from dnd5esheets.db import create_scoped_session
+from dnd5esheets.models import Player
 from dnd5esheets.repositories.player import PlayerRepository
 from dnd5esheets.schemas import JsonWebTokenData
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+class OptionalOAuth2PasswordBearer(OAuth2PasswordBearer):
+    """Enable"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.auto_error = get_settings().MULTITENANT_ENABLED
 
 
-async def get_current_user(
+oauth2_scheme = OptionalOAuth2PasswordBearer(tokenUrl="token")
+
+
+async def get_current_user_id(
     session: AsyncSession = Depends(create_scoped_session),
     settings=Depends(get_settings),
     token=Depends(oauth2_scheme),
-):
+) -> int | None:
+    if not settings.MULTITENANT_ENABLED:
+        return None
+
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -34,4 +48,4 @@ async def get_current_user(
     player = await PlayerRepository.get_by_email(session, email=token_data.username)
     if player is None:
         raise credentials_exception
-    return player
+    return player.id

--- a/dnd5esheets/security/user.py
+++ b/dnd5esheets/security/user.py
@@ -1,0 +1,37 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dnd5esheets.config import get_settings
+from dnd5esheets.db import create_scoped_session
+from dnd5esheets.repositories.player import PlayerRepository
+from dnd5esheets.schemas import JsonWebTokenData
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+async def get_current_user(
+    session: AsyncSession = Depends(create_scoped_session),
+    settings=Depends(get_settings),
+    token=Depends(oauth2_scheme),
+):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[settings.JWT_ENCODING_ALGORITHM]
+        )
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = JsonWebTokenData(username=username)
+    except JWTError:
+        raise credentials_exception
+    player = await PlayerRepository.get_by_email(session, email=token_data.username)
+    if player is None:
+        raise credentials_exception
+    return player


### PR DESCRIPTION
This will make sure we scope the returned resources to those associated with the owner of the JWT.

```console
~/c/5esheets/d/front main !5 ?1 ❯ curl -s -X 'POST' \
  'http://127.0.0.1:8000/api/login/token' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'username=br%40test.com&password=azerty' | jq .
{
  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJickB0ZXN0LmNvbSIsImV4cCI6MTY4NzY0NDM3M30.gIBqd8ZloatxcpADfuf3UsQVWyQh74_OvcC1GYwyAmc",
  "token_type": "bearer"
}

~/c/5esheets/d/front main !5 ?1 ❯ curl -s -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJickB0ZXN0LmNvbSIsImV4cCI6MTY4NzY0NDM3M30.gIBqd8ZloatxcpADfuf3UsQVWyQh74_OvcC1GYwyAmc" http://localhost:8000/api/character/ | jq .
[
  {
    "id": 1,
    "name": "Douglas McTrickfoot",
    "slug": "douglas-mctrickfoot",
    "class_": "Artilleur",
    "level": 4,
    "player": {
      "id": 1,
      "name": "Balthazar"
    },
    "party": {
      "id": 1,
      "name": "Famille McTrickfoot"
    }
  }
]
```

If a resources that is not owned by the owner of the JWT, an HTTP 401 exception should be raised.


⚠️ Because we're currently building the frontend and haven't built the authn form, we disable any form of resource scoping in dev _for now_. This can be re-enabled by changing `BaseSettings.MULTITENANT_ENABLED = True` in the config.