### PR TITLE
Recompute the passive perception when the wisdom score or proficiency bonus change

### DIFF
--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -324,7 +324,7 @@ export default function CharacterSheet({
                 class="square-rounded"
                 name="passiveperception"
                 placeholder="10"
-                value="{{ character.data['passiveperception'] }}"
+                value={ character.data['passive_perception'] }
               />
               <span class="tooltiptext" id="passiveperception-tooltip"></span>
             </div>

--- a/dnd5esheets/front/src/store/index.ts
+++ b/dnd5esheets/front/src/store/index.ts
@@ -64,7 +64,6 @@ const douglas: CharacterSchema = {
     race: "Gnome",
     alignment: "Chaotique Bon",
     darkvision: true,
-    passiveperception: "13",
     otherprofs:
       "**Outils**\r\n- menuisier\r\n- souffleur de verre\r\n- bricolage\r\n- voleur\r\n- forgeron\r\n\r\n**Langues**\r\n- Nain\r\n- Gnome\r\n- Commun\r\n\r\n**Armes**\r\n- légères",
     ac: "14",
@@ -196,6 +195,17 @@ const effects = {
       `${attribute}_save_mod`,
       (character: CharacterSchema) =>
         scoreToProficiencyModifier(character.data[attribute], character.data.proficiencies[attribute], character.data.proficiency_bonus)
+    ])
+  ),
+
+  // Recompute the passive perception score when the character's wisdom changes
+  ...Object.fromEntries(
+    [
+      "wisdom"
+    ].map((attribute) => [
+      `passive_perception`,
+      (character: CharacterSchema) =>
+        10 + scoreToProficiencyModifier(character.data.wisdom, character.data.proficiencies.perception, character.data.proficiency_bonus)
     ])
   ),
 

--- a/dnd5esheets/front/src/store/index.ts
+++ b/dnd5esheets/front/src/store/index.ts
@@ -199,15 +199,8 @@ const effects = {
   ),
 
   // Recompute the passive perception score when the character's wisdom changes
-  ...Object.fromEntries(
-    [
-      "wisdom"
-    ].map((attribute) => [
-      `passive_perception`,
-      (character: CharacterSchema) =>
+    passive_perception: (character: CharacterSchema) =>
         10 + scoreToProficiencyModifier(character.data.wisdom, character.data.proficiencies.perception, character.data.proficiency_bonus)
-    ])
-  ),
 
   ...Object.fromEntries(
     [


### PR DESCRIPTION
The passive perception depends on:
- the level of mastery of the perception skill (none, proficient, master)
- the proficiency bonus
- the wisdom modifier

| Initial state | Increase WIS |Increase level | Increase perception mastery|
| -- | -- | -- | --|
|<img width="326" alt="Screenshot 2023-06-26 at 17 45 20" src="https://github.com/brouberol/5esheets/assets/480131/7edeb990-239c-45f3-b2ef-4064e625b34e">|<img width="324" alt="Screenshot 2023-06-26 at 17 42 32" src="https://github.com/brouberol/5esheets/assets/480131/ff81a103-a2b3-49c8-9706-3943411a697b"> | <img width="340" alt="Screenshot 2023-06-26 at 17 42 52" src="https://github.com/brouberol/5esheets/assets/480131/002a4338-3d52-4db8-bacc-307f08a08272">|<img width="342" alt="Screenshot 2023-06-26 at 17 43 02" src="https://github.com/brouberol/5esheets/assets/480131/ac76f518-9e8d-43eb-b375-f188f302856f">|




