### PR TITLE
Recompute the proficiency bonus from the character level

### DIFF
--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -221,14 +221,14 @@ export default function CharacterSheet({
             <div class="proficiencybonus box">
               <div class="box-label-container">
                 <label class="subtitle" for="proficiencybonus">
-                  {t("proficiency bous")}
+                  {t("proficiency_bonus")}
                 </label>
               </div>
               <input
                 class="square-rounded"
                 name="proficiencybonus"
                 placeholder="+2"
-                value="{{ character.data['proficiencybonus'] }}"
+                value={character.data.proficiency_bonus}
               />
             </div>
             <LabeledBox label={t("saving_throws")}>

--- a/dnd5esheets/front/src/store/index.ts
+++ b/dnd5esheets/front/src/store/index.ts
@@ -58,8 +58,6 @@ const douglas: CharacterSchema = {
       deception: 0,
     },
 
-    proficiency_bonus: 2,
-
     experiencepoints: 0,
     background: "Artistan",
     playername: "Balthazar",
@@ -153,6 +151,11 @@ const scoreToProficiencyModifier = (
 ): number =>
     scoreToSkillModifier(score) + proficiency * proficiencyBonus
 
+const levelToProficiencyBonus = (level: number): number  => {
+  return Math.ceil(1 + (level / 4))
+};
+
+
 const store = { [douglas.slug]: douglas };
 const [characters, setCharacters] = createStore(store);
 
@@ -170,6 +173,15 @@ const effects = {
       (character: CharacterSchema) =>
         scoreToSkillModifier(character.data[attribute]),
     ])
+  ),
+
+  // Recompute the proficiency bonus when the level changes
+  ...Object.fromEntries(
+    [[
+      "proficiency_bonus",
+      (character: CharacterSchema) =>
+        levelToProficiencyBonus(character.level),
+    ]]
   ),
 
   ...Object.fromEntries(


### PR DESCRIPTION
Everytime the character level changes, we recompute the proficiency bonus, which in turn, recomputes the skill modifiers.


| Before | After |
| -- | -- |
|<img width="377" alt="Screenshot 2023-06-26 at 17 26 41" src="https://github.com/brouberol/5esheets/assets/480131/e1388ec3-3079-4c0e-98d9-d89057177b8a"> | <img width="381" alt="Screenshot 2023-06-26 at 17 26 46" src="https://github.com/brouberol/5esheets/assets/480131/64974df1-a5f3-4278-94ec-94de3afe2f23">|


