### PR TITLE
Fetch item translations from the `foundryvtt-dnd5e-lang-fr-fr` module data 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ db-base-items: db-migrate ## Populate the base items in database
 	@echo "\n[+] Populating the database with base items"
 	@$(app-cli) db populate base-items
 
-db-dev-fixtures: db-base-items ## Populate the local database with development fixtures
+db-dev-fixtures: data db-base-items ## Populate the local database with development fixtures
 	@echo "\n[+] Populating the database with development fixtures"
 	@$(app-cli) db populate fixtures
 

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,13 @@ $(front-root)/src/5esheets-client: $(front-root)/openapi.json
 	@echo "\n[+] Generating the typescript API client for the 5esheets API"
 	@$(npm-run) generate-client
 
-$(app-root)/data/items-base.json:
-	@echo "\n [+] Fetching base equipment data"
-	@curl -s https://raw.githubusercontent.com/5etools-mirror-1/5etools-mirror-1.github.io/master/data/items-base.json | python3 scripts/preprocess_base_item_json.py
+$(app-root)/data/items-base.json: $(app-root)/data/translations-items-fr.json
+	@echo "\n[+] Fetching base equipment data"
+	@curl -s https://raw.githubusercontent.com/5etools-mirror-1/5etools-mirror-1.github.io/master/data/items-base.json | poetry run python3 scripts/preprocess_base_item_json.py
+
+$(app-root)/data/translations-items-fr.json:
+	@echo "\n[+] Fetching items french translations"
+	@curl -s https://gitlab.com/baktov.sugar/foundryvtt-dnd5e-lang-fr-fr/-/raw/master/dnd5e_fr-FR/compendium/dnd5e.items.json > $(app-root)/data/translations-items-fr.json
 
 api-doc:  ## Open the 5esheets API documentation
 	open http://localhost:$(app-port)/redoc

--- a/dnd5esheets/data/items-base.json
+++ b/dnd5esheets/data/items-base.json
@@ -1,6 +1,12 @@
 [
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Fl\u00e8che",
+          "description": "Munitions standard utilis\u00e9es pour les arcs de toutes sortes. Ces fl\u00e8ches banales sont fabriqu\u00e9es \u00e0 partir d'un manche en bois lisse, avec des plumes d'oie et un rev\u00eatement en m\u00e9tal martel\u00e9."
+        }
+      },
       "rarity": "none",
       "weight": 0.05,
       "value": 5
@@ -16,6 +22,7 @@
   },
   {
     "meta": {
+      "translations": {},
       "rarity": "none",
       "weight": 1,
       "value": 100
@@ -31,6 +38,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Hache d'armes",
+          "description": "Une lame en croissant robuste mont\u00e9e sur un manche \u00e9pais entour\u00e9 de cuir pour une meilleur prise. Cette hache est assez grande pour \u00eatre mani\u00e9e \u00e0 deux mains et est orn\u00e9e de pointes sur le c\u00f4t\u00e9 oppos\u00e9 de la lame et au bout du manche."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 1000
@@ -58,6 +71,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Sarbacane",
+          "description": "Une arme primitive, mais mortelle, utilis\u00e9e par les tribues et les gu\u00e9rilleros. L'aiguille tir\u00e9e par cette arme peut d\u00e9livrer une dose l\u00e9thale de poison."
+        }
+      },
       "rarity": "none",
       "weight": 1,
       "value": 1000
@@ -86,6 +105,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Aiguilles de sarbacane (50)",
+          "description": "Munition faite pour \u00eatre tir\u00e9e d'une sarbacane, \u00e0 la force des poumons. Ces aiguilles sont fr\u00e9quemment tremp\u00e9es dans du poison incapacitant ou mortel."
+        }
+      },
       "rarity": "none",
       "weight": 0.02,
       "value": 2
@@ -101,6 +126,7 @@
   },
   {
     "meta": {
+      "translations": {},
       "rarity": "none",
       "weight": 1,
       "value": 100
@@ -116,6 +142,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Cuirasse",
+          "description": "Cette armure se compose d'une pi\u00e8ce principale de m\u00e9tal maintenue avec du cuir souple sur la poitrine. Bien qu'elle laisse les jambes et les bras relativement \u00e0 d\u00e9couvert, cette armure offre une bonne protection pour les organes vitaux tout en ne g\u00eanant pas trop son porteur."
+        }
+      },
       "rarity": "none",
       "weight": 20,
       "value": 40000,
@@ -133,6 +165,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Cotte de mailles",
+          "description": "Fait d'anneaux m\u00e9talliques entrecrois\u00e9s, la cotte de mailles comprend une couche de tissu matelass\u00e9 port\u00e9 sous la cotte pour \u00e9viter les frottements et amortir l'impact de coups. L'ensemble comprend des gantelets."
+        }
+      },
       "rarity": "none",
       "weight": 55,
       "value": 7500,
@@ -154,6 +192,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Chemise de mailles",
+          "description": "Fait d'anneaux m\u00e9talliques entrecrois\u00e9s, la chemise de mailles est utilis\u00e9e entre des couches de v\u00eatements ou de cuir. Cette armure offre une protection modeste pour le haut du corps et permet au son provoqu\u00e9 par les anneaux frottant l'un contre l'autre d'\u00eatre att\u00e9nu\u00e9 par les couches de v\u00eatements ext\u00e9rieures."
+        }
+      },
       "rarity": "none",
       "weight": 20,
       "value": 5000,
@@ -171,6 +215,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Gourdin",
+          "description": "Un gros bout de bois de forme un simple, mais efficace, aussi appel\u00e9e calebasse. Ces armes sont utilis\u00e9es pour matraquer les ennemis, meurtrir la chair et briser les os."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 10
@@ -197,6 +247,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Carreaux d'arbal\u00e8te",
+          "description": "Cette munition, utilis\u00e9e par les arbal\u00e8tes, est g\u00e9n\u00e9ralement faite d'une tige en m\u00e9tal avec une pointe ac\u00e9r\u00e9e."
+        }
+      },
       "rarity": "none",
       "weight": 0.075,
       "value": 5
@@ -212,6 +268,7 @@
   },
   {
     "meta": {
+      "translations": {},
       "rarity": "none",
       "weight": 1.5,
       "value": 100
@@ -227,6 +284,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Boule de cristal",
+          "description": "Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+        }
+      },
       "rarity": "none",
       "weight": 1,
       "value": 1000
@@ -244,6 +307,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Dague",
+          "description": "Une lame en m\u00e9tal courte mont\u00e9e sur une petite poign\u00e9e avec une garde. La dague est efficace en arme secondaire pour les combattants aggu\u00e9ris ou pour en arme cach\u00e9e pour les assassins et les voleurs."
+        }
+      },
       "rarity": "none",
       "weight": 1,
       "value": 200
@@ -273,6 +342,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Fl\u00e9chette",
+          "description": "Un petit outil de lanc\u00e9 fabriqu\u00e9 en bois avec un empennage en plume en forme de croix ainsi qu'une extr\u00e9mit\u00e9 pointue en bois ou en m\u00e9tal. Avec suffisament de force, une fl\u00e9chette peut percer la peau."
+        }
+      },
       "rarity": "none",
       "weight": 0.25,
       "value": 5
@@ -300,6 +375,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Fl\u00e9au d'armes",
+          "description": "Un ensemble de boules \u00e0 pointes reli\u00e9es par une cha\u00eene et attach\u00e9es \u00e0 un solide manche en bois. Le fl\u00e9au provoque des d\u00e9g\u00e2ts d\u00e9vastateurs lorsqu'il tourne en arc de cercle mortel."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 1000
@@ -322,6 +403,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Coutille",
+          "description": "Sabre court \u00e0 deux tranchants au bout d'un grand manche."
+        }
+      },
       "rarity": "none",
       "weight": 6,
       "value": 2000
@@ -349,6 +436,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Hache \u00e0 deux mains",
+          "description": "Cette \u00e9norme hache comporte deux lames en double croissant mont\u00e9es de chaque c\u00f4t\u00e9 d'un grand arbre \u00e0 pointes. Con\u00e7ue pour \u00eatre mani\u00e9e \u00e0 deux mains et pour fendre les ennemis en deux"
+        }
+      },
       "rarity": "none",
       "weight": 7,
       "value": 3000
@@ -376,6 +469,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Massue",
+          "description": "Une variante plus grande du gourdin simple, un lourd manche en bois avec un \u00e9norme n\u0153ud de bois au bout, inflige des dommages paralysants aux malheureux ennemis."
+        }
+      },
       "rarity": "none",
       "weight": 10,
       "value": 20
@@ -402,6 +501,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "\u00c9p\u00e9e \u00e0 deux mains",
+          "description": "Une puissante lame \u00e0 deux mains mesure plus d'un m\u00e8tre de long et presque cinq pouces de large. Cette arme n\u00e9cessite un entra\u00eenement martial intensif, mais ceux qui savent s'en servir sont de redoutables guerriers."
+        }
+      },
       "rarity": "none",
       "weight": 6,
       "value": 5000
@@ -429,6 +534,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Hallebarde",
+          "description": "La hallebarde est une arme d\u00e9fensive puissante qui permet \u00e0 un guerrier de repousser ses ennemis en utilisant la longue port\u00e9e du manche et ainsi attaquer \u00e0 distance de s\u00e9curit\u00e9."
+        }
+      },
       "rarity": "none",
       "weight": 6,
       "value": 2000
@@ -456,6 +567,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Armure Demi-plate",
+          "description": "Cette armure est constitu\u00e9e de plaques m\u00e9talliques fa\u00e7onn\u00e9es qui recouvrent la majeure partie du corps. Mis \u00e0 part les jambi\u00e8res attach\u00e9es avec des lani\u00e8res de cuir, elle ne prot\u00e8ge pas les jambes."
+        }
+      },
       "rarity": "none",
       "weight": 40,
       "value": 75000,
@@ -474,6 +591,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Arbal\u00e8te de poing",
+          "description": "Une arbal\u00e8te l\u00e9g\u00e8re con\u00e7ue pour \u00eatre tenue dans une main ou attach\u00e9e au poignet pour tirer des carreaux."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 7500
@@ -504,6 +627,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Hachette",
+          "description": "Cette hache \u00e0 une main est l\u00e9g\u00e8re et \u00e9quilibr\u00e9e pour le lancer tout en restant utile dans le combat au contact."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 500
@@ -532,6 +661,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Arbal\u00e8te lourde",
+          "description": "Une grande arbal\u00e8te mont\u00e9e sur un solide bloc de bois qui est charg\u00e9 \u00e0 l'aide d'une manivelle et qui tire d'\u00e9pais carreaux en acier avec une acc\u00e9l\u00e9ration mortelle qui transperce l'armure et la chair."
+        }
+      },
       "rarity": "none",
       "weight": 18,
       "value": 5000
@@ -563,6 +698,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Armure de peaux",
+          "description": "Cette armure brute est compos\u00e9e de fourrures et de peaux \u00e9paisses. Elle est couramment port\u00e9e par les tribus barbares, les humano\u00efdes mal\u00e9fiques, et d'autres personnes qui n'ont pas acc\u00e8s aux outils et mat\u00e9riaux n\u00e9cessaires pour cr\u00e9er de meilleures armures."
+        }
+      },
       "rarity": "none",
       "weight": 12,
       "value": 1000,
@@ -580,6 +721,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Javeline",
+          "description": "Cette lance l\u00e9g\u00e8re et flexible est con\u00e7ue pour \u00eatre lanc\u00e9e, mais elle est aussi suffisamment polyvalente pour \u00eatre utilis\u00e9e en combat en m\u00eal\u00e9e."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 50
@@ -607,6 +754,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Lance d'har\u00e7on",
+          "description": "Une pointe d'acier brillante pour percer les d\u00e9fenses les plus dures de l'ennemi, enfonc\u00e9e par la force d'un coursier au galop. Bien que mieux adapt\u00e9e au combat \u00e0 cheval, la lance peut \u00eatre utilis\u00e9e \u00e0 pieds. Vous \u00eates d\u00e9savantag\u00e9 lorsque vous utilisez une lance pour attaquer une cible situ\u00e9e \u00e0 moins de 1,5 m\u00e8tre de vous. De plus, une lance n\u00e9cessite deux mains pour \u00eatre mani\u00e9e lorsque vous n'\u00eates pas mont\u00e9.Vous avez un d\u00e9savantage lorsque vous utilisez une lance d'ar\u00e7on pour attaquer une cible \u00e0 1,50 m\u00e8tre ou moins de vous. En outre, une lance d'ar\u00e7on requiert deux mains pour \u00eatre mani\u00e9e lorsque vous n'\u00eates pas sur une monture."
+        }
+      },
       "rarity": "none",
       "weight": 6,
       "value": 1000,
@@ -634,6 +787,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Armure de cuir",
+          "description": "La cuirasse et les protecteurs d'\u00e9paules de cette armure sont faits de cuir qui a \u00e9t\u00e9 durci en \u00e9tant bouilli dans de l'huile. Le reste de l'armure est fait de mat\u00e9riaux plus tendres et plus souples."
+        }
+      },
       "rarity": "none",
       "weight": 10,
       "value": 1000,
@@ -651,6 +810,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Arbal\u00e8te l\u00e9g\u00e8re",
+          "description": "Une petite arbal\u00e8te avec un manche en bois et une corde tendue qui est capable de tirer un seul coup qui peut perforer m\u00eame les armures lourdes \u00e0 bout portant."
+        }
+      },
       "rarity": "none",
       "weight": 5,
       "value": 2500
@@ -681,6 +846,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Marteau l\u00e9ger",
+          "description": "Ce solide marteau est suffisamment petit pour \u00eatre mani\u00e9 avec agilit\u00e9 ou utilis\u00e9 en combinaison avec une autre arme."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 200
@@ -709,6 +880,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Arc long",
+          "description": "Un \u00e9pais morceau de bois lamell\u00e9 est courb\u00e9 par une corde tendue capable de lancer des fl\u00e8ches mortelles \u00e0 longue distance."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 5000
@@ -739,6 +916,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "\u00c9p\u00e9e longue",
+          "description": "L'\u00e9p\u00e9e longue est une arme tr\u00e8s polyvalente qui peut \u00e9galement \u00eatre mani\u00e9e \u00e0 deux mains pour des coups plus punitifs."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 1500
@@ -766,6 +949,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Masse d'armes",
+          "description": "Une lourde boule de m\u00e9tal mont\u00e9e au bout d'une massue \u00e9galement de m\u00e9tal. La t\u00eate est munie de pointes et de lames con\u00e7ues pour perforer l'armure et briser les os situ\u00e9s en dessous."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 500
@@ -789,6 +978,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Maillet",
+          "description": "Cette masse lourde \u00e0 deux mains \u00e9crase le m\u00e9tal et les os avec une force tonitruante."
+        }
+      },
       "rarity": "none",
       "weight": 10,
       "value": 1000
@@ -816,6 +1011,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Morgenstern",
+          "description": "Un globe de m\u00e9tal vicieusement pointu, mont\u00e9 au bout d'un manche robuste, constitue une arme mortelle qui peut perforer aussi bien l'armure que la chair."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 1500
@@ -839,6 +1040,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Filet",
+          "description": "Une cr\u00e9ature de taille G ou plus petite qui est touch\u00e9e par un filet est entrav\u00e9e jusqu'\u00e0 ce qu'elle soit lib\u00e9r\u00e9e. Un filet n'a aucun effet sur les cr\u00e9atures sans forme ou de taille sup\u00e9rieure \u00e0 G. Une cr\u00e9ature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se lib\u00e9rer ou de lib\u00e9rer une autre cr\u00e9ature \u00e0 sa port\u00e9e en cas de succ\u00e8s. Infliger 5 points de d\u00e9g\u00e2ts tranchants \u00e0 un filet (CA 10) permet \u00e9galement de lib\u00e9rer une cr\u00e9ature sans la blesser, mettant fin \u00e0 l'effet tout en d\u00e9truisant le filet. Lorsque vous utilisez une action, une action bonus ou une r\u00e9action pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement r\u00e9aliser."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 100,
@@ -864,6 +1071,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Orbe",
+          "description": "Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 2000
@@ -881,6 +1094,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Armure matelass\u00e9e",
+          "description": "L'armure matelass\u00e9e est constitu\u00e9e de couches de tissu et de molleton matelass\u00e9s. L'armure matelass\u00e9e offre un niveau de protection comparable \u00e0 celui du cuir raidi mais est un peu moins encombrante pour le porteur."
+        }
+      },
       "rarity": "none",
       "weight": 8,
       "value": 500,
@@ -899,6 +1118,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Pique",
+          "description": "Une lame robuste mont\u00e9e au bout d'un long manche en m\u00e9tal. Con\u00e7ue comme une arme d\u00e9fensive avec une port\u00e9e consid\u00e9rable pour repousser et menacer les ennemis."
+        }
+      },
       "rarity": "none",
       "weight": 18,
       "value": 500
@@ -926,6 +1151,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Harnois",
+          "description": "Le harnois est constitu\u00e9 de plaques de m\u00e9tal entrecrois\u00e9es qui couvrent l'ensemble du corps. L'ensemble inclut des gants, des bottes en cuir \u00e9pais, un casque \u00e0 visi\u00e8re, et d'\u00e9paisses couches de rembourrage sous l'armure. Des boucles et des sangles distribuent le poids sur le corps."
+        }
+      },
       "rarity": "none",
       "weight": 65,
       "value": 150000,
@@ -947,6 +1178,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "B\u00e2ton",
+          "description": "Un \u00e9pais manche en bois envelopp\u00e9 d'une solide poign\u00e9e fait une arme tr\u00e8s fonctionnelle en plus d'un solide b\u00e2ton de marche."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 20
@@ -973,6 +1210,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Rapi\u00e8re",
+          "description": "Une lame m\u00e9tallique mince et r\u00e9sistante, l\u00e9g\u00e8re mais de longue port\u00e9e, con\u00e7ue pour des attaques rapides afin de cibler les points faibles des d\u00e9fenses ennemies avec une rapidit\u00e9 fulgurante."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 2500
@@ -999,6 +1242,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Broigne",
+          "description": "This armor is leather armor with heavy rings sewn into it. The rings help reinforce the armor against blows from swords and axes. Ring mail is inferior to chain mail, and it's usually worn only by those who can't afford better armor."
+        }
+      },
       "rarity": "none",
       "weight": 40,
       "value": 3000,
@@ -1017,6 +1266,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Sceptre",
+          "description": "Une tige d'os, de pierre, de m\u00e9tal ou de mat\u00e9riaux plus exotiques, taill\u00e9e ou fa\u00e7onn\u00e9e de fa\u00e7on complexe. Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 1000
@@ -1034,6 +1289,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Armure d'\u00e9cailles",
+          "description": "Cette armure se compose d'une veste et de jambi\u00e8res (et parfois d\u2019une jupe s\u00e9par\u00e9e) de cuir recouvert de pi\u00e8ces de m\u00e9tal qui se chevauchent, un peu comme les \u00e9cailles d'un poisson. L'ensemble comprend \u00e9galement des gantelets."
+        }
+      },
       "rarity": "none",
       "weight": 45,
       "value": 5000,
@@ -1052,6 +1313,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Cimeterre",
+          "description": "Cette lame incurv\u00e9e est large pr\u00e8s du manche mais s'arque et se r\u00e9tr\u00e9cit en une pointe."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 2500
@@ -1079,6 +1346,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Bouclier",
+          "description": "Un bouclier est fait de bois ou de m\u00e9tal et est port\u00e9 dans une main. Le fait de porter un bouclier augmente votre classe d'armure de 2. Vous ne pouvez b\u00e9n\u00e9ficier que d'un seul bouclier \u00e0 la fois."
+        }
+      },
       "rarity": "none",
       "weight": 6,
       "value": 1000,
@@ -1095,6 +1368,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Arc court",
+          "description": "Cet arc \u00e0 deux mains est un peu plus petit que la variante traditionnelle de l'arc long, ce qui le rend bien adapt\u00e9 aux attaques rapides en mouvement ou \u00e0 cheval."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 2500
@@ -1124,6 +1403,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "\u00c9p\u00e9e courte",
+          "description": " lame de taille moyenne avec une garde crois\u00e9e ferme et un manche gain\u00e9 de cuir. Une arme qui compense en polyvalence ce qui lui manque en termes de port\u00e9e."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 1000
@@ -1151,6 +1436,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Serpe",
+          "description": "Une lame en croissant mont\u00e9e sur un court manche, assez l\u00e9g\u00e8re pour \u00eatre mani\u00e9e d'une seule main afin de trancher les cultures ... ou les ennemis."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 100
@@ -1176,6 +1467,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Fronde",
+          "description": "Une lani\u00e8re de cuir flexible fix\u00e9e \u00e0 un manche en bois qui est capable de projeter des pierres ou des balles m\u00e9talliques \u00e0 une vitesse mortelle."
+        }
+      },
       "rarity": "none",
       "value": 10
     },
@@ -1202,6 +1499,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Billes de fronde",
+          "description": "Caillou durci de pierre, d'os ou de m\u00e9tal qui peut \u00eatre lanc\u00e9 \u00e0 grande vitesse \u00e0 l'aide d'une fronde.\n**Note de Foundry: Il sera g\u00e9n\u00e9ralement impossible d'acheter une balle de fronde car elles valent moins d'une pi\u00e8ce de cuivre (5 balles = 1 cp)."
+        }
+      },
       "rarity": "none",
       "weight": 0.075,
       "value": 0.2
@@ -1217,6 +1520,7 @@
   },
   {
     "meta": {
+      "translations": {},
       "rarity": "none",
       "weight": 1.5,
       "value": 4
@@ -1232,6 +1536,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Lance",
+          "description": "Une pointe d'acier \u00e9tincelante au sommet d'un solide manche en bois, la lance peut \u00eatre mani\u00e9e \u00e0 une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 100
@@ -1261,6 +1571,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Clibanion",
+          "description": "Cette armure est faite d'\u00e9troites bandes verticales de m\u00e9tal rivet\u00e9es sur un support de cuir qui est port\u00e9 sur un rembourrage de tissu. Une cotte de mailles souple prot\u00e8ge les articulations."
+        }
+      },
       "rarity": "none",
       "weight": 60,
       "value": 20000,
@@ -1282,6 +1598,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "B\u00e2ton",
+          "description": "Un b\u00e2ton noueux ou poli en bois, en os ou en mat\u00e9riaux plus exotiques comme le cristal. Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 500
@@ -1310,6 +1632,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Armure de cuir clout\u00e9",
+          "description": "Fabriqu\u00e9 en cuir r\u00e9sistant mais souple, le cuir clout\u00e9 est renforc\u00e9 par des rivets ou des pointes serr\u00e9es."
+        }
+      },
       "rarity": "none",
       "weight": 13,
       "value": 4500,
@@ -1327,6 +1655,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Trident",
+          "description": "Une lance \u00e0 plusieurs dents con\u00e7ue pour empaler une cible \u00e0 plusieurs endroits, en les immobilisant. Souvent utilis\u00e9e en combinaison avec un filet pour pi\u00e9ger et harceler les ennemis."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 500
@@ -1355,6 +1689,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Baguette",
+          "description": "Un instrument d\u00e9licat \u00e0 une seule main en bois, os, cristal ou autres mat\u00e9riaux exotiques qui est couramment utilis\u00e9 comme point de mire pour aider \u00e0 la projection d'arcanes.Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+        }
+      },
       "rarity": "none",
       "weight": 1,
       "value": 1000
@@ -1372,6 +1712,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Pic de guerre",
+          "description": "Une pointe incurv\u00e9e massive mont\u00e9e \u00e0 l'arri\u00e8re d'un solide manche - con\u00e7ue pour percer les blindages avec une force mortelle."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 500
@@ -1394,6 +1740,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Marteau de guerre",
+          "description": "Un marteau en m\u00e9tal lourd pouvant \u00eatre mani\u00e9 d'une seule main avec un bouclier ou \u00e0 deux mains pour d\u00e9livrer des coups \u00e9crasants."
+        }
+      },
       "rarity": "none",
       "weight": 2,
       "value": 1500
@@ -1421,6 +1773,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "Fouet",
+          "description": "Une corde tendue fa\u00eete de cuir, de corde ou de cha\u00eene qui peut attraper des ennemis proches, les lac\u00e9rant et les harcelant \u00e0 distance."
+        }
+      },
       "rarity": "none",
       "weight": 3,
       "value": 200
@@ -1447,6 +1805,12 @@
   },
   {
     "meta": {
+      "translations": {
+        "fr": {
+          "name": "B\u00e2ton",
+          "description": "Le b\u00e2ton a \u00e9t\u00e9 sculpt\u00e9 dans bois sp\u00e9cial et grav\u00e9 de puissantes runes pour invoquer la puissance de la nature par ceux qui entendent son appel. Focaliseur druidique. Un focaliseur druidique peut \u00eatre un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois sp\u00e9cial, un b\u00e2ton pris d'un arbre vivant, ou bien encore un objet totem qui int\u00e8gre des plumes, de la fourrure, des os ou des dents d'animaux sacr\u00e9s. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+        }
+      },
       "rarity": "none",
       "weight": 4,
       "value": 500

--- a/dnd5esheets/data/items-base.json
+++ b/dnd5esheets/data/items-base.json
@@ -1,10 +1,11 @@
 [
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
-          "name": "Fl\u00e8che",
-          "description": "Munitions standard utilis\u00e9es pour les arcs de toutes sortes. Ces fl\u00e8ches banales sont fabriqu\u00e9es \u00e0 partir d'un manche en bois lisse, avec des plumes d'oie et un rev\u00eatement en m\u00e9tal martel\u00e9."
+          "name": "Flèche",
+          "description": "Munitions standard utilisées pour les arcs de toutes sortes. Ces flèches banales sont fabriquées à partir d'un manche en bois lisse, avec des plumes d'oie et un revêtement en métal martelé."
         }
       },
       "rarity": "none",
@@ -36,12 +37,14 @@
     "subtype": "A",
     "type": "munition"
   },
+  null,
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Hache d'armes",
-          "description": "Une lame en croissant robuste mont\u00e9e sur un manche \u00e9pais entour\u00e9 de cuir pour une meilleur prise. Cette hache est assez grande pour \u00eatre mani\u00e9e \u00e0 deux mains et est orn\u00e9e de pointes sur le c\u00f4t\u00e9 oppos\u00e9 de la lame et au bout du manche."
+          "description": "Une lame en croissant robuste montée sur un manche épais entouré de cuir pour une meilleur prise. Cette hache est assez grande pour être maniée à deux mains et est ornée de pointes sur le côté opposé de la lame et au bout du manche."
         }
       },
       "rarity": "none",
@@ -74,7 +77,7 @@
       "translations": {
         "fr": {
           "name": "Sarbacane",
-          "description": "Une arme primitive, mais mortelle, utilis\u00e9e par les tribues et les gu\u00e9rilleros. L'aiguille tir\u00e9e par cette arme peut d\u00e9livrer une dose l\u00e9thale de poison."
+          "description": "Une arme primitive, mais mortelle, utilisée par les tribues et les guérilleros. L'aiguille tirée par cette arme peut délivrer une dose léthale de poison."
         }
       },
       "rarity": "none",
@@ -108,7 +111,7 @@
       "translations": {
         "fr": {
           "name": "Aiguilles de sarbacane (50)",
-          "description": "Munition faite pour \u00eatre tir\u00e9e d'une sarbacane, \u00e0 la force des poumons. Ces aiguilles sont fr\u00e9quemment tremp\u00e9es dans du poison incapacitant ou mortel."
+          "description": "Munition faite pour être tirée d'une sarbacane, à la force des poumons. Ces aiguilles sont fréquemment trempées dans du poison incapacitant ou mortel."
         }
       },
       "rarity": "none",
@@ -145,7 +148,7 @@
       "translations": {
         "fr": {
           "name": "Cuirasse",
-          "description": "Cette armure se compose d'une pi\u00e8ce principale de m\u00e9tal maintenue avec du cuir souple sur la poitrine. Bien qu'elle laisse les jambes et les bras relativement \u00e0 d\u00e9couvert, cette armure offre une bonne protection pour les organes vitaux tout en ne g\u00eanant pas trop son porteur."
+          "description": "Cette armure se compose d'une pièce principale de métal maintenue avec du cuir souple sur la poitrine. Bien qu'elle laisse les jambes et les bras relativement à découvert, cette armure offre une bonne protection pour les organes vitaux tout en ne gênant pas trop son porteur."
         }
       },
       "rarity": "none",
@@ -168,7 +171,7 @@
       "translations": {
         "fr": {
           "name": "Cotte de mailles",
-          "description": "Fait d'anneaux m\u00e9talliques entrecrois\u00e9s, la cotte de mailles comprend une couche de tissu matelass\u00e9 port\u00e9 sous la cotte pour \u00e9viter les frottements et amortir l'impact de coups. L'ensemble comprend des gantelets."
+          "description": "Fait d'anneaux métalliques entrecroisés, la cotte de mailles comprend une couche de tissu matelassé porté sous la cotte pour éviter les frottements et amortir l'impact de coups. L'ensemble comprend des gantelets."
         }
       },
       "rarity": "none",
@@ -195,7 +198,7 @@
       "translations": {
         "fr": {
           "name": "Chemise de mailles",
-          "description": "Fait d'anneaux m\u00e9talliques entrecrois\u00e9s, la chemise de mailles est utilis\u00e9e entre des couches de v\u00eatements ou de cuir. Cette armure offre une protection modeste pour le haut du corps et permet au son provoqu\u00e9 par les anneaux frottant l'un contre l'autre d'\u00eatre att\u00e9nu\u00e9 par les couches de v\u00eatements ext\u00e9rieures."
+          "description": "Fait d'anneaux métalliques entrecroisés, la chemise de mailles est utilisée entre des couches de vêtements ou de cuir. Cette armure offre une protection modeste pour le haut du corps et permet au son provoqué par les anneaux frottant l'un contre l'autre d'être atténué par les couches de vêtements extérieures."
         }
       },
       "rarity": "none",
@@ -218,7 +221,7 @@
       "translations": {
         "fr": {
           "name": "Gourdin",
-          "description": "Un gros bout de bois de forme un simple, mais efficace, aussi appel\u00e9e calebasse. Ces armes sont utilis\u00e9es pour matraquer les ennemis, meurtrir la chair et briser les os."
+          "description": "Un gros bout de bois de forme un simple, mais efficace, aussi appelée calebasse. Ces armes sont utilisées pour matraquer les ennemis, meurtrir la chair et briser les os."
         }
       },
       "rarity": "none",
@@ -249,8 +252,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Carreaux d'arbal\u00e8te",
-          "description": "Cette munition, utilis\u00e9e par les arbal\u00e8tes, est g\u00e9n\u00e9ralement faite d'une tige en m\u00e9tal avec une pointe ac\u00e9r\u00e9e."
+          "name": "Carreaux d'arbalète",
+          "description": "Cette munition, utilisée par les arbalètes, est généralement faite d'une tige en métal avec une pointe acérée."
         }
       },
       "rarity": "none",
@@ -287,7 +290,7 @@
       "translations": {
         "fr": {
           "name": "Boule de cristal",
-          "description": "Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+          "description": "Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
         }
       },
       "rarity": "none",
@@ -310,7 +313,7 @@
       "translations": {
         "fr": {
           "name": "Dague",
-          "description": "Une lame en m\u00e9tal courte mont\u00e9e sur une petite poign\u00e9e avec une garde. La dague est efficace en arme secondaire pour les combattants aggu\u00e9ris ou pour en arme cach\u00e9e pour les assassins et les voleurs."
+          "description": "Une lame en métal courte montée sur une petite poignée avec une garde. La dague est efficace en arme secondaire pour les combattants agguéris ou pour en arme cachée pour les assassins et les voleurs."
         }
       },
       "rarity": "none",
@@ -344,8 +347,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Fl\u00e9chette",
-          "description": "Un petit outil de lanc\u00e9 fabriqu\u00e9 en bois avec un empennage en plume en forme de croix ainsi qu'une extr\u00e9mit\u00e9 pointue en bois ou en m\u00e9tal. Avec suffisament de force, une fl\u00e9chette peut percer la peau."
+          "name": "Fléchette",
+          "description": "Un petit outil de lancé fabriqué en bois avec un empennage en plume en forme de croix ainsi qu'une extrémité pointue en bois ou en métal. Avec suffisament de force, une fléchette peut percer la peau."
         }
       },
       "rarity": "none",
@@ -373,12 +376,14 @@
     ],
     "type": "weapon"
   },
+  null,
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
-          "name": "Fl\u00e9au d'armes",
-          "description": "Un ensemble de boules \u00e0 pointes reli\u00e9es par une cha\u00eene et attach\u00e9es \u00e0 un solide manche en bois. Le fl\u00e9au provoque des d\u00e9g\u00e2ts d\u00e9vastateurs lorsqu'il tourne en arc de cercle mortel."
+          "name": "Fléau d'armes",
+          "description": "Un ensemble de boules à pointes reliées par une chaîne et attachées à un solide manche en bois. Le fléau provoque des dégâts dévastateurs lorsqu'il tourne en arc de cercle mortel."
         }
       },
       "rarity": "none",
@@ -406,7 +411,7 @@
       "translations": {
         "fr": {
           "name": "Coutille",
-          "description": "Sabre court \u00e0 deux tranchants au bout d'un grand manche."
+          "description": "Sabre court à deux tranchants au bout d'un grand manche."
         }
       },
       "rarity": "none",
@@ -438,8 +443,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Hache \u00e0 deux mains",
-          "description": "Cette \u00e9norme hache comporte deux lames en double croissant mont\u00e9es de chaque c\u00f4t\u00e9 d'un grand arbre \u00e0 pointes. Con\u00e7ue pour \u00eatre mani\u00e9e \u00e0 deux mains et pour fendre les ennemis en deux"
+          "name": "Hache à deux mains",
+          "description": "Cette énorme hache comporte deux lames en double croissant montées de chaque côté d'un grand arbre à pointes. Conçue pour être maniée à deux mains et pour fendre les ennemis en deux"
         }
       },
       "rarity": "none",
@@ -472,7 +477,7 @@
       "translations": {
         "fr": {
           "name": "Massue",
-          "description": "Une variante plus grande du gourdin simple, un lourd manche en bois avec un \u00e9norme n\u0153ud de bois au bout, inflige des dommages paralysants aux malheureux ennemis."
+          "description": "Une variante plus grande du gourdin simple, un lourd manche en bois avec un énorme nœud de bois au bout, inflige des dommages paralysants aux malheureux ennemis."
         }
       },
       "rarity": "none",
@@ -503,8 +508,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "\u00c9p\u00e9e \u00e0 deux mains",
-          "description": "Une puissante lame \u00e0 deux mains mesure plus d'un m\u00e8tre de long et presque cinq pouces de large. Cette arme n\u00e9cessite un entra\u00eenement martial intensif, mais ceux qui savent s'en servir sont de redoutables guerriers."
+          "name": "Épée à deux mains",
+          "description": "Une puissante lame à deux mains mesure plus d'un mètre de long et presque cinq pouces de large. Cette arme nécessite un entraînement martial intensif, mais ceux qui savent s'en servir sont de redoutables guerriers."
         }
       },
       "rarity": "none",
@@ -537,7 +542,7 @@
       "translations": {
         "fr": {
           "name": "Hallebarde",
-          "description": "La hallebarde est une arme d\u00e9fensive puissante qui permet \u00e0 un guerrier de repousser ses ennemis en utilisant la longue port\u00e9e du manche et ainsi attaquer \u00e0 distance de s\u00e9curit\u00e9."
+          "description": "La hallebarde est une arme défensive puissante qui permet à un guerrier de repousser ses ennemis en utilisant la longue portée du manche et ainsi attaquer à distance de sécurité."
         }
       },
       "rarity": "none",
@@ -570,7 +575,7 @@
       "translations": {
         "fr": {
           "name": "Armure Demi-plate",
-          "description": "Cette armure est constitu\u00e9e de plaques m\u00e9talliques fa\u00e7onn\u00e9es qui recouvrent la majeure partie du corps. Mis \u00e0 part les jambi\u00e8res attach\u00e9es avec des lani\u00e8res de cuir, elle ne prot\u00e8ge pas les jambes."
+          "description": "Cette armure est constituée de plaques métalliques façonnées qui recouvrent la majeure partie du corps. Mis à part les jambières attachées avec des lanières de cuir, elle ne protège pas les jambes."
         }
       },
       "rarity": "none",
@@ -593,8 +598,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Arbal\u00e8te de poing",
-          "description": "Une arbal\u00e8te l\u00e9g\u00e8re con\u00e7ue pour \u00eatre tenue dans une main ou attach\u00e9e au poignet pour tirer des carreaux."
+          "name": "Arbalète de poing",
+          "description": "Une arbalète légère conçue pour être tenue dans une main ou attachée au poignet pour tirer des carreaux."
         }
       },
       "rarity": "none",
@@ -630,7 +635,7 @@
       "translations": {
         "fr": {
           "name": "Hachette",
-          "description": "Cette hache \u00e0 une main est l\u00e9g\u00e8re et \u00e9quilibr\u00e9e pour le lancer tout en restant utile dans le combat au contact."
+          "description": "Cette hache à une main est légère et équilibrée pour le lancer tout en restant utile dans le combat au contact."
         }
       },
       "rarity": "none",
@@ -663,8 +668,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Arbal\u00e8te lourde",
-          "description": "Une grande arbal\u00e8te mont\u00e9e sur un solide bloc de bois qui est charg\u00e9 \u00e0 l'aide d'une manivelle et qui tire d'\u00e9pais carreaux en acier avec une acc\u00e9l\u00e9ration mortelle qui transperce l'armure et la chair."
+          "name": "Arbalète lourde",
+          "description": "Une grande arbalète montée sur un solide bloc de bois qui est chargé à l'aide d'une manivelle et qui tire d'épais carreaux en acier avec une accélération mortelle qui transperce l'armure et la chair."
         }
       },
       "rarity": "none",
@@ -701,7 +706,7 @@
       "translations": {
         "fr": {
           "name": "Armure de peaux",
-          "description": "Cette armure brute est compos\u00e9e de fourrures et de peaux \u00e9paisses. Elle est couramment port\u00e9e par les tribus barbares, les humano\u00efdes mal\u00e9fiques, et d'autres personnes qui n'ont pas acc\u00e8s aux outils et mat\u00e9riaux n\u00e9cessaires pour cr\u00e9er de meilleures armures."
+          "description": "Cette armure brute est composée de fourrures et de peaux épaisses. Elle est couramment portée par les tribus barbares, les humanoïdes maléfiques, et d'autres personnes qui n'ont pas accès aux outils et matériaux nécessaires pour créer de meilleures armures."
         }
       },
       "rarity": "none",
@@ -719,12 +724,15 @@
     "effect": "$ac := 12 + min($dex, 2)",
     "type": "armor"
   },
+  null,
+  null,
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Javeline",
-          "description": "Cette lance l\u00e9g\u00e8re et flexible est con\u00e7ue pour \u00eatre lanc\u00e9e, mais elle est aussi suffisamment polyvalente pour \u00eatre utilis\u00e9e en combat en m\u00eal\u00e9e."
+          "description": "Cette lance légère et flexible est conçue pour être lancée, mais elle est aussi suffisamment polyvalente pour être utilisée en combat en mêlée."
         }
       },
       "rarity": "none",
@@ -756,8 +764,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Lance d'har\u00e7on",
-          "description": "Une pointe d'acier brillante pour percer les d\u00e9fenses les plus dures de l'ennemi, enfonc\u00e9e par la force d'un coursier au galop. Bien que mieux adapt\u00e9e au combat \u00e0 cheval, la lance peut \u00eatre utilis\u00e9e \u00e0 pieds. Vous \u00eates d\u00e9savantag\u00e9 lorsque vous utilisez une lance pour attaquer une cible situ\u00e9e \u00e0 moins de 1,5 m\u00e8tre de vous. De plus, une lance n\u00e9cessite deux mains pour \u00eatre mani\u00e9e lorsque vous n'\u00eates pas mont\u00e9.Vous avez un d\u00e9savantage lorsque vous utilisez une lance d'ar\u00e7on pour attaquer une cible \u00e0 1,50 m\u00e8tre ou moins de vous. En outre, une lance d'ar\u00e7on requiert deux mains pour \u00eatre mani\u00e9e lorsque vous n'\u00eates pas sur une monture."
+          "name": "Lance d'harçon",
+          "description": "Une pointe d'acier brillante pour percer les défenses les plus dures de l'ennemi, enfoncée par la force d'un coursier au galop. Bien que mieux adaptée au combat à cheval, la lance peut être utilisée à pieds. Vous êtes désavantagé lorsque vous utilisez une lance pour attaquer une cible située à moins de 1,5 mètre de vous. De plus, une lance nécessite deux mains pour être maniée lorsque vous n'êtes pas monté.Vous avez un désavantage lorsque vous utilisez une lance d'arçon pour attaquer une cible à 1,50 mètre ou moins de vous. En outre, une lance d'arçon requiert deux mains pour être maniée lorsque vous n'êtes pas sur une monture."
         }
       },
       "rarity": "none",
@@ -785,12 +793,14 @@
     ],
     "type": "weapon"
   },
+  null,
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Armure de cuir",
-          "description": "La cuirasse et les protecteurs d'\u00e9paules de cette armure sont faits de cuir qui a \u00e9t\u00e9 durci en \u00e9tant bouilli dans de l'huile. Le reste de l'armure est fait de mat\u00e9riaux plus tendres et plus souples."
+          "description": "La cuirasse et les protecteurs d'épaules de cette armure sont faits de cuir qui a été durci en étant bouilli dans de l'huile. Le reste de l'armure est fait de matériaux plus tendres et plus souples."
         }
       },
       "rarity": "none",
@@ -812,8 +822,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Arbal\u00e8te l\u00e9g\u00e8re",
-          "description": "Une petite arbal\u00e8te avec un manche en bois et une corde tendue qui est capable de tirer un seul coup qui peut perforer m\u00eame les armures lourdes \u00e0 bout portant."
+          "name": "Arbalète légère",
+          "description": "Une petite arbalète avec un manche en bois et une corde tendue qui est capable de tirer un seul coup qui peut perforer même les armures lourdes à bout portant."
         }
       },
       "rarity": "none",
@@ -848,8 +858,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Marteau l\u00e9ger",
-          "description": "Ce solide marteau est suffisamment petit pour \u00eatre mani\u00e9 avec agilit\u00e9 ou utilis\u00e9 en combinaison avec une autre arme."
+          "name": "Marteau léger",
+          "description": "Ce solide marteau est suffisamment petit pour être manié avec agilité ou utilisé en combinaison avec une autre arme."
         }
       },
       "rarity": "none",
@@ -878,12 +888,13 @@
     ],
     "type": "weapon"
   },
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Arc long",
-          "description": "Un \u00e9pais morceau de bois lamell\u00e9 est courb\u00e9 par une corde tendue capable de lancer des fl\u00e8ches mortelles \u00e0 longue distance."
+          "description": "Un épais morceau de bois lamellé est courbé par une corde tendue capable de lancer des flèches mortelles à longue distance."
         }
       },
       "rarity": "none",
@@ -918,8 +929,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "\u00c9p\u00e9e longue",
-          "description": "L'\u00e9p\u00e9e longue est une arme tr\u00e8s polyvalente qui peut \u00e9galement \u00eatre mani\u00e9e \u00e0 deux mains pour des coups plus punitifs."
+          "name": "Épée longue",
+          "description": "L'épée longue est une arme très polyvalente qui peut également être maniée à deux mains pour des coups plus punitifs."
         }
       },
       "rarity": "none",
@@ -952,7 +963,7 @@
       "translations": {
         "fr": {
           "name": "Masse d'armes",
-          "description": "Une lourde boule de m\u00e9tal mont\u00e9e au bout d'une massue \u00e9galement de m\u00e9tal. La t\u00eate est munie de pointes et de lames con\u00e7ues pour perforer l'armure et briser les os situ\u00e9s en dessous."
+          "description": "Une lourde boule de métal montée au bout d'une massue également de métal. La tête est munie de pointes et de lames conçues pour perforer l'armure et briser les os situés en dessous."
         }
       },
       "rarity": "none",
@@ -981,7 +992,7 @@
       "translations": {
         "fr": {
           "name": "Maillet",
-          "description": "Cette masse lourde \u00e0 deux mains \u00e9crase le m\u00e9tal et les os avec une force tonitruante."
+          "description": "Cette masse lourde à deux mains écrase le métal et les os avec une force tonitruante."
         }
       },
       "rarity": "none",
@@ -1009,12 +1020,14 @@
     ],
     "type": "weapon"
   },
+  null,
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Morgenstern",
-          "description": "Un globe de m\u00e9tal vicieusement pointu, mont\u00e9 au bout d'un manche robuste, constitue une arme mortelle qui peut perforer aussi bien l'armure que la chair."
+          "description": "Un globe de métal vicieusement pointu, monté au bout d'un manche robuste, constitue une arme mortelle qui peut perforer aussi bien l'armure que la chair."
         }
       },
       "rarity": "none",
@@ -1038,12 +1051,13 @@
     "subtype": "M",
     "type": "weapon"
   },
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Filet",
-          "description": "Une cr\u00e9ature de taille G ou plus petite qui est touch\u00e9e par un filet est entrav\u00e9e jusqu'\u00e0 ce qu'elle soit lib\u00e9r\u00e9e. Un filet n'a aucun effet sur les cr\u00e9atures sans forme ou de taille sup\u00e9rieure \u00e0 G. Une cr\u00e9ature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se lib\u00e9rer ou de lib\u00e9rer une autre cr\u00e9ature \u00e0 sa port\u00e9e en cas de succ\u00e8s. Infliger 5 points de d\u00e9g\u00e2ts tranchants \u00e0 un filet (CA 10) permet \u00e9galement de lib\u00e9rer une cr\u00e9ature sans la blesser, mettant fin \u00e0 l'effet tout en d\u00e9truisant le filet. Lorsque vous utilisez une action, une action bonus ou une r\u00e9action pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement r\u00e9aliser."
+          "description": "Une créature de taille G ou plus petite qui est touchée par un filet est entravée jusqu'à ce qu'elle soit libérée. Un filet n'a aucun effet sur les créatures sans forme ou de taille supérieure à G. Une créature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se libérer ou de libérer une autre créature à sa portée en cas de succès. Infliger 5 points de dégâts tranchants à un filet (CA 10) permet également de libérer une créature sans la blesser, mettant fin à l'effet tout en détruisant le filet. Lorsque vous utilisez une action, une action bonus ou une réaction pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement réaliser."
         }
       },
       "rarity": "none",
@@ -1074,7 +1088,7 @@
       "translations": {
         "fr": {
           "name": "Orbe",
-          "description": "Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+          "description": "Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
         }
       },
       "rarity": "none",
@@ -1096,8 +1110,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Armure matelass\u00e9e",
-          "description": "L'armure matelass\u00e9e est constitu\u00e9e de couches de tissu et de molleton matelass\u00e9s. L'armure matelass\u00e9e offre un niveau de protection comparable \u00e0 celui du cuir raidi mais est un peu moins encombrante pour le porteur."
+          "name": "Armure matelassée",
+          "description": "L'armure matelassée est constituée de couches de tissu et de molleton matelassés. L'armure matelassée offre un niveau de protection comparable à celui du cuir raidi mais est un peu moins encombrante pour le porteur."
         }
       },
       "rarity": "none",
@@ -1121,7 +1135,7 @@
       "translations": {
         "fr": {
           "name": "Pique",
-          "description": "Une lame robuste mont\u00e9e au bout d'un long manche en m\u00e9tal. Con\u00e7ue comme une arme d\u00e9fensive avec une port\u00e9e consid\u00e9rable pour repousser et menacer les ennemis."
+          "description": "Une lame robuste montée au bout d'un long manche en métal. Conçue comme une arme défensive avec une portée considérable pour repousser et menacer les ennemis."
         }
       },
       "rarity": "none",
@@ -1149,12 +1163,13 @@
     ],
     "type": "weapon"
   },
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Harnois",
-          "description": "Le harnois est constitu\u00e9 de plaques de m\u00e9tal entrecrois\u00e9es qui couvrent l'ensemble du corps. L'ensemble inclut des gants, des bottes en cuir \u00e9pais, un casque \u00e0 visi\u00e8re, et d'\u00e9paisses couches de rembourrage sous l'armure. Des boucles et des sangles distribuent le poids sur le corps."
+          "description": "Le harnois est constitué de plaques de métal entrecroisées qui couvrent l'ensemble du corps. L'ensemble inclut des gants, des bottes en cuir épais, un casque à visière, et d'épaisses couches de rembourrage sous l'armure. Des boucles et des sangles distribuent le poids sur le corps."
         }
       },
       "rarity": "none",
@@ -1180,8 +1195,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "B\u00e2ton",
-          "description": "Un \u00e9pais manche en bois envelopp\u00e9 d'une solide poign\u00e9e fait une arme tr\u00e8s fonctionnelle en plus d'un solide b\u00e2ton de marche."
+          "name": "Bâton",
+          "description": "Un épais manche en bois enveloppé d'une solide poignée fait une arme très fonctionnelle en plus d'un solide bâton de marche."
         }
       },
       "rarity": "none",
@@ -1212,8 +1227,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Rapi\u00e8re",
-          "description": "Une lame m\u00e9tallique mince et r\u00e9sistante, l\u00e9g\u00e8re mais de longue port\u00e9e, con\u00e7ue pour des attaques rapides afin de cibler les points faibles des d\u00e9fenses ennemies avec une rapidit\u00e9 fulgurante."
+          "name": "Rapière",
+          "description": "Une lame métallique mince et résistante, légère mais de longue portée, conçue pour des attaques rapides afin de cibler les points faibles des défenses ennemies avec une rapidité fulgurante."
         }
       },
       "rarity": "none",
@@ -1240,6 +1255,9 @@
     ],
     "type": "weapon"
   },
+  null,
+  null,
+  null,
   {
     "meta": {
       "translations": {
@@ -1269,7 +1287,7 @@
       "translations": {
         "fr": {
           "name": "Sceptre",
-          "description": "Une tige d'os, de pierre, de m\u00e9tal ou de mat\u00e9riaux plus exotiques, taill\u00e9e ou fa\u00e7onn\u00e9e de fa\u00e7on complexe. Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+          "description": "Une tige d'os, de pierre, de métal ou de matériaux plus exotiques, taillée ou façonnée de façon complexe. Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
         }
       },
       "rarity": "none",
@@ -1291,8 +1309,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Armure d'\u00e9cailles",
-          "description": "Cette armure se compose d'une veste et de jambi\u00e8res (et parfois d\u2019une jupe s\u00e9par\u00e9e) de cuir recouvert de pi\u00e8ces de m\u00e9tal qui se chevauchent, un peu comme les \u00e9cailles d'un poisson. L'ensemble comprend \u00e9galement des gantelets."
+          "name": "Armure d'écailles",
+          "description": "Cette armure se compose d'une veste et de jambières (et parfois d’une jupe séparée) de cuir recouvert de pièces de métal qui se chevauchent, un peu comme les écailles d'un poisson. L'ensemble comprend également des gantelets."
         }
       },
       "rarity": "none",
@@ -1316,7 +1334,7 @@
       "translations": {
         "fr": {
           "name": "Cimeterre",
-          "description": "Cette lame incurv\u00e9e est large pr\u00e8s du manche mais s'arque et se r\u00e9tr\u00e9cit en une pointe."
+          "description": "Cette lame incurvée est large près du manche mais s'arque et se rétrécit en une pointe."
         }
       },
       "rarity": "none",
@@ -1349,7 +1367,7 @@
       "translations": {
         "fr": {
           "name": "Bouclier",
-          "description": "Un bouclier est fait de bois ou de m\u00e9tal et est port\u00e9 dans une main. Le fait de porter un bouclier augmente votre classe d'armure de 2. Vous ne pouvez b\u00e9n\u00e9ficier que d'un seul bouclier \u00e0 la fois."
+          "description": "Un bouclier est fait de bois ou de métal et est porté dans une main. Le fait de porter un bouclier augmente votre classe d'armure de 2. Vous ne pouvez bénéficier que d'un seul bouclier à la fois."
         }
       },
       "rarity": "none",
@@ -1371,7 +1389,7 @@
       "translations": {
         "fr": {
           "name": "Arc court",
-          "description": "Cet arc \u00e0 deux mains est un peu plus petit que la variante traditionnelle de l'arc long, ce qui le rend bien adapt\u00e9 aux attaques rapides en mouvement ou \u00e0 cheval."
+          "description": "Cet arc à deux mains est un peu plus petit que la variante traditionnelle de l'arc long, ce qui le rend bien adapté aux attaques rapides en mouvement ou à cheval."
         }
       },
       "rarity": "none",
@@ -1405,8 +1423,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "\u00c9p\u00e9e courte",
-          "description": " lame de taille moyenne avec une garde crois\u00e9e ferme et un manche gain\u00e9 de cuir. Une arme qui compense en polyvalence ce qui lui manque en termes de port\u00e9e."
+          "name": "Épée courte",
+          "description": " lame de taille moyenne avec une garde croisée ferme et un manche gainé de cuir. Une arme qui compense en polyvalence ce qui lui manque en termes de portée."
         }
       },
       "rarity": "none",
@@ -1434,12 +1452,13 @@
     ],
     "type": "weapon"
   },
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Serpe",
-          "description": "Une lame en croissant mont\u00e9e sur un court manche, assez l\u00e9g\u00e8re pour \u00eatre mani\u00e9e d'une seule main afin de trancher les cultures ... ou les ennemis."
+          "description": "Une lame en croissant montée sur un court manche, assez légère pour être maniée d'une seule main afin de trancher les cultures ... ou les ennemis."
         }
       },
       "rarity": "none",
@@ -1470,7 +1489,7 @@
       "translations": {
         "fr": {
           "name": "Fronde",
-          "description": "Une lani\u00e8re de cuir flexible fix\u00e9e \u00e0 un manche en bois qui est capable de projeter des pierres ou des balles m\u00e9talliques \u00e0 une vitesse mortelle."
+          "description": "Une lanière de cuir flexible fixée à un manche en bois qui est capable de projeter des pierres ou des balles métalliques à une vitesse mortelle."
         }
       },
       "rarity": "none",
@@ -1502,7 +1521,7 @@
       "translations": {
         "fr": {
           "name": "Billes de fronde",
-          "description": "Caillou durci de pierre, d'os ou de m\u00e9tal qui peut \u00eatre lanc\u00e9 \u00e0 grande vitesse \u00e0 l'aide d'une fronde.\n**Note de Foundry: Il sera g\u00e9n\u00e9ralement impossible d'acheter une balle de fronde car elles valent moins d'une pi\u00e8ce de cuivre (5 balles = 1 cp)."
+          "description": "Caillou durci de pierre, d'os ou de métal qui peut être lancé à grande vitesse à l'aide d'une fronde.\n**Note de Foundry: Il sera généralement impossible d'acheter une balle de fronde car elles valent moins d'une pièce de cuivre (5 balles = 1 cp)."
         }
       },
       "rarity": "none",
@@ -1539,7 +1558,7 @@
       "translations": {
         "fr": {
           "name": "Lance",
-          "description": "Une pointe d'acier \u00e9tincelante au sommet d'un solide manche en bois, la lance peut \u00eatre mani\u00e9e \u00e0 une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle."
+          "description": "Une pointe d'acier étincelante au sommet d'un solide manche en bois, la lance peut être maniée à une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle."
         }
       },
       "rarity": "none",
@@ -1569,12 +1588,13 @@
     ],
     "type": "weapon"
   },
+  null,
   {
     "meta": {
       "translations": {
         "fr": {
           "name": "Clibanion",
-          "description": "Cette armure est faite d'\u00e9troites bandes verticales de m\u00e9tal rivet\u00e9es sur un support de cuir qui est port\u00e9 sur un rembourrage de tissu. Une cotte de mailles souple prot\u00e8ge les articulations."
+          "description": "Cette armure est faite d'étroites bandes verticales de métal rivetées sur un support de cuir qui est porté sur un rembourrage de tissu. Une cotte de mailles souple protège les articulations."
         }
       },
       "rarity": "none",
@@ -1600,8 +1620,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "B\u00e2ton",
-          "description": "Un b\u00e2ton noueux ou poli en bois, en os ou en mat\u00e9riaux plus exotiques comme le cristal. Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+          "name": "Bâton",
+          "description": "Un bâton noueux ou poli en bois, en os ou en matériaux plus exotiques comme le cristal. Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
         }
       },
       "rarity": "none",
@@ -1634,8 +1654,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "Armure de cuir clout\u00e9",
-          "description": "Fabriqu\u00e9 en cuir r\u00e9sistant mais souple, le cuir clout\u00e9 est renforc\u00e9 par des rivets ou des pointes serr\u00e9es."
+          "name": "Armure de cuir clouté",
+          "description": "Fabriqué en cuir résistant mais souple, le cuir clouté est renforcé par des rivets ou des pointes serrées."
         }
       },
       "rarity": "none",
@@ -1658,7 +1678,7 @@
       "translations": {
         "fr": {
           "name": "Trident",
-          "description": "Une lance \u00e0 plusieurs dents con\u00e7ue pour empaler une cible \u00e0 plusieurs endroits, en les immobilisant. Souvent utilis\u00e9e en combinaison avec un filet pour pi\u00e9ger et harceler les ennemis."
+          "description": "Une lance à plusieurs dents conçue pour empaler une cible à plusieurs endroits, en les immobilisant. Souvent utilisée en combinaison avec un filet pour piéger et harceler les ennemis."
         }
       },
       "rarity": "none",
@@ -1692,7 +1712,7 @@
       "translations": {
         "fr": {
           "name": "Baguette",
-          "description": "Un instrument d\u00e9licat \u00e0 une seule main en bois, os, cristal ou autres mat\u00e9riaux exotiques qui est couramment utilis\u00e9 comme point de mire pour aider \u00e0 la projection d'arcanes.Focaliseur arcanique. Un focaliseur arcanique est un objet sp\u00e9cial (orbe, boule de cristal, baguette, b\u00e2ton, sceptre) con\u00e7u pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+          "description": "Un instrument délicat à une seule main en bois, os, cristal ou autres matériaux exotiques qui est couramment utilisé comme point de mire pour aider à la projection d'arcanes.Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts."
         }
       },
       "rarity": "none",
@@ -1715,7 +1735,7 @@
       "translations": {
         "fr": {
           "name": "Pic de guerre",
-          "description": "Une pointe incurv\u00e9e massive mont\u00e9e \u00e0 l'arri\u00e8re d'un solide manche - con\u00e7ue pour percer les blindages avec une force mortelle."
+          "description": "Une pointe incurvée massive montée à l'arrière d'un solide manche - conçue pour percer les blindages avec une force mortelle."
         }
       },
       "rarity": "none",
@@ -1743,7 +1763,7 @@
       "translations": {
         "fr": {
           "name": "Marteau de guerre",
-          "description": "Un marteau en m\u00e9tal lourd pouvant \u00eatre mani\u00e9 d'une seule main avec un bouclier ou \u00e0 deux mains pour d\u00e9livrer des coups \u00e9crasants."
+          "description": "Un marteau en métal lourd pouvant être manié d'une seule main avec un bouclier ou à deux mains pour délivrer des coups écrasants."
         }
       },
       "rarity": "none",
@@ -1776,7 +1796,7 @@
       "translations": {
         "fr": {
           "name": "Fouet",
-          "description": "Une corde tendue fa\u00eete de cuir, de corde ou de cha\u00eene qui peut attraper des ennemis proches, les lac\u00e9rant et les harcelant \u00e0 distance."
+          "description": "Une corde tendue faîte de cuir, de corde ou de chaîne qui peut attraper des ennemis proches, les lacérant et les harcelant à distance."
         }
       },
       "rarity": "none",
@@ -1807,8 +1827,8 @@
     "meta": {
       "translations": {
         "fr": {
-          "name": "B\u00e2ton",
-          "description": "Le b\u00e2ton a \u00e9t\u00e9 sculpt\u00e9 dans bois sp\u00e9cial et grav\u00e9 de puissantes runes pour invoquer la puissance de la nature par ceux qui entendent son appel. Focaliseur druidique. Un focaliseur druidique peut \u00eatre un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois sp\u00e9cial, un b\u00e2ton pris d'un arbre vivant, ou bien encore un objet totem qui int\u00e8gre des plumes, de la fourrure, des os ou des dents d'animaux sacr\u00e9s. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts."
+          "name": "Bâton",
+          "description": "Le bâton a été sculpté dans bois spécial et gravé de puissantes runes pour invoquer la puissance de la nature par ceux qui entendent son appel. Focaliseur druidique. Un focaliseur druidique peut être un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois spécial, un bâton pris d'un arbre vivant, ou bien encore un objet totem qui intègre des plumes, de la fourrure, des os ou des dents d'animaux sacrés. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts."
         }
       },
       "rarity": "none",
@@ -1835,5 +1855,6 @@
       "V"
     ],
     "type": "weapon"
-  }
+  },
+  null
 ]

--- a/dnd5esheets/data/items-base.json
+++ b/dnd5esheets/data/items-base.json
@@ -1,5 +1,4 @@
 [
-  null,
   {
     "meta": {
       "translations": {
@@ -37,8 +36,6 @@
     "subtype": "A",
     "type": "munition"
   },
-  null,
-  null,
   {
     "meta": {
       "translations": {
@@ -376,8 +373,6 @@
     ],
     "type": "weapon"
   },
-  null,
-  null,
   {
     "meta": {
       "translations": {
@@ -724,9 +719,6 @@
     "effect": "$ac := 12 + min($dex, 2)",
     "type": "armor"
   },
-  null,
-  null,
-  null,
   {
     "meta": {
       "translations": {
@@ -793,8 +785,6 @@
     ],
     "type": "weapon"
   },
-  null,
-  null,
   {
     "meta": {
       "translations": {
@@ -888,7 +878,6 @@
     ],
     "type": "weapon"
   },
-  null,
   {
     "meta": {
       "translations": {
@@ -1020,8 +1009,6 @@
     ],
     "type": "weapon"
   },
-  null,
-  null,
   {
     "meta": {
       "translations": {
@@ -1051,7 +1038,6 @@
     "subtype": "M",
     "type": "weapon"
   },
-  null,
   {
     "meta": {
       "translations": {
@@ -1163,7 +1149,6 @@
     ],
     "type": "weapon"
   },
-  null,
   {
     "meta": {
       "translations": {
@@ -1255,9 +1240,6 @@
     ],
     "type": "weapon"
   },
-  null,
-  null,
-  null,
   {
     "meta": {
       "translations": {
@@ -1452,7 +1434,6 @@
     ],
     "type": "weapon"
   },
-  null,
   {
     "meta": {
       "translations": {
@@ -1588,7 +1569,6 @@
     ],
     "type": "weapon"
   },
-  null,
   {
     "meta": {
       "translations": {
@@ -1855,6 +1835,5 @@
       "V"
     ],
     "type": "weapon"
-  },
-  null
+  }
 ]

--- a/dnd5esheets/data/translations-items-fr.json
+++ b/dnd5esheets/data/translations-items-fr.json
@@ -1,0 +1,4038 @@
+{
+    "label": "Items (SRD - AideDD)",
+    "mapping": {
+        "weight": {
+            "path": "data.weight",
+            "converter": "weight"
+        },
+        "range": {
+            "path": "data.range",
+            "converter": "range"
+        },
+        "rarity": {
+            "path": "data.rarity",
+            "converter": "rarity"
+        },
+        "target": {
+            "path": "data.target",
+            "converter": "range"
+        }
+    },
+	"entries": [
+		{
+			"id": "Acid (vial)",
+			"name": "Acide (fiole)",
+			"description": "<p>Au prix d'une action, vous pouvez lancer le contenu de ce flacon sur une créature à 1,50 mètre ou moins de vous, ou jeter le flacon jusqu'à 6 mètres, le brisant à l'impact. Dans les deux cas, faire une attaque à distance contre une créature ou un objet, en considérant l'acide comme une arme improvisée. En cas de succès, la cible reçoit 2d6 dégâts d'acide.</p>"
+		},
+		{
+			"id": "Blowgun Needle",
+			"name": "Aiguilles de sarbacane (50)",
+			"description": "<p>Munition faite pour être tirée d'une sarbacane, à la force des poumons. Ces aiguilles sont fréquemment trempées dans du poison incapacitant ou mortel.</p>"
+		},
+		{
+			"id": "Wings of Flying",
+			"name": "Ailes de vol",
+			"description": "<div class=\"description \">Lorsque vous portez cette cape, vous pouvez utiliser une action pour prononcer son mot de commande. Cela transforme la cape en une paire d'ailes de chauve-souris ou d'oiseau sur votre dos pendant 1 heure, ou jusqu'à ce que vous répétiez le mot de commande au prix d'une action. Les ailes vous donnent une vitesse de vol de 18 mètres. Quand elles disparaissent, vous ne pouvez plus les utiliser à nouveau durant 1d12 heures.\n<br></div>"
+		},
+		{
+			"id": "Amulet",
+			"name": "Amulette",
+			"description": "Cela peut être une amulette avec un symbole représentant une divinité, ce même symbole gravé ou incrusté tel un emblème sur un bouclier, ou une toute petite boîte renfermant le fragment d'une relique sacrée. Un clerc ou paladin peut utiliser un symbole sacré comme focaliseur magique. Pour utiliser le symbole de cette manière, le lanceur doit le porter visiblement, en main ou sur un bouclier.</p>"
+		},
+		{
+			"id": "Periapt of Proof against Poison",
+			"name": "Amulette antidote",
+			"description": "Cette fine chaîne d'argent possède une gemme noire joliment taillée. Lorsque vous la portez, les poisons n'ont aucun effet sur vous. Vous êtes immunisé contre l'état empoisonné et contre les dégâts de poison."
+		},
+		{
+			"id": "Amulet of Proof against Detection and Location",
+			"name": "Amulette d'anti-détection",
+			"description": "Lorsque vous portez cette amulette, vous êtes protégé contre la divination magique. Vous ne pouvez pas être ciblé par une telle magie ou perçu par des capteurs de divination magique."
+		},
+		{
+			"id": "Periapt of Health",
+			"name": "Amulette de bonne santé",
+			"description": "<div class=\"description \">Vous êtes immunisé contre toutes les maladies tant que vous portez ce pendentif. Si vous êtes déjà infecté par une maladie, les effets de celle-ci disparaissent tant que vous portez le pendentif.\n<br></div>"
+		},
+		{
+			"id": "Periapt of Wound Closure",
+			"name": "Amulette de cicatrisation",
+			"description": "<div class=\"description \">Lorsque vous portez ce pendentif, vous vous stabilisez chaque fois que vous êtes mourant au début de votre tour. En outre, chaque fois que vous lancez un dé de vie pour regagner des points de vie, vous doublez le nombre de points de vie récupéré.\n<br></div>"
+		},
+		{
+			"id": "Amulet of Health",
+			"name": "Amulette de santé",
+			"description": "Objet merveilleux, rare (nécessite un lien) Votre Constitution passe à 19 tant que vous portez cette amulette. L'amulette n'a aucun effet sur vous si votre Constitution est de 19 ou plus sans elle."
+		},
+		{
+			"id": "Amulet of the Planes",
+			"name": "Amulette des plans",
+			"description": "Objet merveilleux, très rare (nécessite un lien) Lorsque vous portez cette amulette, vous pouvez utiliser une action pour nommer un lieu qui vous est familier sur un autre plan d'existence. Ensuite, faites un jet d'Intelligence DD 15. En cas de réussite, vous lancez le sort changement de plan. En cas d'échec, vous et toute créature ou objet dans un rayon de 4,50 m voyagez vers une destination aléatoire. Lancez un d100. Sur 1-60, vous voyagez à un endroit aléatoire sur le plan que vous avez nommé. Sur 61-100, vous voyagez dans un plan d'existence déterminé au hasard."
+		},
+		{
+			"id": "Ring of Free Action",
+			"name": "Anneau d'action libre",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, les terrains difficiles ne vous coûtent pas de déplacement supplémentaire. De plus, aucune magie ne peut réduire votre vitesse de déplacement ni vous paralyser ou vous entraver.\n<br></div>"
+		},
+		{
+			"id": "Ring of Evasion",
+			"name": "Anneau d'évasion",
+			"description": "<div class=\"description \">Cet anneau possède 3 charges, et regagne 1d3 charges dépensées chaque jour à l'aube. Lorsque vous échouez à un jet de sauvegarde de Dextérité alors que vous portez l'anneau, vous pouvez utiliser votre réaction pour dépenser 1 charge et ainsi réussir ce jet de sauvegarde.\n<br></div>"
+		},
+		{
+			"id": "Ring of Animal Influence",
+			"name": "Anneau d'influence sur les animaux",
+			"description": "<div class=\"description \">Cet anneau possède 3 charges, et il récupère 1d3 charges dépensées chaque jour au lever du soleil. Tant que vous êtes équipé de cet anneau, vous pouvez utiliser une action pour dépenser 1 de ses charges pour lancer l'un des sorts suivants :\n<br>• <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=amitie-avec-les-animaux\">Amitié avec les animaux</a></em> (sauvegarde DD 13)\n<br>• <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=peur\">Peur</a></em> (sauvegarde DD 13), vous ne pouvez cibler que les bêtes qui ont une valeur d'Intelligence inférieure ou égale à 3\n<br>• <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=communication-avec-les-animaux\">Communication avec les animaux</a></em>\n<br></div>"
+		},
+		{
+			"id": "Ring of Invisibility",
+			"name": "Anneau d'invisibilité",
+			"description": "<div class=\"description \">Lorsque vous portez cet anneau, vous pouvez devenir invisible par une action. Tout ce que vous portez ou transportez devient invisible avec vous. Vous restez invisible jusqu'à ce que l'anneau soit retiré, jusqu'à ce que vous attaquiez ou lanciez un sort, ou jusqu'à ce que vous utilisiez une action bonus pour redevenir visible.\n<br></div>"
+		},
+		{
+			"id": "Ring of Warmth",
+			"name": "Anneau de chaleur",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, vous avez la résistance aux dégâts de froid. De plus, vous et tout ce que vous portez et transportez êtes insensibles aux effets des basses températures, jusqu'à un négatif maximum de -45°C.\n<br></div>"
+		},
+		{
+			"id": "Ring of Air Elemental Command",
+			"name": "Anneau de contrôle de l'air élémentaire",
+			"description": "<div class=\"description \">Cet anneau est relié à l'un des quatre plans Élémentaires. Le MD choisit ou détermine de manière aléatoire le plan en question.\n<br>Tant que vous êtes équipé de cet anneau, vous avez un avantage aux jets d'attaque effectués contre les élémentaires provenant du plan lié à l'anneau, tandis qu'eux ont un désavantage à leurs jets d'attaque effectués contre vous. De plus, vous avez accès à des capacités en relation avec le plan lié à l'anneau.\n<br>L'anneau possède 5 charges. Il récupère 1d4 + 1 charges dépensées chaque jour au lever du soleil. Les sorts lancés depuis l'anneau ont un DD de 17.\n<br><strong>Anneau de contrôle de l'Air Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'air. De plus, lorsque vous tombez, vous descendez à une vitesse de 18 mètres par tour et ne subissez aucun dégât de chute. Vous pouvez également parler et comprendre l'aérien.\n<br>Si vous aider à tuer un élémentaire de l'air alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts de foudre.\n<br>• Vous avez une vitesse de vol égale à votre vitesse de déplacement et pouvez faire un vol stationnaire.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=chaine-d-eclairs\">chaîne d'éclairs</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=bourrasque\">bourrasque</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-vent\">mur de vent</a></em> (1 charge).\n<br><strong>Anneau de contrôle de la Terre Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de la terre. De plus, vous pouvez vous déplacer sur des terrains difficiles composés de gravats, de rochers, ou de boue comme si c'étaient des terrains normaux. Vous pouvez également parler et comprendre le terreux.\n<br>Si vous aider à tuer un élémentaire de la terre alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts d'acide.\n<br>• Vous pouvez vous déplacer au travers de la terre ou de roches solides comme si ces zones étaient des terrains difficiles. Si vous y terminez votre tour, vous êtes expulsé sur l'espace inoccupé le plus proche que celui que vous occupiez.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=faconnage-de-la-pierre\">façonnage de la pierre</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=peau-de-pierre\">peau de pierre</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-pierre\">mur de pierre</a></em> (3 charges).\n<br><strong>Anneau de contrôle du Feu Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire du feu. De plus, vous avez la résistance aux dégâts de feu. Vous pouvez également parler et comprendre l'igné.\n<br>Si vous aider à tuer un élémentaire du feu alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous êtes immunisé aux dégâts de feu.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mains-brulantes\">mains brûlantes</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (3 charges).\n<br><strong>Anneau de contrôle de l'Eau Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'eau. De plus, vous pouvez vous déplacer et rester sur les surfaces liquides comme si vous étiez sur la terre ferme. Vous pouvez également parler et comprendre l'aquatique.\n<br>Si vous aider à tuer un élémentaire de l'eau alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous pouvez respirer sous l'eau et vous obtenez une vitesse de nage égale à votre vitesse de marche.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=creation-ou-destruction-d-eau\">création ou destruction d'eau</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=controle-de-l-eau\">contrôle de l'eau</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tempete-de-grele\">tempête de grêle</a></em> (2 charges), <em>mur de glace</em> (3 charge).\n<br></div>"
+		},
+		{
+			"id": "Ring of Water Elemental Command",
+			"name": "Anneau de contrôle de l'eau élémentaire",
+			"description": "<div class=\"description \">Cet anneau est relié à l'un des quatre plans Élémentaires. Le MD choisit ou détermine de manière aléatoire le plan en question.\n<br>Tant que vous êtes équipé de cet anneau, vous avez un avantage aux jets d'attaque effectués contre les élémentaires provenant du plan lié à l'anneau, tandis qu'eux ont un désavantage à leurs jets d'attaque effectués contre vous. De plus, vous avez accès à des capacités en relation avec le plan lié à l'anneau.\n<br>L'anneau possède 5 charges. Il récupère 1d4 + 1 charges dépensées chaque jour au lever du soleil. Les sorts lancés depuis l'anneau ont un DD de 17.\n<br><strong>Anneau de contrôle de l'Air Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'air. De plus, lorsque vous tombez, vous descendez à une vitesse de 18 mètres par tour et ne subissez aucun dégât de chute. Vous pouvez également parler et comprendre l'aérien.\n<br>Si vous aider à tuer un élémentaire de l'air alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts de foudre.\n<br>• Vous avez une vitesse de vol égale à votre vitesse de déplacement et pouvez faire un vol stationnaire.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=chaine-d-eclairs\">chaîne d'éclairs</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=bourrasque\">bourrasque</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-vent\">mur de vent</a></em> (1 charge).\n<br><strong>Anneau de contrôle de la Terre Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de la terre. De plus, vous pouvez vous déplacer sur des terrains difficiles composés de gravats, de rochers, ou de boue comme si c'étaient des terrains normaux. Vous pouvez également parler et comprendre le terreux.\n<br>Si vous aider à tuer un élémentaire de la terre alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts d'acide.\n<br>• Vous pouvez vous déplacer au travers de la terre ou de roches solides comme si ces zones étaient des terrains difficiles. Si vous y terminez votre tour, vous êtes expulsé sur l'espace inoccupé le plus proche que celui que vous occupiez.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=faconnage-de-la-pierre\">façonnage de la pierre</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=peau-de-pierre\">peau de pierre</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-pierre\">mur de pierre</a></em> (3 charges).\n<br><strong>Anneau de contrôle du Feu Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire du feu. De plus, vous avez la résistance aux dégâts de feu. Vous pouvez également parler et comprendre l'igné.\n<br>Si vous aider à tuer un élémentaire du feu alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous êtes immunisé aux dégâts de feu.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mains-brulantes\">mains brûlantes</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (3 charges).\n<br><strong>Anneau de contrôle de l'Eau Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'eau. De plus, vous pouvez vous déplacer et rester sur les surfaces liquides comme si vous étiez sur la terre ferme. Vous pouvez également parler et comprendre l'aquatique.\n<br>Si vous aider à tuer un élémentaire de l'eau alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous pouvez respirer sous l'eau et vous obtenez une vitesse de nage égale à votre vitesse de marche.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=creation-ou-destruction-d-eau\">création ou destruction d'eau</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=controle-de-l-eau\">contrôle de l'eau</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tempete-de-grele\">tempête de grêle</a></em> (2 charges), <em>mur de glace</em> (3 charge).\n<br></div>"
+		},
+		{
+			"id": "Ring of Earth Elemental Command",
+			"name": "Anneau de contrôle de la terre élémentaire",
+			"description": "<div class=\"description \">Cet anneau est relié à l'un des quatre plans Élémentaires. Le MD choisit ou détermine de manière aléatoire le plan en question.\n<br>Tant que vous êtes équipé de cet anneau, vous avez un avantage aux jets d'attaque effectués contre les élémentaires provenant du plan lié à l'anneau, tandis qu'eux ont un désavantage à leurs jets d'attaque effectués contre vous. De plus, vous avez accès à des capacités en relation avec le plan lié à l'anneau.\n<br>L'anneau possède 5 charges. Il récupère 1d4 + 1 charges dépensées chaque jour au lever du soleil. Les sorts lancés depuis l'anneau ont un DD de 17.\n<br><strong>Anneau de contrôle de l'Air Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'air. De plus, lorsque vous tombez, vous descendez à une vitesse de 18 mètres par tour et ne subissez aucun dégât de chute. Vous pouvez également parler et comprendre l'aérien.\n<br>Si vous aider à tuer un élémentaire de l'air alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts de foudre.\n<br>• Vous avez une vitesse de vol égale à votre vitesse de déplacement et pouvez faire un vol stationnaire.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=chaine-d-eclairs\">chaîne d'éclairs</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=bourrasque\">bourrasque</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-vent\">mur de vent</a></em> (1 charge).\n<br><strong>Anneau de contrôle de la Terre Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de la terre. De plus, vous pouvez vous déplacer sur des terrains difficiles composés de gravats, de rochers, ou de boue comme si c'étaient des terrains normaux. Vous pouvez également parler et comprendre le terreux.\n<br>Si vous aider à tuer un élémentaire de la terre alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts d'acide.\n<br>• Vous pouvez vous déplacer au travers de la terre ou de roches solides comme si ces zones étaient des terrains difficiles. Si vous y terminez votre tour, vous êtes expulsé sur l'espace inoccupé le plus proche que celui que vous occupiez.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=faconnage-de-la-pierre\">façonnage de la pierre</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=peau-de-pierre\">peau de pierre</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-pierre\">mur de pierre</a></em> (3 charges).\n<br><strong>Anneau de contrôle du Feu Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire du feu. De plus, vous avez la résistance aux dégâts de feu. Vous pouvez également parler et comprendre l'igné.\n<br>Si vous aider à tuer un élémentaire du feu alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous êtes immunisé aux dégâts de feu.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mains-brulantes\">mains brûlantes</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (3 charges).\n<br><strong>Anneau de contrôle de l'Eau Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'eau. De plus, vous pouvez vous déplacer et rester sur les surfaces liquides comme si vous étiez sur la terre ferme. Vous pouvez également parler et comprendre l'aquatique.\n<br>Si vous aider à tuer un élémentaire de l'eau alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous pouvez respirer sous l'eau et vous obtenez une vitesse de nage égale à votre vitesse de marche.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=creation-ou-destruction-d-eau\">création ou destruction d'eau</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=controle-de-l-eau\">contrôle de l'eau</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tempete-de-grele\">tempête de grêle</a></em> (2 charges), <em>mur de glace</em> (3 charge).\n<br></div>"
+		},
+		{
+			"id": "Ring of Fire Elemental Command",
+			"name": "Anneau de contrôle du feu élémentaire",
+			"description": "<div class=\"description \">Cet anneau est relié à l'un des quatre plans Élémentaires. Le MD choisit ou détermine de manière aléatoire le plan en question.\n<br>Tant que vous êtes équipé de cet anneau, vous avez un avantage aux jets d'attaque effectués contre les élémentaires provenant du plan lié à l'anneau, tandis qu'eux ont un désavantage à leurs jets d'attaque effectués contre vous. De plus, vous avez accès à des capacités en relation avec le plan lié à l'anneau.\n<br>L'anneau possède 5 charges. Il récupère 1d4 + 1 charges dépensées chaque jour au lever du soleil. Les sorts lancés depuis l'anneau ont un DD de 17.\n<br><strong>Anneau de contrôle de l'Air Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'air. De plus, lorsque vous tombez, vous descendez à une vitesse de 18 mètres par tour et ne subissez aucun dégât de chute. Vous pouvez également parler et comprendre l'aérien.\n<br>Si vous aider à tuer un élémentaire de l'air alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts de foudre.\n<br>• Vous avez une vitesse de vol égale à votre vitesse de déplacement et pouvez faire un vol stationnaire.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=chaine-d-eclairs\">chaîne d'éclairs</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=bourrasque\">bourrasque</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-vent\">mur de vent</a></em> (1 charge).\n<br><strong>Anneau de contrôle de la Terre Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de la terre. De plus, vous pouvez vous déplacer sur des terrains difficiles composés de gravats, de rochers, ou de boue comme si c'étaient des terrains normaux. Vous pouvez également parler et comprendre le terreux.\n<br>Si vous aider à tuer un élémentaire de la terre alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous avez une résistance aux dégâts d'acide.\n<br>• Vous pouvez vous déplacer au travers de la terre ou de roches solides comme si ces zones étaient des terrains difficiles. Si vous y terminez votre tour, vous êtes expulsé sur l'espace inoccupé le plus proche que celui que vous occupiez.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=faconnage-de-la-pierre\">façonnage de la pierre</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=peau-de-pierre\">peau de pierre</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-pierre\">mur de pierre</a></em> (3 charges).\n<br><strong>Anneau de contrôle du Feu Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire du feu. De plus, vous avez la résistance aux dégâts de feu. Vous pouvez également parler et comprendre l'igné.\n<br>Si vous aider à tuer un élémentaire du feu alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous êtes immunisé aux dégâts de feu.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mains-brulantes\">mains brûlantes</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (3 charges).\n<br><strong>Anneau de contrôle de l'Eau Élémentaire</strong>. Vous pouvez dépenser 2 des charges de l'anneau pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-de-monstre\">domination de monstre</a></em> sur un élémentaire de l'eau. De plus, vous pouvez vous déplacer et rester sur les surfaces liquides comme si vous étiez sur la terre ferme. Vous pouvez également parler et comprendre l'aquatique.\n<br>Si vous aider à tuer un élémentaire de l'eau alors que vous êtes lié à cet anneau, vous gagnez accès aux propriétés suivantes :\n<br>• Vous pouvez respirer sous l'eau et vous obtenez une vitesse de nage égale à votre vitesse de marche.\n<br>• Vous pouvez lancer les sorts suivants depuis l'anneau, en dépensant le nombre de charges nécessaire : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=creation-ou-destruction-d-eau\">création ou destruction d'eau</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=controle-de-l-eau\">contrôle de l'eau</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tempete-de-grele\">tempête de grêle</a></em> (2 charges), <em>mur de glace</em> (3 charge).\n<br></div>"
+		},
+		{
+			"id": "Ring of Djinni Summoning",
+			"name": "Anneau de convocation de djinn",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, vous pouvez prononcer son mot de commande en utilisant une action pour invoquer un djinn particulier depuis le plan élémentaire de l'Air. Le djinn apparaît dans un espace inoccupé de votre choix dans un rayon de 36 mètres autour de vous. Il reste aussi longtemps que vous vous concentrez (comme lorsque vous vous concentrez sur un sort), pour une durée maximale de 1 heure, ou jusqu'à ce que ses points de vie tombent à 0. Puis il retourne dans son plan natif.\n<br>Tant qu'il est invoqué, le djinn a une attitude amicale envers vous et vos compagnons. Il obéit aux ordres que vous lui donnez, quelle que soit la langue utilisée. Si vous ne lui donnez aucun ordre, le djinn se défend lui-même contre les attaquants mais n'entreprend aucune autre action.\n<br>Après son départ, le djinn ne peut être réinvoqué pendant 24 heures, et l'anneau devient un simple anneau non magique si le djinn meurt.\n<br></div>"
+		},
+		{
+			"id": "Ring of Shooting Stars",
+			"name": "Anneau de feu d'étoiles",
+			"description": "<div class=\"description \">Lorsque vous portez cette bague dans une zone de lumière faible ou de ténèbres, vous pouvez jeter <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lumieres-dansantes\">lumières dansantes</a></em> et <em>lumière</em> depuis l'anneau à volonté. Lancer un de ces deux sorts depuis l'anneau nécessite une action.\n<br>L'anneau a 6 charges pour les propriétés suivantes. L'anneau regagne 1d6 charges dépensées chaque jour à l'aube.\n<br><strong>Lucioles</strong>. Vous pouvez dépenser 1 charge par une action pour lancer <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lueurs-feeriques\">lueurs féeriques</a></em> depuis l'anneau.\n<br><strong>Boule de foudre</strong>. Vous pouvez dépenser 2 charges par une action pour créer de une à quatre sphères de foudre de 1 mètre de diamètre. Plus vous créez de sphères, moins elles seront puissantes individuellement.\n<br>Chaque sphère apparaît dans un espace inoccupé que vous pouvez voir dans un rayon de 36 mètres autour de vous. Les sphères persistent aussi longtemps que vous vous concentrez (comme pour se concentrer sur un sort), jusqu'à 1 minute. Chaque sphère émet en lumière faible dans un rayon de 9 mètres.\n<br>Par une action bonus, vous pouvez déplacer chaque sphère de 9 mètres, mais pas à plus de 36 mètres de vous. Quand une créature autre que vous est à 1,50 m ou moins d'une sphère, la sphère décharge de la foudre sur cette créature et disparaît. Cette créature doit alors faire un jet de sauvegarde de Dextérité DD 15. En cas d'échec, la créature subit des dégâts de foudre dont le montant dépend du nombre de sphères que vous avez créés.\n<br><table><tbody><tr><th>Sphères</th><th>Dégâts de foudre</th></tr><tr><td class=\"center\">4</td><td class=\"center\">2d4</td></tr><tr><td class=\"center\">3</td><td class=\"center\">2d6</td></tr><tr><td class=\"center\">2</td><td class=\"center\">5d4</td></tr><tr><td class=\"center\">1</td><td class=\"center\">4d12</td></tr></tbody></table>\n<br><strong>Feu d'étoiles</strong>. Vous pouvez dépenser de 1 à 3 charges par une action. Pour chaque charge dépensée, vous lancez un trait brillant de lumière depuis l'anneau vers un point que vous pouvez voir dans un rayon de 18 mètres autour de vous. Chaque créature dans un cube de 4,50 mètres de côté depuis ce point est constellé d'étincelles et doit faire un jet de sauvegarde de Dextérité DD 15, subissant 5d4 dégâts de feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Ring of Feather Falling",
+			"name": "Anneau de feuille morte",
+			"description": "<div class=\"description \">Si vous tombez alors que vous portez cet anneau, vous descendez de 18 mètres par round et ne prenez aucun dégât de chute.\n<br></div>"
+		},
+		{
+			"id": "Ring of Water Walking",
+			"name": "Anneau de marche sur l'eau",
+			"description": "<div class=\"description \">Tant que vous portez cet anneau, vous pouvez vous déplacer et rester sur les surfaces liquides comme si vous vous trouviez sur la terre ferme.\n<br></div>"
+		},
+		{
+			"id": "Ring of Swimming",
+			"name": "Anneau de nage",
+			"description": "<div class=\"description \">Vous avez une vitesse de nage de 12 mètres lorsque vous portez cet anneau.\n<br></div>"
+		},
+		{
+			"id": "Ring of Protection",
+			"name": "Anneau de protection",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +1 à la CA et aux jets de sauvegarde lorsque vous portez cet anneau.\n<br></div>"
+		},
+		{
+			"id": "Ring of Mind Shielding",
+			"name": "Anneau de protection mentale",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, vous êtes immunisé aux magies qui permettent à d'autres créatures de lire dans vos pensées, de déterminer si vous êtes en train de mentir, de connaître votre alignement ou de connaître votre type de créature. Les créatures ne peuvent communiquer avec vous par télépathie que si vous le leur permettez.\n<br>Vous pouvez utiliser une action pour rendre l'anneau invisible jusqu'à ce que vous utilisiez une autre action pour le rendre visible, jusqu'à ce que vous l'enleviez, ou jusqu'à ce que vous mourriez.\n<br>Si vous mourrez alors que vous portez l'anneau, votre âme pénètre à l'intérieur de l'anneau, à moins qu'une autre âme soit déjà à l'intérieur. Vous pouvez rester dans l'anneau ou bien partir pour l'au-delà. Aussi longtemps que votre âme se trouve dans l'anneau, vous pouvez communiquer par télépathie avec la créature qui s'en est équipée. Une personne qui s'est équipée de l'anneau ne peut empêcher cette communication télépathique.\n<br></div>"
+		},
+		{
+			"id": "Ring of Regeneration",
+			"name": "Anneau de régénération",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, vous récupérez 1d6 points de vie toutes les 10 minutes, à condition qu'il vous reste au moins 1 point de vie. Si vous perdez un membre, l'anneau fait repousser la partie manquante, qui redevient alors fonctionnelle, en 1d6 + 1 jours, à condition que vous ayez au moins 1 point de vie pendant toute cette période.\n<br></div>"
+		},
+		{
+			"id": "Ring of Spell Turning",
+			"name": "Anneau de renvoi des sorts",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, vous avez un avantage aux jets de sauvegarde contre les sorts dont vous êtes la cible unique (mais pas les sorts de zone). De plus, si vous obtenez un 20 naturel à votre jet de sauvegarde contre un sort de niveau 7 ou inférieur, le sort n'a aucun effet sur vous et cible son propre lanceur à la place, en utilisant le niveau d'emplacement de sort, le DD au jet de sauvegarde des sorts, le bonus à l'attaque du sort, et la caractéristique d'incantation de son lanceur originel.\n<br></div>"
+		},
+		{
+			"id": "Ring of Acid Resistance",
+			"name": "Anneau de résistance à l'acide",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Force Resistance",
+			"name": "Anneau de résistance à la force",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Lightning Resistance",
+			"name": "Anneau de résistance à la foudre",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Fire Resistance",
+			"name": "Anneau de résistance au feu",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Cold Resistance",
+			"name": "Anneau de résistance au froid",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Poison Resistance",
+			"name": "Anneau de résistance au poison",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Thunder Resistance",
+			"name": "Anneau de résistance du tonnerre",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Necrotic Resistance",
+			"name": "Anneau de résistance nécrotique",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Psychic Resistance",
+			"name": "Anneau de résistance psychique",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Radiant Resistance",
+			"name": "Anneau de résistance radiant",
+			"description": "<div class=\"description \">Vous obtenez la résistance à un type de dégâts tant que vous portez cet anneau. La gemme sur l'anneau indique le type, lequel est choisi par le MD ou déterminé au hasard.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th><th>Gemme</th></tr><tr><td class=\"center\">1</td><td>Acide</td><td>Perle</td></tr><tr><td class=\"center\">2</td><td>Froid</td><td>Tourmaline</td></tr><tr><td class=\"center\">3</td><td>Feu</td><td>Grenat</td></tr><tr><td class=\"center\">4</td><td>Force</td><td>Saphir</td></tr><tr><td class=\"center\">5</td><td>Foudre</td><td>Citrine</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td><td>Jais</td></tr><tr><td class=\"center\">7</td><td>Poison</td><td>Améthyste</td></tr><tr><td class=\"center\">8</td><td>Psychique</td><td>Jade</td></tr><tr><td class=\"center\">9</td><td>Radiant</td><td>Topaze</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td><td>Spinelle</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Ring of Jumping",
+			"name": "Anneau de saut",
+			"description": "<div class=\"description \">Lorsque vous portez cet anneau, vous pouvez lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=saut\">saut</a></em> depuis l'anneau par une action bonus, à volonté, mais vous ne pouvez cibler que vous-même.\n<br></div>"
+		},
+		{
+			"id": "Ring of Spell Storing",
+			"name": "Anneau de stockage de sort",
+			"description": "<div class=\"description \">Cet anneau garde les sorts qu'on lui a jetés, les conservant jusqu'à ce que l'utilisateur qui lui est lié les utilise. L'anneau peut stocker jusqu'à l'équivalent de 5 niveaux de sorts à la fois. Lorsqu'on le trouve, il contient 1d6 - 1 niveaux de sorts mémorisés, choisis par le MD.\n<br>Toute créature peut lancer un sort du niveau 1 à 5 dans l'anneau en touchant celui-ci au moment de lancer le sort. Le sort ne produit alors aucun effet, il est simplement stocké dans l'anneau. Si l'anneau ne peut pas contenir le sort, ce dernier est dépensé, sans produire d'effet. Le niveau d'emplacement utilisé pour lancer le sort détermine combien d'espace il utilise.\n<br>Lorsque vous portez cet anneau, vous pouvez jeter n'importe quel sort qu'il contient. Le sort utilise le niveau d'emplacement, le DD de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation du lanceur d'origine, mais à part cela il est traité comme si vous lanciez le sort vous-même. Le sort qui est lancé n'est alors plus stocké par l'anneau et libère l'espace.\n<br></div>"
+		},
+		{
+			"id": "Ring of Telekinesis",
+			"name": "Anneau de télékinésie",
+			"description": "<div class=\"description \">Lorsque vous portez cet anneau, vous pouvez lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=telekinesie\">télékinésie</a></em> à volonté, mais vous ne pouvez cibler que des objets qui ne sont pas portés ou transportés.\n<br></div>"
+		},
+		{
+			"id": "Ring of Three Wishes",
+			"name": "Anneau de triple souhait",
+			"description": "<div class=\"description \">Lorsque vous portez cet anneau, vous pouvez utiliser une action pour dépenser une de ses 3 charges pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> depuis l'anneau. L'anneau devient non magique lorsque vous utilisez la dernière charge.\n<br></div>"
+		},
+		{
+			"id": "Ring of X-ray Vision",
+			"name": "Anneau de vision aux rayons X",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cet anneau, vous pouvez utiliser une action pour prononcer son mot de commande. Lorsque vous le faites, vous pouvez voir à l'intérieur et au travers des matières solides pendant 1 minute. Cette vision possède un rayon de 9 mètres. Pour vous, les objets solides se trouvant dans ce rayon vous semblent transparents et n'interdisent pas à la lumière de les traverser. Cette vision peut pénétrer jusqu'à 30 centimètres de pierre, 2,50 centimètres de métal commun ou jusqu'à 90 centimètres de bois ou de terre. Des substances plus denses bloquent la vision, comme le ferait une fine feuille de plomb.\n<br>À chaque fois que vous utilisez de nouveau cet anneau avant de prendre un repos long, vous devez réussir un jet de sauvegarde de Constitution DD 15 sous peine de subir 1 niveau d'épuisement.\n<br></div>"
+		},
+		{
+			"id": "Ring of the Ram",
+			"name": "Anneau du bélier",
+			"description": "<div class=\"description \">Cet anneau possède 3 charges, et il récupère 1d3 charges dépensées chaque jour au lever du soleil. Tant que vous êtes équipé de cet anneau, vous pouvez utiliser une action pour dépenser 1 à 3 de ses charges pour attaquer une créature que vous pouvez voir et se trouvant à 18 mètres maximum de vous. L'anneau fait apparaître la tête d'un bélier fantomatique et effectue son jet d'attaque avec un bonus de +7. Si le coup touche, pour chaque charge que vous avez dépensée, la cible subit 2d10 dégâts de force et est repoussée de vous sur 1,50 mètre.\n<br>Sinon, vous pouvez dépenser 1 à 3 des charges de l'anneau en utilisant une action pour tenter de briser un objet que vous pouvez voir, se trouvant à 18 mètres de vous maximum, et qui n'est ni porté ni transporté. L'anneau effectue un jet de Force avec un bonus de +5 pour chaque charge que vous avez dépensée.\n<br></div>"
+		},
+		{
+			"id": "Antitoxin",
+			"name": "Antidote (fiole)",
+			"description": "<p>Une créature qui boit cette fiole gagne un avantage aux jets de sauvegarde contre le poison pendant 1 heure. Il ne confère aucun avantage aux morts-vivants et aux créatures artificielles.</p>"
+		},
+		{
+			"id": "Hand Crossbow",
+			"name": "Arbalète de poing",
+			"description": "<p>Une arbalète légère conçue pour être tenue dans une main ou attachée au poignet pour tirer des carreaux.</p>"
+		},
+		{
+			"id": "Hand Crossbow +1",
+			"name": "Arbalète de poing +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Hand Crossbow +2",
+			"name": "Arbalète de poing +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Hand Crossbow +3",
+			"name": "Arbalète de poing +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Light Crossbow",
+			"name": "Arbalète légère",
+			"description": "<p>Une petite arbalète avec un manche en bois et une corde tendue qui est capable de tirer un seul coup qui peut perforer même les armures lourdes à bout portant.</p>"
+		},
+		{
+			"id": "Light Crossbow +1",
+			"name": "Arbalète légère +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Light Crossbow +2",
+			"name": "Arbalète légère +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Light Crossbow +3",
+			"name": "Arbalète légère +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Light Crossbow",
+			"name": "Arbalète légère vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Heavy Crossbow",
+			"name": "Arbalète lourde",
+			"description": "<p>Une grande arbalète montée sur un solide bloc de bois qui est chargé à l'aide d'une manivelle et qui tire d'épais carreaux en acier avec une accélération mortelle qui transperce l'armure et la chair.</p>"
+		},
+		{
+			"id": "Heavy Crossbow +1",
+			"name": "Arbalète lourde +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Heavy Crossbow +2",
+			"name": "Arbalète lourde +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Heavy Crossbow +3",
+			"name": "Arbalète lourde +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Heavy Crossbow",
+			"name": "Arbalète lourde vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Vicious Hand Crossbow",
+			"name": "Arbalète vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Shortbow",
+			"name": "Arc court",
+			"description": "<p>Cet arc à deux mains est un peu plus petit que la variante traditionnelle de l'arc long, ce qui le rend bien adapté aux attaques rapides en mouvement ou à cheval.</p>"
+		},
+		{
+			"id": "Shortbow +2",
+			"name": "Arc court  +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Shortbow +1",
+			"name": "Arc court +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Shortbow +3",
+			"name": "Arc court +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Shortbow",
+			"name": "Arc court vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Oathbow",
+			"name": "Arc du serment",
+			"description": "<div class=\"description \">Quand vous encochez une flèche à la corde de cet arc, il murmure en elfique : « Prompte défaite à mes ennemis ». Lorsque vous faites une attaque à distance avec cet arc vous pouvez dire en tant que phrase de commande : « Prompte mort à ceux qui m'ont fait du tort ». La cible de votre attaque devient votre ennemi juré jusqu'à ce qu'il meure ou jusqu'à l'aube sept jours plus tard. Vous ne pouvez avoir qu'un seul ennemi juré à la fois. Quand votre ennemi juré meurt, vous pouvez en choisir un nouveau après la prochaine aube.\n<br>Lorsque vous effectuez une attaque à distance contre votre ennemi juré avec cette arme, vous avez un avantage au jet d'attaque. De plus, votre cible ne bénéficie d'aucun abri s'il n'est pas total, et vous ne souffrez pas de désavantage dû aux tirs à longue portée. Si l'attaque touche, votre ennemi juré subit 3d6 dégâts perforants supplémentaires.\n<br>Tant que votre ennemi juré est en vie, vous avez un désavantage aux jets d'attaque avec toutes les autres armes.\n<br></div>"
+		},
+		{
+			"id": "Longbow",
+			"name": "Arc long",
+			"description": "<p>Un épais morceau de bois lamellé est courbé par une corde tendue capable de lancer des flèches mortelles à longue distance.</p>"
+		},
+		{
+			"id": "Longbow +1",
+			"name": "Arc long +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Longbow +2",
+			"name": "Arc long +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Longbow +3",
+			"name": "Arc long +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Longbow",
+			"name": "Arc long vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Scale Mail",
+			"name": "Armure d'écailles",
+			"description": "<p>Cette armure se compose d'une veste et de jambières (et parfois d’une jupe séparée) de cuir recouvert de pièces de métal qui se chevauchent, un peu comme les écailles d'un poisson. L'ensemble comprend également des gantelets.</p>"
+		},
+		{
+			"id": "Scale Mail +1",
+			"name": "Armure d'écailles +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Scale Mail +2",
+			"name": "Armure d'écailles +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Scale Mail +3",
+			"name": "Armure d'écailles +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Dragon Scale Mail",
+			"name": "Armure d'écailles de dragon",
+			"description": "<div class=\"description \">Une armure d'écailles de dragon est fabriquée à partir des écailles d'une sorte de dragon. Parfois les dragons récoltent les écailles qu'ils ont perdues et les offrent aux humanoïdes. Dans d'autres cas, des chasseurs écorchent avec soin et préservent la peau écailleuse des dragons morts. Quoi qu'il en soit, une armure d'écailles de dragon est un objet très précieux et très apprécié.\n<br>Tant que vous portez cette armure, vous bonus un bonus de +1 à la Classe d'Armure, vous avez un avantage à vos jets de sauvegarde contre la Présence terrifiante et les souffles des dragons, et vous avez la résistance à un type de dégâts déterminé par le type de dragon dont proviennent les écailles (voir la table ci-dessous).\n<br>De plus, vous pouvez concentrer vos sens, en utilisant une action, pour déterminer magiquement la distance et la direction du dragon (de même type que votre armure) le plus proche de vous et situé à 45 kilomètres maximum. Cette action spéciale ne peut pas être réutilisée avant le prochain lever de soleil.\n<br><table><tbody><tr><th>Dragon</th><th>Résistance</th></tr><tr><td>Blanc</td><td>Froid</td></tr><tr><td>Bleu</td><td>Foudre</td></tr><tr><td>Noir</td><td>Acide</td></tr><tr><td>Rouge</td><td>Feu</td></tr><tr><td>Vert</td><td>Poison</td></tr><tr><td>Airain</td><td>Feu</td></tr><tr><td>Argent</td><td>Froid</td></tr><tr><td>Bronze</td><td>Foudre</td></tr><tr><td>Cuivre</td><td>Acide</td></tr><tr><td>Or</td><td>Feu</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Scale Mail Armor of Resistance",
+			"name": "Armure d'écailles de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Adamantine Scale Mail",
+			"name": "Armure d'écailles en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Armor of Invulnerability",
+			"name": "Armure d'invulnérabilité",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous avez une résistance contre tous les dégâts non magiques tant que vous portez cette armure. De plus, vous pouvez utiliser une action pour vous immuniser aux dégâts non magiques pendant 10 minutes ou jusqu'à ce que vous ne portiez plus cette armure. Une fois que cette action spéciale est utilisée, elle ne peut être utilisée de nouveau avant le prochain lever du soleil.</p>"
+		},
+		{
+			"id": "Leather Armor",
+			"name": "Armure de cuir",
+			"description": "<p>La cuirasse et les protecteurs d'épaules de cette armure sont faits de cuir qui a été durci en étant bouilli dans de l'huile. Le reste de l'armure est fait de matériaux plus tendres et plus souples.</p>"
+		},
+		{
+			"id": "Leather Armor +1",
+			"name": "Armure de cuir +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Leather Armor +2",
+			"name": "Armure de cuir +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Leather Armor +3",
+			"name": "Armure de cuir +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Studded Leather Armor",
+			"name": "Armure de cuir clouté",
+			"description": "<p>Fabriqué en cuir résistant mais souple, le cuir clouté est renforcé par des rivets ou des pointes serrées.</p>"
+		},
+		{
+			"id": "Studded Leather Armor +1",
+			"name": "Armure de cuir clouté +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Studded Leather Armor +2",
+			"name": "Armure de cuir clouté +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Studded Leather Armor +3",
+			"name": "Armure de cuir clouté +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Studded Leather Armor of Resistance",
+			"name": "Armure de cuir clouté de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Leather Armor of Resistance",
+			"name": "Armure de cuir de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Hide Armor",
+			"name": "Armure de peaux",
+			"description": "<p>Cette armure brute est composée de fourrures et de peaux épaisses. Elle est couramment portée par les tribus barbares, les humanoïdes maléfiques, et d'autres personnes qui n'ont pas accès aux outils et matériaux nécessaires pour créer de meilleures armures.</p>"
+		},
+		{
+			"id": "Hide Armor +1",
+			"name": "Armure de peaux +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Hide Armor +2",
+			"name": "Armure de peaux +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Hide Armor +3",
+			"name": "Armure de peaux +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Hide Armor of Resistance",
+			"name": "Armure de peaux de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Armor of Vulnerability",
+			"name": "Armure de vulnérabilité",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Tant que vous portez cette armure, vous avez une résistance contre l'un des types de dégâts suivants : contondant, perforant ou tranchant. Le MD choisit le type ou le détermine aléatoirement.</p>\n<p><strong>Malédiction</strong>.&nbsp;Cette armure est maudite, un fait qui n'est révélé que lorsqu'un sort d'&nbsp;identify&nbsp; est lancé sur l'armure ou si vous vous liez à elle. Se lier à l'armure vous maudit jusqu'à ce que vous soyez ciblé par le sort &nbsp;remove curse&nbsp;ou une magie similaire; retirer l'armure ne permet pas de mettre un terme à la malédiction. Tant que vous êtes maudit, vous avez une vulnérabilité face aux deux autres types de dégâts associés à cette armure (pas celui contre lequel l'armure vous confère une résistance).</p>"
+		},
+		{
+			"id": "Half Plate Armor",
+			"name": "Armure Demi-plate",
+			"description": "<p>Cette armure est constituée de plaques métalliques façonnées qui recouvrent la majeure partie du corps. Mis à part les jambières attachées avec des lanières de cuir, elle ne protège pas les jambes.</p>"
+		},
+		{
+			"id": "Half Plate Armor +1",
+			"name": "Armure demi-plate +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Half Plate Armor +2",
+			"name": "Armure demi-plate +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Half Plate Armor +3",
+			"name": "Armure demi-plate +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Half Plate Armor of Resistance",
+			"name": "Armure demi-plate de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Demon Armor",
+			"name": "Armure démoniaque",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous gagnez un bonus de +1 à la CA, et vous pouvez comprendre et parler l'abyssal. En outre, les gantelets griffus de l'armure transforment vos coups à mains nues en armes magiques qui infligent des dégâts tranchants, avec un bonus de +1 aux jets d'attaque et de dégâts et un dé de dégâts de 1d8.\n<br><strong>Malédiction</strong>. Une fois que vous avez enfilé cette armure maudite, vous ne pouvez plus l'ôter, sauf si vous êtes la cible du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=delivrance-des-maledictions\">délivrance des malédictions</a></em> ou d'une magie similaire. Tant que vous portez l'armure, vous avez un désavantage aux jets d'attaque contre les démons et aux jets de sauvegarde contre leurs sorts et leurs capacités spéciales.\n<br></div>"
+		},
+		{
+			"id": "Padded Armor",
+			"name": "Armure matelassée",
+			"description": "<p>L'armure matelassée est constituée de couches de tissu et de molleton matelassés. L'armure matelassée offre un niveau de protection comparable à celui du cuir raidi mais est un peu moins encombrante pour le porteur.</p>"
+		},
+		{
+			"id": "Padded Armor +1",
+			"name": "Armure matelassée +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Padded Armor +2",
+			"name": "Armure matelassée +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Padded Armor +3",
+			"name": "Armure matelassée +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Padded Armor of Resistance",
+			"name": "Armure matelassée de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Trinket",
+			"name": "Babiole (trinket)",
+			"description": "<p>Items non-SRD introduits à la page 159, avec le tableau d100 aux pages 160-161.</p>"
+		},
+		{
+			"id": "Wand",
+			"name": "Baguette",
+			"description": "<p>Un instrument délicat à une seule main en bois, os, cristal ou autres matériaux exotiques qui est couramment utilisé comme point de mire pour aider à la projection d'arcanes.Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Wand of Lightning Bolts",
+			"name": "Baguette d'éclairs",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Si vous la tenez, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=eclair\">éclair</a></em> (sauvegarde DD 15). Avec 1 charge, vous lancez la version de niveau 3 du sort. Vous pouvez augmenter le niveau de l'emplacement de sort de un pour chaque charge supplémentaire que vous dépensez.\n<br>La baguette regagne 1d6 + 1 charges chaque jour à aube. Lorsque vous dépensez la dernière charge, lancez 1d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Binding",
+			"name": "Baguette d'entraves",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges pour les propriétés suivantes. Elle regagne 1d6 + 1 charges chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez 1d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br><strong>Sorts</strong>. Lorsque vous tenez la baguette, vous pouvez utiliser une action pour dépenser des charges et lancer l'un des sorts suivants (sauvegarde DD 17) : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=immobilisation-de-monstre\">immobilisation de monstre</a></em> (5 charges) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=immobilisation-de-personne\">immobilisation de personne</a></em> (2 charges).\n<br><strong>Échappatoire</strong>. Lorsque vous tenez la baguette, vous pouvez utiliser votre réaction pour dépenser 1 charge et obtenir un avantage à un jet de sauvegarde pour éviter d'être paralysé ou entravé, ou dépenser 1 charge pour avoir un avantage à un jet pour s'échapper d'une situation de lutte.\n<br></div>"
+		},
+		{
+			"id": "Yew Wand",
+			"name": "Baguette d'if",
+			"description": "<p>La baguette a été sculptée dans de l'if ou un autre bois spécial et gravé de puissantes runes pour invoquer la puissance de la nature par ceux qui entendent son appel. Focaliseur druidique. Un focaliseur druidique peut être un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois spécial, un bâton pris d'un arbre vivant, ou bien encore un objet totem qui intègre des plumes, de la fourrure, des os ou des dents d'animaux sacrés. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Wand of Fireballs",
+			"name": "Baguette de boules de feu",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Si vous la tenez, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (sauvegarde DD 15). Avec 1 charge, vous lancez la version de niveau 3 du sort. Vous pouvez augmenter le niveau de l'emplacement de sort de un pour chaque charge supplémentaire que vous dépensez.\n<br>La baguette regagne 1d6 + 1 charges chaque jour à aube. Lorsque vous dépensez la dernière charge, lancez 1d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Enemy Detection",
+			"name": "Baguette de détection de l'ennemi",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Lorsque vous la tenez, vous pouvez utiliser une action pour dépenser 1 charge et prononcer son mot de commande. Pendant 1 minute, vous connaissez la direction de la créature hostile la plus proche de vous dans un rayon de 18 mètres, mais pas sa distance. La baguette détecte la présence de créatures hostiles cachées, invisibles, éthérées ou déguisées, de même que celles en pleine vue. L'effet cesse si vous ne tenez plus la baguette.\n<br>La baguette regagne 1d6 + 1 charges chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez 1d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Magic Detection",
+			"name": "Baguette de détection de la magie",
+			"description": "<div class=\"description \">Cette baguette possède 3 charges. Tant que vous tenez cette baguette, vous pouvez dépenser 1 charge au prix d'une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-de-la-magie\">détection de la magie</a></em> depuis la baguette. La baguette regagne 1d3 charges dépensées chaque jour à l'aube.\n<br></div>"
+		},
+		{
+			"id": "Wand of Polymorph",
+			"name": "Baguette de métamorphose",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Si vous la tenez, vous pouvez utiliser une action pour dépenser 1 de ses charges et jeter le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=metamorphose\">métamorphose</a></em> (sauvegarde DD 15).\n<br>La baguette récupère 1d6 + 1 charges dépensées chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez un d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Paralysis",
+			"name": "Baguette de paralysie",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Si vous la tenez, vous pouvez utiliser une action pour dépenser 1 de ses charges et lancer un fin rayon bleu du bout de la baguette vers une créature que vous pouvez voir à 18 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Constitution DD 15 ou être paralysée pour 1 minute. À la fin de chacun de ses tours, la cible peut faire refaire un jet de sauvegarde, mettant fin à l'effet pour elle-même en cas de réussite.\n<br>La baguette récupère 1d6 + 1 charges dépensées chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez un d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Fear",
+			"name": "Baguette de peur",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges pour les propriétés suivantes. Elle regagne 1d6 + 1 charges dépensées tous les jours à l'aube. Lorsque vous dépensez la dernière charge de la baguette, lancez un d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br><strong>Injonction</strong>. Si vous tenez la baguette, vous pouvez utiliser une action pour dépenser 1 charge et ordonner à une autre créature de fuir ou de se mettre à plat ventre, comme avec le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=injonction\">injonction</a></em> (sauvegarde DD 15).\n<br><strong>Cône de peur</strong>. Tout en tenant la baguette, vous pouvez utiliser une action pour dépenser 2 charges afin que la pointe de la baguette émette un cône de 18 mètres de lumière orange. Toute créature dans le cône doit réussir un jet de sauvegarde de Sagesse DD 15 ou vous l'effrayez durant 1 minute. Tant qu'elle est effrayée de cette façon, une créature doit passer ses tours à essayer de se déplacer aussi loin que possible de vous, et elle ne peut pas se déplacer volontairement dans un espace à 9 mètres ou moins de vous. elle ne peut également pas prendre de réaction. Pour son action, elle ne peut qu'utiliser l'action Foncer ou essayer de d'échapper d'un effet qui l'empêche de bouger. Si elle n'a nulle part où aller, la créature peut utiliser l'action Esquiver. À la fin de chacun de ses tours, une créature peut rejeter le jet de sauvegarde, mettant fin à l'effet en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Magic Missiles",
+			"name": "Baguette de projectiles magiques",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Tant que vous la tenez, vous pouvez utiliser une action pour dépenser de 1 ou plus de ses charges pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=projectile-magique\">projectile magique</a></em> depuis la baguette. Pour 1 charge, vous lancez le sort comme si vous utilisiez un emplacement de sort de niveau 1, et vous augmentez le niveau d'emplacement de sort de un pour chaque charge additionnelle dépensée.\n<br>La baguette récupère 1d6 + 1 charges dépensées chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez un d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Web",
+			"name": "Baguette de toile d'araignée",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Si vous la tenez, vous pouvez utiliser une action pour dépenser 1 de ses charges et jeter le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=toile-d-araignee\">toile d'araignée</a></em> (sauvegarde DD 15).\n<br>La baguette récupère 1d6 + 1 charges dépensées chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez un d20. Sur un 1, la baguette tombe en cendres et est détruite.\n<br></div>"
+		},
+		{
+			"id": "Wand of Secrets",
+			"name": "Baguette des secrets",
+			"description": "<div class=\"description \">Cette baguette possède 3 charges. Si vous la tenez, vous pouvez utiliser une action pour dépenser 1 de ses charges et si un piège ou une porte secrète se trouve dans un rayon de 9 mètres autour de vous, la baguette tremble et pointe vers le plus proche de vous. La baguette récupère 1d3 charges dépensées chaque jour à l'aube.\n<br></div>"
+		},
+		{
+			"id": "Wand of the War Mage +1",
+			"name": "Baguette du mage de guerre +1",
+			"description": "<div class=\"description \">Lorsque vous tenez cette baguette, vous gagnez un bonus aux jets d'attaque des sorts. Le bonus est déterminé par la rareté de la baguette. En outre, vous ignorez les abris partiels lorsque vous effectuez une attaque avec un sort.\n<br></div>"
+		},
+		{
+			"id": "Wand of the War Mage +2",
+			"name": "Baguette du mage de guerre +2",
+			"description": "<div class=\"description \">Lorsque vous tenez cette baguette, vous gagnez un bonus aux jets d'attaque des sorts. Le bonus est déterminé par la rareté de la baguette. En outre, vous ignorez les abris partiels lorsque vous effectuez une attaque avec un sort.\n<br></div>"
+		},
+		{
+			"id": "Wand of the War Mage +3",
+			"name": "Baguette du mage de guerre +3",
+			"description": "<div class=\"description \">Lorsque vous tenez cette baguette, vous gagnez un bonus aux jets d'attaque des sorts. Le bonus est déterminé par la rareté de la baguette. En outre, vous ignorez les abris partiels lorsque vous effectuez une attaque avec un sort.\n<br></div>"
+		},
+		{
+			"id": "Wand of Wonder",
+			"name": "Baguette merveilleuse",
+			"description": "<div class=\"description \">Cette baguette possède 7 charges. Tant que vous la portez, vous pouvez utiliser une action pour dépenser 1 de ses charges et choisir une cible se trouvant à 36 mètres de vous. La cible peut être une créature, un objet, ou un point dans l'espace. Lancez un d100 et consultez la table qui suit pour découvrir ce qui survient.\n<br>Si l'effet produit vous fait lancer un sort depuis la baguette, le DD du jet de sauvegarde du sort est de 15. Si le sort possède normalement une portée exprimée en mètres, sa portée passe à 36 mètres si ce n'est pas déjà le cas.\n<br>Si un effet couvre une zone, vous devez centrer le sort sur la cible et l'inclure dans la zone d'effet. Si un effet est à cibles multiples, le MD détermine aléatoirement quelles sont celles qui sont affectées.\n<br>La baguette récupère 1d6 + 1 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge de la baguette, lancez 1d20. Sur un 1, la baguette tombe en poussière et est détruite.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Effet</th></tr><tr><td class=\"center\">01-05</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lenteur\">lenteur</a></em>.</td></tr><tr><td class=\"center\">06-10</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lueurs-feeriques\">lueurs féeriques</a></em>.</td></tr><tr><td class=\"center\">11-15</td><td>Vous êtes étourdi jusqu'au début de votre prochain tour, persuadé que quelque chose d'incroyable vient tout juste de se produire.</td></tr><tr><td class=\"center\">16-20</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=bourrasque\">bourrasque</a></em>.</td></tr><tr><td class=\"center\">21-25</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> sur la cible que vous avez choisie. Si vous n'avez pas ciblé de créature, vous subissez à la place 1d6 dégâts psychiques.</td></tr><tr><td class=\"center\">26-30</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=nuage-puant\">nuage puant</a></em>.</td></tr><tr><td class=\"center\">31-33</td><td>Une pluie battante tombe dans un rayon de 18 mètres centré sur la cible. La zone devient légèrement obscurcie. La pluie tombe jusqu'au début de votre prochain tour.</td></tr><tr><td class=\"center\">34-36</td><td>Un animal apparaît dans l'espace inoccupé le plus proche de la cible. L'animal n'est pas sous votre contrôle et agit comme il devrait le faire normalement. Lancez 1d100 pour déterminer quel animal apparaît. Sur un résultat de 01-25, un rhinocéros apparaît ; sur un résultat de 26-50, un éléphant apparaît ; sur un résultat de 51-100, un rat apparaît.</td></tr><tr><td class=\"center\">37-46</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=eclair\">éclair</a></em>.</td></tr><tr><td class=\"center\">47-49</td><td>Un nuage de 600 énormes papillons remplit une zone de 9 mètres de rayon centré sur la cible. La zone devient fortement obscurcie. Les papillons restent en place pendant 10 minutes.\n<br></td></tr><tr><td class=\"center\">50-53</td><td>Vous augmentez la taille de la cible de la même manière que si vous aviez lancé le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=agrandissement-rapetissement\">agrandissement/rapetissement</a></em>. Si la cible ne peut pas être affectée par ce sort, ou si vous n'avez pas ciblé de créature, vous devenez la cible de ce sort.</td></tr><tr><td class=\"center\">54-58</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tenebres\">ténèbres</a></em>.</td></tr><tr><td class=\"center\">59-62</td><td>De l'herbe pousse sur le sol dans un rayon de 18 mètres centré sur la cible. Si de l'herbe se trouve déjà dans la zone, elle pousse jusqu'à atteindre 10 fois sa taille normale et reste ainsi surdéveloppée pendant 1 minute.</td></tr><tr><td class=\"center\">63-65</td><td>Un objet du choix du MD disparaît dans le plan éthéré. L'objet ne doit ni être porté ni être transporté, se trouver dans un rayon de 36 mètres autour de la cible, et ne pas être plus large qu'un cube de 3 mètres d'arête.</td></tr><tr><td class=\"center\">66-69</td><td>Vous êtes rétréci comme si vous aviez lancé sur vous le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=agrandissement-rapetissement\">agrandissement/rapetissement</a></em>.</td></tr><tr><td class=\"center\">70-79</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em>.</td></tr><tr><td class=\"center\">80-84</td><td>Vous lancez le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invisibilite\">invisibilité</a></em> sur vous-même.</td></tr><tr><td class=\"center\">85-87</td><td>Des feuilles se mettent à pousser sur la cible. Si vous avez choisi un point de l'espace comme cible, les feuilles apparaissent sur la créature la plus proche de ce point. À moins qu'elles ne soient enlevées, les feuilles brunissent et tombent d'elles-mêmes au bout de 24 heures.</td></tr><tr><td class=\"center\">88-90</td><td>Un chapelet de 1d4 x 10 gemmes, chacune valant 1 po, jaillit de l'extrémité de la baguette en une ligne de 9 mètres de long et de 1,50 mètre de large. Chaque gemme infligeant 1 dégât contondant, et le total des dégâts infligés par les gemmes est divisé équitablement entre toutes les créatures présentes sur la ligne.</td></tr><tr><td class=\"center\">91-95</td><td>Une explosion de chatoyantes lumières colorées émane de vous sur un rayon de 9 mètres. Vous, et chacune des créatures présentent dans la zone et capables de voir, devez réussir un jet de sauvegarde de Constitution DD 15 sous peine d'être aveuglé pendant 1 minute. Une créature peut retenter son jet de sauvegarde à la fin de chacun de ses tours, mettant un terme à l'effet qui l'affecte en cas de réussite.</td></tr><tr><td class=\"center\">96-97</td><td>La teinte de la cible vire au bleu brillant pendant 1d10 jours. Si vous choisissez un point de l'espace, la créature la plus proche de ce point est affectée.</td></tr><tr><td class=\"center\">98-00</td><td>Si vous avez ciblé une créature, elle doit effectuer un jet de sauvegarde de Constitution DD 15. Si vous n'avez pas ciblé une créature, vous devenez la cible et devez effectuer le jet de sauvegarde. Si le jet de sauvegarde échoue de 5 ou plus, la cible est instantanément pétrifiée. Sur tout autre échec au jet de sauvegarde, la cible est entravée et commence à se changer en pierre. Tant qu'elle est entravée de la sorte, la cible doit répéter le jet de sauvegarde à la fin de son prochain tour, devenant pétrifiée en cas d'échec ou mettant un terme à l'effet en cas de réussite. La pétrification perdure jusqu'à ce que la cible soit libérée par un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=restauration-superieure\">restauration supérieure</a></em> ou une magie similaire.</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Broom of Flying",
+			"name": "Balai volant",
+			"description": "<div class=\"description \">Ce balai de bois pèse 1,5 kg et ressemble à un balai normal jusqu'à ce que vous l'enfourchiez à califourchon et prononciez son mot de commande. Il se met alors à planer et peut être chevauché dans les airs. Sa vitesse de vol est de 15 mètres. Il peut porter 200 kg, mais s'il en transporte plus de 100, sa vitesse est limitée à 9 mètres. Le balai cesse de planer une fois que vous atterrissez.\n<br>Vous pouvez ordonner au balai de voyager seul vers une destination qui vous est familière et distante de 1,5 kilomètre ou moins en prononçant le mot de commande et en nommant le lieu. Tant que le balai est à 1,5 kilomètre ou moins de vous, vous pouvez le rappeler à vous en prononçant un autre mot de commande.\n<br></div>"
+		},
+		{
+			"id": "Merchant's Scale",
+			"name": "Balance de marchand",
+			"description": "<p>Cela comprend une petite balance, des plateaux et un assortiment de poids approprié jusqu'à 1 kilo. Avec, vous pouvez mesurer le poids exact de petits objets, tels que des métaux précieux ou des biens commerciaux, pour aider à déterminer leur valeur.</p>"
+		},
+		{
+			"id": "Headband of Intellect",
+			"name": "Bandeau d'intelligence",
+			"description": "<p><em>Votre Intelligence est de 19 tant que vous portez ce bandeau. Le serre-tête n'a aucun effet sur vous si votre Intelligence est de 19 ou plus sans lui.</p>"
+		},
+		{
+			"id": "Folding Boat",
+			"name": "Bateau pliable",
+			"description": "<div class=\"description \">Cet objet ressemble à une boîte en bois de 30 centimètres de long, 15 centimètres de large, et 15 centimètres de hauteur. Il pèse 2 kilos et flotte. Il peut être ouvert pour y entreposer des objets à l'intérieur. Cet objet a également trois mots de commande, chacun nécessitant une action pour être prononcé.\n<br>Le premier mot de commande entraîne le dépliement de la boîte en un bateau de 3 mètres de long, 1,20 mètre de large et 60 centimètres de profondeur. Le bateau possède une paire de rames, une ancre, un mât, et une voile triangulaire. Le bateau peut contenir jusqu'à 4 créatures de taille M confortablement installées.\n<br>Le second mot de commande provoque le dépliage de la boîte en un navire de 7,20 mètres de long, 2,40 mètres de large, et 1,80 mètre de profondeur. Ce navire a un pont, des sièges de rame, cinq paires de rames, un aviron de queue, une ancre, une cabine de pont, et un mât portant une voile carrée. Le bateau peut contenir jusqu'à 15 créatures de taille M confortablement installées.\n<br>Lorsque la boîte devient un vaisseau, son poids devient celui d'un vaisseau de sa taille, et tout ce qui était placé dans la boîte se trouve dans le bateau.\n<br>Le troisième mot de commande fait revenir le <em>bateau pliable</em> à son état de boîte, à condition qu'aucune créature ne soit à son bord. Tout objet dans le navire qui ne peut pas tenir dans la boîte reste en dehors de la boîte lorsqu'elle se plie. Tout objet qui se trouve dans le vaisseau et pouvant tenir dans la boîte y est rangé.\n<br></div>"
+		},
+		{
+			"id": "Quarterstaff",
+			"name": "Bâton",
+			"description": "<p>Un épais manche en bois enveloppé d'une solide poignée fait une arme très fonctionnelle en plus d'un solide bâton de marche.</p>"
+		},
+		{
+			"id": "Staff",
+			"name": "Bâton",
+			"description": "<p>Un bâton noueux ou poli en bois, en os ou en matériaux plus exotiques comme le cristal. Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Wooden Staff",
+			"name": "Bâton",
+			"description": "<p>Le bâton a été sculpté dans bois spécial et gravé de puissantes runes pour invoquer la puissance de la nature par ceux qui entendent son appel. Focaliseur druidique. Un focaliseur druidique peut être un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois spécial, un bâton pris d'un arbre vivant, ou bien encore un objet totem qui intègre des plumes, de la fourrure, des os ou des dents d'animaux sacrés. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Quarterstaff +1",
+			"name": "Bâton +1",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Quarterstaff +2",
+			"name": "Bâton +2",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Quarterstaff +3",
+			"name": "Bâton +3",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Stick of Incense",
+			"name": "Bâton d'encens",
+			"description": "<p>Lorsque des blocs d'encens ne peuvent pas être utilisés ou qu'une alternative moins coûteuse est nécessaire, les gens les utilisent souvent pour parfumer l'air, que ce soit à des fins agréables ou religieuses.</p>"
+		},
+		{
+			"id": "Staff of Charming",
+			"name": "Bâton d'envoûtement",
+			"description": "<div class=\"description \">Tant que vous tenez ce bâton, vous pouvez utiliser une action pour dépenser l'une de ses 10 charges afin de lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=charme-personne\">charme-personne</a></em>, <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=injonction\">injonction</a></em> ou <em>compréhension des langues</em> en utilisant votre propre DD des sorts. Le bâton peut également être utilisé en tant qu'arme magique.\n<br>Si vous tenez le bâton et échouez un jet de sauvegarde contre un sort d'enchantement dont vous êtes la cible unique, vous pouvez transformer votre échec au jet de sauvegarde en une réussite. Vous ne pouvez plus utiliser cette propriété du bâton avant le prochain lever de soleil. Si vous réussissez un jet de sauvegarde contre un sort d'enchantement dont vous êtes la cible unique, avec ou sans l'intervention du bâton, vous pouvez utiliser votre réaction pour dépenser 1 charge du bâton et renvoyer le sort à son lanceur originel comme si vous veniez de lancer ce sort.\n<br>Le bâton récupère 1d8 + 2 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Sur un résultat de 1, le bâton devient une simple arme non magique.\n<br></div>"
+		},
+		{
+			"id": "Staff of Striking",
+			"name": "Bâton de combat",
+			"description": "<div class=\"description \">Ce bâton peut être utilisé comme une arme magique conférant un bonus de +3 aux jets d'attaque et de dégâts effectués avec lui.\n<br>Le bâton possède 10 charges. Lorsque vous touchez lors d'une attaque au corps à corps en l'utilisant, vous pouvez dépenser jusqu'à 3 de ses charges. Pour chaque charge que vous dépensez, la cible subit 1d6 dégâts de force supplémentaires. Le bâton récupère 1d6 + 4 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Sur un résultat de 1, le bâton devient un simple bâton (arme) non magique.\n<br></div>"
+		},
+		{
+			"id": "Staff of Fire",
+			"name": "Bâton de feu",
+			"description": "<div class=\"description \">Vous obtenez la résistance aux dégâts de feu tant que vous tenez ce bâton.\n<br>Le bâton possède 10 charges. Tant que vous le tenez, vous pouvez utiliser une action pour en dépenser 1 ou plusieurs charges afin de lancer l'un des sorts suivants tout en utilisant votre propre DD des sorts : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mains-brulantes\">mains brûlantes</a></em> (1 de charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (3 charges) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (4 charges).\n<br>Le bâton récupère 1d6 + 4 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Si le résultat est un 1, le bâton noircit, tombe en cendres et est détruit.\n<br></div>"
+		},
+		{
+			"id": "Staff of Withering",
+			"name": "Bâton de flétrissement",
+			"description": "<div class=\"description \">Ce bâton possède 3 charges et récupère 1d3 charges dépensées chaque jour à l'aube.\n<br>Le bâton peut être utilisé comme un bâton magique. Si l'attaque touche, il inflige les mêmes dégâts qu'un bâton normal, et vous pouvez dépenser 1 charge pour infliger 2d10 dégâts nécrotiques supplémentaires à la cible. En outre, la cible doit réussir un jet de sauvegarde de Constitution DD 15 ou avoir un désavantage pendant 1 heure à tous les jets de caractéristiques ou de sauvegarde basés sur la Force ou la Constitution.\n<br></div>"
+		},
+		{
+			"id": "Staff of Frost",
+			"name": "Bâton de givre",
+			"description": "<div class=\"description \">Vous obtenez la résistance aux dégâts de froid tant que vous tenez ce bâton.\n<br>Le bâton possède 10 charges. Tant que vous le tenez, vous pouvez utiliser une action pour en dépenser 1 ou plusieurs charges afin de lancer l'un des sorts suivants tout en utilisant votre propre DD des sorts : <em>cône de froid</em> (5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=nappe-de-brouillard\">nappe de brouillard</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tempete-de-grele\">tempête de grêle</a></em> (4 charges) ou <em>mur de glace</em> (4 charges).\n<br>Le bâton récupère 1d6 + 4 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Si le résultat est un 1, le bâton se change en eau et est détruit.\n<br></div>"
+		},
+		{
+			"id": "Staff of Swarming Insects",
+			"name": "Bâton de grand essaim",
+			"description": "<div class=\"description \">Ce bâton possède 10 charges et récupère 1d6 + 4 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Sur un résultat de 1, un essaim d'insectes consomme et détruit le bâton, puis disparaît.\n<br><strong>Sorts</strong>. Tant que vous tenez le bâton, vous pouvez l'utiliser, en prenant une action pour dépenser plusieurs de ses charges, afin de lancer l'un des sorts suivants tout en utilisant votre propre DD des sorts : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=insecte-géant\">insecte géant</a></em> (4 charges) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=fleau-d-insectes\">fléau d'insectes</a></em> (5 charges).\n<br><strong>Nuage d'insectes</strong>. Tant que vous tenez le bâton, vous pouvez utiliser une action pour dépenser 1 charge et ainsi faire apparaître une nuée d'insectes volants inoffensifs dans un rayon de 9 mètres autour de vous. Les insectes restent pendant 10 minutes, obscurcissant fortement la zone pour toutes les créatures, vous excepté. La nuée se déplace en même temps que vous, et reste centrée sur vous. Un vent d'au moins 15 kilomètres par heure disperse la nuée, mettant un terme à l'effet.\n<br></div>"
+		},
+		{
+			"id": "Staff of Healing",
+			"name": "Bâton de guérison",
+			"description": "<div class=\"description \">Ce bâton possède 10 charges. Tant que vous le tenez, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges afin de lancer l'un des sorts suivants tout en utilisant votre propre DD des sorts et le modificateur de votre caractéristique d'incantation : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=soins\">soins</a></em> (1 charge par niveau d'emplacement de sort, jusqu'au niveau 4 maximum), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=restauration-partielle\">restauration partielle</a></em> (2 charges) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=soins-de-groupe\">soins de groupe</a></em> (5 charges).\n<br>Le bâton récupère 1d6 + 4 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Sur un résultat de 1, le bâton disparaît pour toujours dans un flash de lumière.\n<br></div>"
+		},
+		{
+			"id": "Staff of Power",
+			"name": "Bâton de puissance",
+			"description": "<div class=\"description \">Ce bâton peut être utilisé comme un bâton (arme) magique conférant un bonus de +2 aux jets d'attaque et de dégâts effectués avec lui. Tant que vous le tenez, vous gagnez un bonus de +2 à la Classe d'Armure, aux jets de sauvegarde, et aux jets d'attaque avec un sort.\n<br>Le bâton possède 20 charges pour les propriétés suivantes. Le bâton récupère 2d8 + 4 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Sur un résultat de 1, le bâton conserve son bonus de +2 aux jets d'attaque et de dégâts mais perd toutes ses autres propriétés. Sur un résultat de 20, le bâton récupère 1d8 + 2 charges.\n<br><strong>Frappe surpuissante</strong>. Lorsque vous touchez lors d'une attaque au corps à corps en utilisant le bâton, vous pouvez dépenser 1 charge pour infliger 1d6 dégâts de force supplémentaires à la cible.\n<br><strong>Sorts</strong>. Tant que vous tenez ce bâton, vous pouvez utiliser une action pour dépenser 1 ou plus de ses charges afin de lancer l'un des sorts suivants depuis le bâton, vous utilisez votre propre DD au jet de sauvegarde des sorts et votre bonus d'attaque avec un sort : <em>cône de froid</em> (5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (emplacement de sort niveau 5, 5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=globe-d-invulnerabilite\">globe d'invulnérabilité</a></em> (6 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=immobilisation-de-monstre\">immobilisation de monstre</a></em> (5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=levitation\">lévitation</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=eclair\">éclair</a></em> (emplacement de sort niveau 5, 5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=projectile-magique\">projectile magique</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=rayon-affaiblissant\">rayon affaiblissant</a></em> (1 charge) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-force\">mur de force</a></em> (5 charges).\n<br><strong>Frappe vengeresse</strong>. Vous pouvez utiliser une action pour briser le bâton contre votre genou ou contre une surface solide, déclenchant alors la frappe vengeresse. Le bâton est détruit et libère la magie qui lui reste en une formidable explosion qui recouvre une zone sphérique de 9 mètres de rayons centrée sur lui.\n<br>Vous avez 50 % de chance de voyager instantanément vers un plan d'existence aléatoire, échappant alors à l'explosion. Si vous ne parvenez pas à éviter l'effet, vous subissez un montant de dégâts de force égal à 16 x le nombre de charges dans le bâton. Toutes les autres créatures dans la zone doivent effectuer un jet de sauvegarde de Dextérité DD 17. En cas d'échec au jet de sauvegarde, une créature subit un montant de dégâts basé sur la distance entre elle et l'épicentre de l'explosion, comme indiqué sur la table ci-dessous. En cas de jet de sauvegarde réussi, une créature ne subit que la moitié des dégâts prévus.\n<br><table><tbody><tr><th>Distance par rapport à l'origine</th><th>Dégâts</th></tr><tr><td>3 m ou moins</td><td>8 x le nombre de charges dans le bâton</td></tr><tr><td>Plus de 3 m, jusqu'à 6 m</td><td>6 x le nombre de charges dans le bâton</td></tr><tr><td>Plus de 6 m, jusqu'à 9 m</td><td>4 x le nombre de charges dans le bâton</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Staff of Thunder and Lightning",
+			"name": "Bâton de tonnerre et de foudre",
+			"description": "<div class=\"description \">Ce bâton peut être manié comme un bâton magique qui octroie un bonus de +2 à l'attaque et aux dégâts. Il a également les propriétés supplémentaires suivantes. Quand une de ces propriétés est utilisée, elle ne peut plus être utilisée jusqu'à la prochaine aube.\n<br><strong>Foudre</strong>. Lorsque vous touchez avec une attaque au corps à corps en utilisant le bâton, vous pouvez infliger à la cible 2d6 dégâts de foudre supplémentaires.\n<br><strong>Tonnerre</strong>. Lorsque vous touchez avec une attaque au corps à corps en utilisant le bâton, vous pouvez faire que le bâton émette un bruit de tonnerre audible jusqu'à 90 mètres. La cible que vous touchez doit réussir un jet de sauvegarde de Constitution DD 17 ou devenir étourdie jusqu'à la fin de votre prochain tour.\n<br><strong>Éclair</strong>. Vous pouvez utiliser une action pour faire jaillir un éclair de la pointe du bâton. L'éclair est une ligne de 1,50 mètre de large et de 36 mètres de long. Chaque créature sur cette ligne doit effectuer un jet de sauvegarde de Dextérité DD 17, subissant 9d6 dégâts de foudre en cas d'échec, ou la moitié de ces dégâts en cas de réussite.\n<br><strong>Coup de tonnerre</strong>. Vous pouvez utiliser une action pour faire éclater depuis le bâton un coup de tonnerre assourdissant, audible jusqu'à 180 mètres. Toute créature dans un rayon de 18 mètres autour de vous (vous excepté) doit alors effectuer un jet de sauvegarde de Constitution DD 17. En cas d'échec, une créature subit 2d6 dégâts de tonnerre et devient assourdie pendant 1 minute. En cas de réussite, une créature ne subit que la moitié de ces dégâts et elle n'est pas assourdie.\n<br><strong>Fureur de l'orage</strong>. Vous pouvez utiliser une action pour utiliser les propriétés d'Éclair et de Coup de tonnerre en même temps. Cela ne dépense pas l'utilisation quotidienne de ces propriétés, uniquement l'utilisation de celle-ci.\n<br></div>"
+		},
+		{
+			"id": "Staff of the Woodlands",
+			"name": "Bâton des forêts",
+			"description": "<div class=\"description \">Ce bâton peut être manié comme un bâton magique qui octroie un bonus de +2 à l'attaque et aux dégâts. Lorsque vous le tenez, vous obtenez un bonus de +2 aux jets d'attaque des sorts.\n<br>Le bâton possède 10 charges pour les propriétés suivantes. Il récupère 1d6 + 4 charges dépensées chaque jour à l'aube. Lorsque vous dépensez la dernière charge, lancez un d20. Sur un 1, le bâton perd ses propriétés et devient un simple bâton non magique.\n<br><strong>Sorts</strong>. Vous pouvez utiliser une action pour dépenser une ou plusieurs des charges du bâton et jeter l'un des sorts suivants depuis celui-lui, en utilisant le DD de sauvegarde de vos sorts : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=amitie-avec-les-animaux\">amitié avec les animaux</a></em> (1 charge), <em>éveil</em> (5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=peau-d-ecorce\">peau d'écorce</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=localisation-d-animaux-ou-de-plantes\">localisation d'animaux ou de plantes</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=communication-avec-les-animaux\">communication avec les animaux</a></em> (1 charge), <em>communication avec les plantes</em> (3 charges) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-d-epines\">mur d'épines</a></em> (6 charges).\n<br>Vous pouvez également utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=passage-sans-trace\">passage sans trace</a></em> depuis le bâton sans utiliser aucune charge.\n<br><strong>Forme d'arbre</strong>. Vous pouvez utiliser une action pour planter une extrémité du bâton dans de la terre fertile et dépenser une charge pour le transformer en un arbre sain. L'arbre fait 18 mètres de haut, son tronc fait 1,50 mètre de diamètre et ses branches s'étalent au sommet sur un rayon de 7,50 mètres. L'arbre apparaît ordinaire mais dégage une faible aura de magie de transmutation s'il est ciblé par <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-de-la-magie\">détection de la magie</a></em>. Tout en touchant l'arbre et en utilisant une autre action pour prononcer le mot de commande, vous pouvez faire reprendre au bâton sa forme normale. Toute créature dans l'arbre tombe alors.\n<br></div>"
+		},
+		{
+			"id": "Staff of the Python",
+			"name": "Bâton du python",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour prononcer le mot de commande du bâton et le lancer au sol dans un rayon de 3 mètres autour de vous. Le bâton devient un serpent constricteur géant (voir le <em>Manuel des Monstres</em> pour les statistiques) sous votre contrôle et qui agit selon son propre score d'initiative. En utilisant une action bonus pour prononcer de nouveau le mot de commande, le bâton reprend sa forme originale dans l'espace qu'occupait le serpent.\n<br>À votre tour, vous pouvez mentalement commander le serpent tant qu'il se trouve à 18 mètres ou moins de vous et que vous n'êtes pas incapable d'agir. Vous décidez quelles actions entreprendra le serpent et où il se déplacera lors du prochain tour, ou vous pouvez lui donner un ordre général comme attaquer vos ennemis ou garder un lieu.\n<br>Si le serpent tombe à 0 point de vie, il meurt et reprend la forme du bâton, puis celui-ci se brise et le bâton est détruit. Si le serpent reprend la forme du bâton avant de perdre tous ses points de vie, il les récupère tous.\n<br></div>"
+		},
+		{
+			"id": "Staff of the Magi",
+			"name": "Bâton du thaumaturge",
+			"description": "<div class=\"description \">Ce bâton peut être utilisé comme un bâton (arme) magique conférant un bonus de +2 aux jets d'attaque et de dégâts effectués avec lui. Tant que vous le tenez, vous bénéficiez d'un bonus de +2 aux jets d'attaque des sorts.\n<br>Le bâton possède 50 charges pour les propriétés suivantes. Il récupère 4d6 + 2 charges dépensées chaque jour au lever du soleil. Si vous dépensez la dernière charge, lancez un d20. Sur un résultat de 20, le bâton récupère 1d12 + 1 charges.\n<br><strong>Absorption de sort</strong>. Tant que vous tenez le bâton, vous avez un avantage aux jets de sauvegarde contre les sorts. De plus, vous pouvez utiliser votre réaction lorsqu'une autre créature lance un sort qui ne cible que vous. Dans ce cas, le bâton absorbe la magie du sort, annulant ses effets et récupérant un nombre de charges égal au niveau de sort absorbé. Cependant, si en faisant cela le nombre total de charges du bâton devient supérieur à 50, le bâton explose comme si vous aviez activé sa propriété Frappe vengeresse (voir ci-dessous).\n<br><strong>Sorts</strong>. Tant que vous tenez ce bâton, vous pouvez utiliser une action pour dépenser plusieurs de ses charges afin de lancer l'un des sorts suivants depuis le bâton, vous utilisez votre propre DD au jet de sauvegarde des sorts et votre caractéristique d'incantation : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em> (7 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=dissipation-de-la-magie\">dissipation de la magie</a></em> (3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (emplacement de sort niveau 7, 7 charges), <em>sphère de feu</em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=tempete-de-grele\">tempête de grêle</a></em> (4 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invisibilite\">invisibilité</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=deblocage\">déblocage</a></em> (2 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=eclair\">éclair</a></em> (emplacement de sort niveau 7, 7 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=passe-muraille\">passe-muraille</a></em> (5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=changement-de-plan\">changement de plan</a></em> (7 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=telekinesie\">télékinésie</a></em> (5 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (4 charges), ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=toile-d-araignee\">toile d'araignée</a></em> (2 charges).\n<br>Vous pouvez également utiliser une action pour lancer l'un des sorts suivants grâce au bâton sans utiliser de charge : <em>verrou magique, <a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-de-la-magie\">détection de la magie</a>, <a href=\"https://www.aidedd.org/dnd/sorts.php?vf=agrandissement-rapetissement\">agrandissement/rapetissement</a>, lumière, <a href=\"https://www.aidedd.org/dnd/sorts.php?vf=main-de-mage\">main de mage</a></em> ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=protection-contre-le-Mal-et-le-Bien\">protection contre le mal et le bien</a></em>.\n<br><strong>Frappe vengeresse</strong>. Vous pouvez utiliser une action pour briser le bâton contre votre genou ou contre une surface solide, déclenchant alors la frappe vengeresse. Le bâton est détruit et libère la magie qui lui reste en une formidable explosion qui recouvre une zone sphérique de 9 mètres de rayons centrée sur lui.\n<br>Vous avez 50 % de chance de voyager instantanément vers un plan d'existence aléatoire, échappant alors à l'explosion. Si vous ne parvenez pas à éviter l'effet, vous subissez un montant de dégâts de force égal à 16 x le nombre de charges dans le bâton. Toutes les autres créatures dans la zone doivent effectuer un jet de sauvegarde de Dextérité DD 17. En cas d'échec au jet de sauvegarde, une créature subit un montant de dégâts basé sur la distance entre elle et l'épicentre de l'explosion, comme indiqué sur la table ci-dessous. En cas de jet de sauvegarde réussi, une créature ne subit que la moitié des dégâts prévus.\n<br><table><tbody><tr><th>Distance par rapport à l'origine</th><th>Dégâts</th></tr><tr><td>3 m ou moins</td><td>8 x le nombre de charges dans le bâton</td></tr><tr><td>Plus de 3 m, jusqu'à 6 m</td><td>6 x le nombre de charges dans le bâton</td></tr><tr><td>Plus de 6 m, jusqu'à 9 m</td><td>4 x le nombre de charges dans le bâton</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Vicious Quarterstaff",
+			"name": "Bâton vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Restorative Ointment",
+			"name": "Baume de Keoghtom",
+			"description": "<div class=\"description \">Ce pot de verre, de 7,50 cm de diamètre, contient 1d4 + 1 doses d'un mélange épais qui sent vaguement l'aloès. Le pot et son contenu pèsent 500 g. Au prix d'une action, une dose de l'onguent peut être avalée ou appliquée sur la peau. La créature qui le reçoit récupère 2d8 + 2 points de vie, cesse d'être empoisonnée, et est guérie de toute maladie.\n<br></div>"
+		},
+		{
+			"id": "Portable Ram",
+			"name": "Bélier portable",
+			"description": "<p>Vous pouvez utiliser un bélier portable pour enfoncer des portes. Ce faisant, vous gagnez un bonus de +4 au jet de Force. Un autre personnage peut vous aider à utiliser le bélier, ce qui vous donne un avantage à ce jet.</span></p>"
+		},
+		{
+			"id": "Ball Bearings",
+			"name": "Billes (sac de 1000)",
+			"description": "<p>Au prix d'une action, vous pouvez sortir ces petites billes métalliques de leur poche pour recouvrir une zone de 3 m x 3 m. Une créature se déplaçant à travers la zone recouverte doit réussir un jet de sauvegarde de Dextérité DD 10 ou tomber à terre. Une créature se déplaçant à travers la zone à la moitié de sa vitesse n'a pas besoin de faire le jet de sauvegarde.</span></p>"
+		},
+		{
+			"id": "Sling Bullet +1",
+			"name": "Billes de fronde +1",
+			"description": "<div class=\"description \">Vous obtenez un bonus à l'attaque et aux dégâts effectués avec cette munition magique. Le bonus est déterminé par la rareté de la munition. Une fois qu'elle touche une cible, la munition n'est plus magique.\n<br></div>"
+		},
+		{
+			"id": "Sling Bullet +2",
+			"name": "Billes de fronde +2",
+			"description": "<div class=\"description \">Vous obtenez un bonus à l'attaque et aux dégâts effectués avec cette munition magique. Le bonus est déterminé par la rareté de la munition. Une fois qu'elle touche une cible, la munition n'est plus magique.\n<br></div>"
+		},
+		{
+			"id": "Sling Bullet +3",
+			"name": "Billes de fronde +3",
+			"description": "<div class=\"description \">Vous obtenez un bonus à l'attaque et aux dégâts effectués avec cette munition magique. Le bonus est déterminé par la rareté de la munition. Une fois qu'elle touche une cible, la munition n'est plus magique.\n<br></div>"
+		},
+		{
+			"id": "Sling Bullet of Slaying",
+			"name": "Billes de fronde Tueuse",
+			"description": "<div class=\"description \">Une bille de fronde tueuse est une arme magique destinée à abattre un type de créature en particulier. Certaines sont plus spécifiques que d'autres ; par exemple, il existe des <em>billes de fronde tueuses de dragons</em> et des <em>billes de fronde tueuses de dragons bleu</em>. Si une créature appartenant au type, à la race ou au groupe associé à la <em>bille de fronde tueuse</em> subit des dégâts de cette bille, cette créature doit effectuer un jet de sauvegarde de Constitution DD 17, subissant 6d10 dégâts perforants supplémentaires en cas d'échec, ou la moitié de ces dégâts supplémentaires en cas de réussite.\n<br>Une fois qu'une <em>bille tueuse</em> a infligé ses dégâts supplémentaires à une créature, elle devient une simple bille non magique.\n<br>D'autres types de munition magique de ce type existent, comme les <em>carreaux tueurs</em> destinés aux arbalètes, mais les flèches sont les plus répandues.\n<br></div>"
+		},
+		{
+			"id": "Bit and Bridle",
+			"name": "Mors et bride",
+			"description": "<p>Composant de la sellerie d'un cheval qui est porté sur sa tête et relié aux rênes. Il se compose de plusieurs lanières de cuir réglables, d'anneaux métalliques et d'une embouchure appelée 'mors' ou 'mullen', faite de corde, d'os, de corne ou d'une autre substance dure comme le bronze, l'acier, le nickel ou le bois.</p>"
+		},
+		{
+			"id": "Block of Incense",
+			"name": "Bloc d'encens",
+			"description": "<p>Fréquemment utilisé par les riches et les religieux pour parfumer l'air à des fins de plaisir ou de rituel.</p>"
+		},
+		{
+			"id": "Tinderbox",
+			"name": "Boite d'allume-feu",
+			"description": "<p>Cette petite boite contient un silex, des amorces et de l'amadou (généralement des bouts de tissu sec trempés dans de l'huile), soit tout le nécessaire pour allumer un feu. L'utiliser pour allumer une torche, ou autre chose qui contient suffisamment d'huile, prend une action. Allumer tout autre type de feu prend 1 minute.</p>\n<p>&nbsp;</p>"
+		},
+		{
+			"id": "Alms Box",
+			"name": "Boîte d'aumônes",
+			"description": "<p>Une boîte avec une fente pour l'argent et un socle détachable, principalement utilisée par les prêtres et autres pour collecter l'aumône.</p>"
+		},
+		{
+			"id": "Bowl of Commanding Water Elementals",
+			"name": "Bol de contrôle des élémentaires de l'eau",
+			"description": "<div class=\"description \">Une fois ce bol rempli d'eau, vous pouvez utiliser une action pour prononcer son mot de commande et convoquer un élémentaire de l'eau comme si vous aviez lancé le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>. Le bol ne peut être utilisé de nouveau de cette façon avant le prochain lever du soleil.\n<br>Il fait environ 30 centimètres de diamètre et la moitié en profondeur, pèse 1,5 kg et peut contenir environ 12 litres.\n<br></div>"
+		},
+		{
+			"id": "Winged Boots",
+			"name": "Bottes ailées",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de ces bottes, vous avez une vitesse de vol égale à votre vitesse de déplacement. Vous pouvez utiliser les bottes pour voler pendant une durée de 4 heures maximum, que ce soit en une seule fois ou en cumulant plusieurs vols de courte durée, chaque utilisation des bottes consommant au minimum 1 minute de la durée d'utilisation total. Si vous êtes en plein vol lorsque la durée expire, vous descendez jusqu'au sol avec une allure de 9 mètres par tour. Les bottes récupèrent 2 heures de capacité de vol pour chaque période continue de 12 heures pendant lesquelles elles ne sont pas utilisées.\n<br></div>"
+		},
+		{
+			"id": "Boots of Levitation",
+			"name": "Bottes de lévitation",
+			"description": "<div class=\"description \">Lorsque vous portez ces bottes, vous pouvez utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=levitation\">lévitation</a></em> sur vous-même à volonté.\n<br></div>"
+		},
+		{
+			"id": "Boots of Striding and Springing",
+			"name": "Bottes de marche et de saut",
+			"description": "<p>Lorsque vous portez ces bottes, votre vitesse de marche passe à 9 mètres, à moins qu'elle ne soit déjà supérieure à cela, et votre vitesse n'est pas réduite par le fait d'être encombré ou de porter une armure lourde. En outre, vous pouvez sauter trois fois la distance normale, bien que vous ne puissiez pas sauter plus loin que ce qu'il vous reste de mouvement le permet.</p>"
+		},
+		{
+			"id": "Boots of Speed",
+			"name": "Bottes de rapidité",
+			"description": "<div class=\"description \">Lorsque vous portez ces bottes, vous pouvez utiliser une action bonus pour claquer vos talons l'un contre l'autre. Si vous le faites, les bottes doublent votre vitesse de marche et toute créature qui tente une attaque d'opportunité à votre encontre le fait avec un désavantage au jet d'attaque. Claquer des talons à nouveau permet de mettre fin à l'effet.\n<br>Lorsque la propriété des bottes a été utilisée pour un total de 10 minutes, la magie cesse de fonctionner jusqu'à ce que vous finissiez un repos long.\n<br></div>"
+		},
+		{
+			"id": "Boots of the Winterlands",
+			"name": "Bottes des contrées hivernales",
+			"description": "<div class=\"description \">Ces bottes de fourrure sont chaudes et confortables. Tant que vous les portez, vous profitez des bénéfices suivants :\n<br>• Vous obtenez la résistance au froid.\n<br>• vous ignorez les terrains difficiles engendrés par la glace ou la neige.\n<br>• Vous pouvez supporter le froid jusqu'à -45°C sans protection supplémentaire. Si vous portez des vêtements chauds, vous pouvez supporter jusqu'à -75°C.\n<br></div>"
+		},
+		{
+			"id": "Boots of Elvenkind",
+			"name": "Bottes elfiques",
+			"description": "<div class=\"description \">Lorsque vous portez ces bottes, vos pas ne produisent aucun son, quelle que soit la surface sur laquelle vous vous déplacez. Vous avez également un avantage aux jets de Dextérité (Discrétion) liés à un déplacement silencieux.\n<br></div>"
+		},
+		{
+			"id": "Shield",
+			"name": "Bouclier",
+			"description": "<p>Un bouclier est fait de bois ou de métal et est porté dans une main. Le fait de porter un bouclier augmente votre classe d'armure de 2. Vous ne pouvez bénéficier que d'un seul bouclier à la fois.</p>"
+		},
+		{
+			"id": "Shield +1",
+			"name": "Bouclier +1",
+			"description": "<div class=\"description \">Si vous tenez en main ce bouclier, vous obtenez un bonus à la CA déterminé par la rareté du bouclier. Ce bonus vient en plus du bonus normal du bouclier à la CA.\n<br></div>"
+		},
+		{
+			"id": "Shield +2",
+			"name": "Bouclier +2",
+			"description": "<div class=\"description \">Si vous tenez en main ce bouclier, vous obtenez un bonus à la CA déterminé par la rareté du bouclier. Ce bonus vient en plus du bonus normal du bouclier à la CA.\n<br></div>"
+		},
+		{
+			"id": "Shield +3",
+			"name": "Bouclier +3",
+			"description": "<div class=\"description \">Si vous tenez en main ce bouclier, vous obtenez un bonus à la CA déterminé par la rareté du bouclier. Ce bonus vient en plus du bonus normal du bouclier à la CA.\n<br></div>"
+		},
+		{
+			"id": "Animated Shield",
+			"name": "Bouclier animé",
+			"description": "Armure (bouclier), très rare (nécessite un lien) Lorsque vous tenez ce bouclier, vous pouvez prononcer son mot de commande au prix d'une action bonus pour l'animer. Le bouclier saute alors en l'air et flotte dans votre espace pour vous protéger comme si vous le maniez, mais en vous laissant les mains libres. Le bouclier reste animé pendant 1 minute, jusqu'à ce que vous utilisiez une action bonus pour mettre fin à l'effet, ou jusqu'à ce que vous soyez incapable d'agir ou mort. Le bouclier tombe alors au sol "
+		},
+		{
+			"id": "Arrow-Catching Shield",
+			"name": "Bouclier antiprojectiles",
+			"description": "<p>Vous gagnez un bonus de +2 à la CA contre les attaques à distance lorsque vous maniez ce bouclier. Ce bonus vient en plus du bonus normal à la CA du bouclier. En outre, chaque fois qu'un attaquant effectue une attaque à distance contre une cible à 1,50 mètre ou moins de vous, vous pouvez utiliser votre réaction pour devenir la cible de l'attaque.</p>"
+		},
+		{
+			"id": "Shield of Missile Attraction",
+			"name": "Bouclier d'attraction des projectiles",
+			"description": "Armure (bouclier), rare (nécessite un lien). Tant que vous tenez ce bouclier, vous avez la résistance aux dégâts des attaques à distance avec une arme. Malédiction. Ce bouclier est maudit. Vous lier à lui vous maudit jusqu'à ce que vous soyez la cible d'un sort de délivrance des malédictions ou d'un effet magique similaire. Retirer le bouclier ne permet pas de mettre fin à la malédiction qui vous affecte. À chaque fois qu'une attaque à distance avec une arme est effectuée contre une cible se trouvant à 3 mètres ou moins de vous, la malédiction fait de vous la cible de l'attaque.</p>"
+		},
+		{
+			"id": "Spellguard Shield",
+			"name": "Bouclier de protection contre la magie",
+			"description": "<p>Tant que vous tenez ce bouclier, vous avez un avantage à vos jets de sauvegarde effectués contre des sorts ou tout autre effet magique, et les attaques avec un sort ont un désavantage contre vous.</p>"
+		},
+		{
+			"id": "Candle",
+			"name": "Bougie",
+			"description": "<p>Une bougie génère une lumière vive dans un rayon de 1,50 mètre et une lumière faible sur 1,50 mètre supplémentaire durant 1 heure.</span></p>"
+		},
+		{
+			"id": "Crystal",
+			"name": "Boule de cristal",
+			"description": "<p>Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts.</span></p>"
+		},
+		{
+			"id": "Crystal Ball",
+			"name": "Boule de cristal",
+			"description": "<div class=\"description \">La <em>boule de cristal</em> typique, un objet très rare, a un diamètre de 15 centimètres. Tant que vous la touchez, vous pouvez lancer un sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> (sauvegarde DD 17) grâce à elle.\n<br>Les variantes de <em>boule de cristal</em> présentées ci-dessous sont des objets légendaires et ont des propriétés supplémentaires.\n<br><strong>Boule de cristal de lecture des pensées</strong>. Vous pouvez utiliser votre action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 17) tant que vous êtes en pleine scrutation avec la <em>boule de cristal</em>, vous ciblez alors une créature que vous pouvez voir et située à 9 mètres maximum du capteur créé par le sort. Vous n'avez pas besoin de vous concentrer sur ce sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine.\n<br><strong>Boule de cristal de télépathie</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous pouvez communiquer par télépathie avec toutes les créatures que vous pouvez voir et qui se trouvent à 9 mètres maximum du capteur créé par le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>. Vous pouvez également utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> (sauvegarde DD 17) au travers du capteur sur l'une de ces créatures. Vous n'avez pas besoin de vous concentrer sur le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine. Une fois qu'il est utilisé, le pouvoir de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> de la <em>boule de cristal</em> ne peut être réutilisé avant le prochain lever de soleil.\n<br><strong>Boule de cristal de vision véritable</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous possédez la vision véritable dans un rayon de 36 mètres centré sur le capteur du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Crystal Ball of Mind Reading",
+			"name": "Boule de cristal de lecture des pensées",
+			"description": "<div class=\"description \">La <em>boule de cristal</em> typique, un objet très rare, a un diamètre de 15 centimètres. Tant que vous la touchez, vous pouvez lancer un sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> (sauvegarde DD 17) grâce à elle.\n<br>Les variantes de <em>boule de cristal</em> présentées ci-dessous sont des objets légendaires et ont des propriétés supplémentaires.\n<br><strong>Boule de cristal de lecture des pensées</strong>. Vous pouvez utiliser votre action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 17) tant que vous êtes en pleine scrutation avec la <em>boule de cristal</em>, vous ciblez alors une créature que vous pouvez voir et située à 9 mètres maximum du capteur créé par le sort. Vous n'avez pas besoin de vous concentrer sur ce sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine.\n<br><strong>Boule de cristal de télépathie</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous pouvez communiquer par télépathie avec toutes les créatures que vous pouvez voir et qui se trouvent à 9 mètres maximum du capteur créé par le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>. Vous pouvez également utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> (sauvegarde DD 17) au travers du capteur sur l'une de ces créatures. Vous n'avez pas besoin de vous concentrer sur le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine. Une fois qu'il est utilisé, le pouvoir de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> de la <em>boule de cristal</em> ne peut être réutilisé avant le prochain lever de soleil.\n<br><strong>Boule de cristal de vision véritable</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous possédez la vision véritable dans un rayon de 36 mètres centré sur le capteur du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Crystal Ball of Telepathy",
+			"name": "Boule de cristal de télépathie",
+			"description": "<div class=\"description \">La <em>boule de cristal</em> typique, un objet très rare, a un diamètre de 15 centimètres. Tant que vous la touchez, vous pouvez lancer un sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> (sauvegarde DD 17) grâce à elle.\n<br>Les variantes de <em>boule de cristal</em> présentées ci-dessous sont des objets légendaires et ont des propriétés supplémentaires.\n<br><strong>Boule de cristal de lecture des pensées</strong>. Vous pouvez utiliser votre action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 17) tant que vous êtes en pleine scrutation avec la <em>boule de cristal</em>, vous ciblez alors une créature que vous pouvez voir et située à 9 mètres maximum du capteur créé par le sort. Vous n'avez pas besoin de vous concentrer sur ce sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine.\n<br><strong>Boule de cristal de télépathie</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous pouvez communiquer par télépathie avec toutes les créatures que vous pouvez voir et qui se trouvent à 9 mètres maximum du capteur créé par le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>. Vous pouvez également utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> (sauvegarde DD 17) au travers du capteur sur l'une de ces créatures. Vous n'avez pas besoin de vous concentrer sur le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine. Une fois qu'il est utilisé, le pouvoir de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> de la <em>boule de cristal</em> ne peut être réutilisé avant le prochain lever de soleil.\n<br><strong>Boule de cristal de vision véritable</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous possédez la vision véritable dans un rayon de 36 mètres centré sur le capteur du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Crystal Ball of True Seeing",
+			"name": "Boule de cristal de vision véritable",
+			"description": "<div class=\"description \">La <em>boule de cristal</em> typique, un objet très rare, a un diamètre de 15 centimètres. Tant que vous la touchez, vous pouvez lancer un sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> (sauvegarde DD 17) grâce à elle.\n<br>Les variantes de <em>boule de cristal</em> présentées ci-dessous sont des objets légendaires et ont des propriétés supplémentaires.\n<br><strong>Boule de cristal de lecture des pensées</strong>. Vous pouvez utiliser votre action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 17) tant que vous êtes en pleine scrutation avec la <em>boule de cristal</em>, vous ciblez alors une créature que vous pouvez voir et située à 9 mètres maximum du capteur créé par le sort. Vous n'avez pas besoin de vous concentrer sur ce sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine.\n<br><strong>Boule de cristal de télépathie</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous pouvez communiquer par télépathie avec toutes les créatures que vous pouvez voir et qui se trouvent à 9 mètres maximum du capteur créé par le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>. Vous pouvez également utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> (sauvegarde DD 17) au travers du capteur sur l'une de ces créatures. Vous n'avez pas besoin de vous concentrer sur le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> pour le maintenir pendant toute sa durée, mais il prend fin si le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> se termine. Une fois qu'il est utilisé, le pouvoir de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> de la <em>boule de cristal</em> ne peut être réutilisé avant le prochain lever de soleil.\n<br><strong>Boule de cristal de vision véritable</strong>. Tant que vous êtes en pleine scrutation avec cette <em>boule de cristal</em>, vous possédez la vision véritable dans un rayon de 36 mètres centré sur le capteur du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Abacus",
+			"name": "Boulier",
+			"description": "<p>Le boulier est un outil de calcul.</p>"
+		},
+		{
+			"id": "Glass Bottle",
+			"name": "Bouteille en verre",
+			"description": "<p>Une bouteille qui peut contenir 75cl de liquide.</span></p>"
+		},
+		{
+			"id": "Eversmoking Bottle",
+			"name": "Bouteille fumigène",
+			"description": "<div class=\"description \">De la fumée s'échappe de l'orifice de cette bouteille en laiton fermée par un bouchon de plomb. La bouteille pèse 500 grammes. Lorsque vous utilisez votre action pour enlever le bouchon, un épais nuage de fumée s'échappe de la bouteille dans un rayon de 18 mètres. La zone a une visibilité nulle. Chaque minute que la bouteille reste ouverte tout en étant dans le nuage, le rayon augmente de 3 mètres jusqu'à atteindre un rayon maximum de 36 mètres.\n<br>Le nuage reste en place aussi longtemps que la bouteille est ouverte. Fermer la bouteille nécessite que vous prononciez le mot de commande en utilisant une action. Une fois que la bouteille est refermée, le nuage se disperse en 10 minutes. Un vent modéré (16 à 30 kilomètres par heure) peut également disperser la fumée en 1 minute, et un vent fort (plus de 30 kilomètres par heure) peut disperser le nuage un 1 tour.\n<br></div>"
+		},
+		{
+			"id": "Bracers of Archery",
+			"name": "Bracelets d'archer",
+			"description": "<div class=\"description \">Tant que vous portez ces bracelets, vous avez la maîtrise des arcs longs et courts, et vous gagnez un bonus de +2 aux jets de dégâts des attaques à distance réalisés avec ces armes.\n<br></div>"
+		},
+		{
+			"id": "Bracers of Defense",
+			"name": "Bracelets de défense",
+			"description": "<div class=\"description \">Lorsque vous portez ces bracelets, vous obtenez un bonus de +2 à votre CA, à condition de ne porter aucune armure et de ne pas utiliser de bouclier.\n<br></div>"
+		},
+		{
+			"id": "Sprig of Mistletoe",
+			"name": "Branche de gui",
+			"description": "<p>Une brindille de gui, de houx ou d'une autre feuille sacrée, cueillie sur un arbre dont les racines sont naturellement enfoncées au sein d'une forêt. Ceux qui tiennent compte de l'appel de la nature sont capables d'exploiter cette connexion pour faire appel à l'incroyable puissance de la nature.Focaliseur druidique. Un focaliseur druidique peut être un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois spécial, un bâton pris d'un arbre vivant, ou bien encore un objet totem qui intègre des plumes, de la fourrure, des os ou des dents d'animaux sacrés. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Brazier of Commanding Fire Elementals",
+			"name": "Brasero de contrôle des élémentaires du feu",
+			"description": "<div class=\"description \">Tant qu'un feu brûle dans ce brasero en cuivre, vous pouvez utiliser une action pour prononcer son mot de commande et convoquer un élémentaire du feu, comme si vous aviez lancé le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>. Le brasero ne peut plus être utilisé de cette façon avant le prochain lever du soleil. Le brasero pèse 2,5 kg.\n<br></div>"
+		},
+		{
+			"id": "Brooch of Shielding",
+			"name": "Broche de protection",
+			"description": "<div class=\"description \">Tant que vous portez cette broche, vous obtenez la résistance aux dégâts de force, et êtes immunisé aux dégâts du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=projectile-magique\">projectile magique</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Ring Mail",
+			"name": "Broigne",
+			"description": "<p>This armor is leather armor with heavy rings sewn into it. The rings help reinforce the armor against blows from swords and axes. Ring mail is inferior to chain mail, and it's usually worn only by those who can't afford better armor.</p>"
+		},
+		{
+			"id": "Ring Mail +1",
+			"name": "Broigne +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Ring Mail +2",
+			"name": "Broigne +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Ring Mail +3",
+			"name": "Broigne +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Mithral Ring Mail",
+			"name": "Broigne de mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Ring Mail Armor of Resistance",
+			"name": "Broigne de Résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Adamantine Ring Mail",
+			"name": "Broigne en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Lock",
+			"name": "Cadenas",
+			"description": "<p>Une clé est fournie avec le cadenas. Sans la clé, une créature qui maîtrise les outils de voleur peut ouvrir le cadenas en réussissant un jet de Dextérité DD 15. Votre MD peut décider que des cadenas de meilleure qualité sont disponibles à des prix plus élevés.</span></p>"
+		},
+		{
+			"id": "Cloak of Displacement",
+			"name": "Cape de déplacement",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cette cape, elle projette une illusion de vous proche de là où vous vous trouvez. De fait, les créatures ont un désavantage aux jets d'attaque effectués contre vous. Si vous subissez des dégâts, la propriété de la cape cesse de fonctionner jusqu'au début de votre prochain tour. Cette capacité est annulée si vous être incapable d'agir, entravé, ou incapable de bouger de quelle que manière que ce soit.\n<br></div>"
+		},
+		{
+			"id": "Cloak of Arachnida",
+			"name": "Cape de l'araignée",
+			"description": "<div class=\"description \">Ce vêtement délicat a été tressé à partir de soie noire et de discrets fils d'argent. Tant que vous en êtes équipé, vous gagnez les avantages suivants :\n<br>• Vous avez la résistance aux dégâts de poison.\n<br>• Vous avez une vitesse d'escalade égale à votre vitesse de déplacement au sol.\n<br>• Vous pouvez monter, descendre ou parcourir des surfaces verticales, et même vous déplacer aux plafonds la tête en bas, tout en gardant vos deux mains libres.\n<br>• Vous ne pouvez pas être prisonnier de toiles (de toutes sortes), et vous pouvez vous déplacer sur des toiles comme si elles étaient de simples terrains difficiles.\n<br>• Vous pouvez utiliser votre action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=toile-d-araignee\">toile d'araignée</a></em> (sauvegarde DD 13). Cette toile créée recouvre une surface deux fois plus grande que ce qui est indiqué dans la description du sort. Une fois qu'elle a été utilisée, cette propriété de la cape ne peut être réutilisée avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Cloak of the Bat",
+			"name": "Cape de la chauve-souris",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cette cape, vous avez un avantage aux jets de Dextérité (Discrétion). Dans une zone de lumière faible ou de ténèbres, vous pouvez attraper les bords de la cape avec vos deux mains et l'utiliser pour voler avec une vitesse de 12 mètres. Si par malheur vous lâchez les bords de la cape alors que vous êtes en train de voler grâce à elle, ou si vous ne vous trouvez plus dans une zone de lumière faible ou de ténèbres, vous perdez cette vitesse de vol.\n<br>Tant que vous êtes équipé de cette cape et que vous vous trouvez dans une zone de lumière faible ou de ténèbres, vous pouvez utiliser votre action pour lancer sur vous-même le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=metamorphose\">métamorphose</a></em> afin de vous transformer en chauve-souris. Tant que vous êtes sous la forme d'une chauve-souris, vous conservez vos valeurs d'Intelligence, de Sagesse, et de Charisme. La cape ne peut être réutilisée de cette manière avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Cloak of the Manta Ray",
+			"name": "Cape de la raie manta",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cette cape et que vous avez enfilé sa capuche, vous pouvez respirer sous l'eau, et vous obtenez une vitesse de nage de 18 mètres. Enfiler ou retirer la capuche prend une action.\n<br></div>"
+		},
+		{
+			"id": "Cloak of Protection",
+			"name": "Cape de protection",
+			"description": "<div class=\"description \">Vous bénéficiez d'un bonus de +1 à la CA et aux jets de sauvegarde tant que vous êtes équipé de cette cape.\n<br></div>"
+		},
+		{
+			"id": "Cape of the Mountebank",
+			"name": "Cape du prestidigitateur",
+			"description": "<div class=\"description \">Cette cape sent légèrement le soufre. Tant que vous en êtes équipé, vous pouvez vous en servir, en utilisant votre action, pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=porte-dimensionnelle\">porte dimensionnelle</a></em>. Cette propriété de la cape ne peut être réutilisée avant le prochain lever de soleil. Lorsque vous disparaissez, vous laissez derrière vous un nuage de fumée, et, à votre arrivée à destination, vous apparaissez également dans un nuage de fumée. La fumée obscurcit légèrement l'endroit que vous quittez et celui où vous apparaissez, et se dissipe à la fin de votre tour suivant. Un vent léger ou plus puissant disperse la fumée.\n<br></div>"
+		},
+		{
+			"id": "Cloak of Elvenkind",
+			"name": "Cape elfique",
+			"description": "<div class=\"description \">Lorsque vous portez cette cape avec sa capuche rabattue sur votre tête, les jets de Sagesse (Perception) pour vous voir ont un désavantage, et vous avez un avantage aux jets de Dextérité (Discrétion) pour vous cacher, grâce aux changements de couleur de la cape qui vous aident à vous camoufler. Mettre ou enlever la capuche nécessite une action.\n<br></div>"
+		},
+		{
+			"id": "Decanter of Endless Water",
+			"name": "Carafe intarissable",
+			"description": "<div class=\"description \">Cette flasque bouchée fait de petits clapotis lorsqu'elle est secouée, comme si elle contenait de l'eau. La carafe pèse 1 kilo.\n<br>Vous pouvez utiliser une action pour enlever le bouchon et prononcer l'un des trois mots de commande, après quoi une certaine quantité d'eau douce ou d'eau salée (selon votre choix) se déverse de la flasque. L'eau cesse de s'écouler au début de votre prochain tour. Choisissez l'une des options suivantes :\n<br>• « Ruisseau » produit 4 litres d'eau.\n<br>• « Fontaine » produit 20 litres d'eau.\n<br>• « Geyser » produit 120 litres d'eau qui apparaissent en un violent jet de 9 mètres de long et 30 centimètres de diamètre. En utilisant une action bonus pendant que vous tenez la carafe, vous pouvez braquer le jet sur une créature que vous pouvez voir et se trouvant à 9 mètres maximum de vous. La cible doit réussir un jet de sauvegarde de Force DD 13 sous peine de subir 1d4 dégâts contondants et être jetée à terre. Au lieu d'une créature, vous pouvez cibler un objet qui n'est ni porté ni transporté et dont le poids ne dépasse pas les 100 kilos. L'objet est soit mis à terre, soit repoussé de vous sur 4,50 mètres.\n<br></div>"
+		},
+		{
+			"id": "Chime of Opening",
+			"name": "Carillon d'ouverture",
+			"description": "<div class=\"description \">Ce tube de métal creux mesure environ 30 centimètres de long et pèse 500 grammes. Vous pouvez le frapper en utilisant une action, et le pointer vers un objet pouvant être ouvert et se trouvant à 36 mètres de vous maximum, comme une porte, un couvercle ou une serrure. En faisant cela, le carillon sonne d'un ton clair, et une serrure ou un loquet sur l'objet s'ouvre, à moins que le son ne puisse pas atteindre l'objet. S'il ne reste aucune serrure ou loquet en place, l'objet s'ouvre de lui-même. Le carillon peut être utilisé dix fois. Après ces dix utilisations, il se fissure et ne sert plus à rien.\n<br></div>"
+		},
+		{
+			"id": "Quiver",
+			"name": "Carquois",
+			"description": "<p>Un carquois peut contenir jusqu'à 20 flèches.</span></p>"
+		},
+		{
+			"id": "Efficient Quiver",
+			"name": "Carquois d'Ehlonna",
+			"description": "<div class=\"description \">Chacun des trois compartiments du carquois est connecté à un espace extradimensionnel qui permet au carquois de contenir un grand nombre d'objets tout en ne pesant jamais plus de 1 kilo au total. Le plus petit compartiment peut contenir jusqu'à 60 flèches, carreaux, ou objets similaires. Le compartiment de taille moyenne peut contenir jusqu'à 18 javelines ou objets similaires. Le plus grand compartiment peut contenir jusqu'à 6 longs objets, comme un arc, un bâton, ou une lance.\n<br>Vous pouvez récupérer tout objet que le carquois contient comme vous le feriez avec un carquois normal ou un fourreau.\n<br></div>"
+		},
+		{
+			"id": "Crossbow Bolt +1",
+			"name": "Carreau d'arbalète +1",
+			"description": "<p>Cette munition, utilisée par les arbalètes, est généralement faite d'une tige en métal avec une pointe acérée. Elle est magiquement imprégnée.</p>\n<p>Vous avez un bonus aux jets d'attaque et de dégats avec cette munition magique. La munition n'est plus magique après avoir toucher une cible.</p>"
+		},
+		{
+			"id": "Crossbow Bolt +2",
+			"name": "Carreau d'arbalète +2",
+			"description": "<p>Cette munition, utilisée par les arbalètes, est généralement faite d'une tige en métal avec une pointe acérée. Elle est magiquement imprégnée.</p>\n<p>Vous avez un bonus aux jets d'attaque et de dégats avec cette munition magique. La munition n'est plus magique après avoir toucher une cible.</p>"
+		},
+		{
+			"id": "Crossbow Bolt +3",
+			"name": "Carreau d'arbalète +3",
+			"description": "<p>Cette munition, utilisée par les arbalètes, est généralement faite d'une tige en métal avec une pointe acérée. Elle est magiquement imprégnée.</p>\n<p>Vous avez un bonus aux jets d'attaque et de dégats avec cette munition magique. La munition n'est plus magique après avoir toucher une cible.</p>"
+		},
+		{
+			"id": "Bolt of Slaying",
+			"name": "Carreau tueur",
+			"description": "<p>Un carreau tueur est une munition magique destinée à abattre un type de créature en particulier. Certains sont plus spécifiques que d'autres ; par exemple, il existe des carreaux tueurs de dragons et des carreaux tueurs de dragons bleu. Si une créature appartenant au type, à la race ou au groupe associé à la flèche tueuse subit des dégâts de ce carreau, cette créature doit effectuer un jet de sauvegarde de Constitution DD 17, subissant 6d10 dégâts perforants supplémentaires en cas d'échec, ou la moitié de ces dégâts supplémentaires en cas de réussite.</span></p>\n<p>Une fois qu'un carreau tueur a infligé ses dégâts supplémentaires à une créature, il devient un simple carreau non magique.</span></p>"
+		},
+		{
+			"id": "Crossbow Bolt",
+			"name": "Carreaux d'arbalète",
+			"description": "<p>Cette munition, utilisée par les arbalètes, est généralement faite d'une tige en métal avec une pointe acérée.</p>"
+		},
+		{
+			"id": "Deck of Illusions",
+			"name": "Cartes d'illusion",
+			"description": "<div class=\"description \">L'étui contient un ensemble de cartes en parchemin. Un jeu complet comprend 34 cartes. Un paquet trouvé dans un trésor a généralement perdu 1d20 - 1 cartes.\n<br>La magie de ce paquet de cartes ne fonctionne que si les cartes sont tirées de manière aléatoire (vous pouvez utiliser un jet de cartes à jouer modifié pour simuler ce paquet de cartes magiques). Vous pouvez utiliser une action pour tirer aléatoirement une carte du paquet et la jeter sur le sol en un point situé à 9 mètres de vous maximum.\n<br>Une illusion d'une ou de plusieurs créatures se forme au-dessus de la carte jetée et reste en place jusqu'à ce qu'elle soit dissipée. Une créature illusoire semble réelle, de la bonne taille, et se comporte de la même manière qu'une créature réelle, elle ne peut cependant pas faire de mal. Tant que vous vous trouvez dans un rayon de 36 mètres de la créature illusoire et que vous pouvez la voir, vous pouvez utiliser une action pour la déplacer n'importe où dans un rayon de 9 mètres autour de sa carte. Toute interaction physique avec la créature illusoire révèle qu'il s'agit d'une illusion, car les objets passent au travers. Quelqu'un qui utilise son action pour inspecter visuellement la créature identifie qu'il s'agit d'une illusion en réussissant un jet d'Intelligence (Investigation) DD 15. La créature semble alors translucide.\n<br>L'illusion reste en place jusqu'à ce que la carte soit déplacée ou que l'illusion soit déplacée. Lorsque l'illusion prend fin, l'image sur la carte disparait, et cette carte ne peut plus être réutilisée.\n<br><table><tbody><tr><th>Carte à jouer</th><th>Illusion</th></tr><tr><td>As de cœur</td><td>Un dragon rouge</td></tr><tr><td>Roi de cœur</td><td>Un chevalier et quatre gardes</td></tr><tr><td>Dame de cœur</td><td>Une succube ou un incube</td></tr><tr><td>Valet de cœur</td><td>Un druide</td></tr><tr><td>10 de cœur</td><td>Un géant des nuages</td></tr><tr><td>9 de cœur</td><td>Un ettin</td></tr><tr><td>8 de cœur</td><td>Un gobelours</td></tr><tr><td>7 de cœur</td><td>Un gobelin</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>As de carreau</td><td>Un tyrannoeil</td></tr><tr><td>Roi de carreau</td><td>Un archimage et son apprenti</td></tr><tr><td>Dame de carreau</td><td>Une tormante</td></tr><tr><td>Valet de carreau</td><td>Un assassin</td></tr><tr><td>10 de carreau</td><td>Un géant du feu</td></tr><tr><td>9 de carreau</td><td>Un ogre mage</td></tr><tr><td>8 de carreau</td><td>Un gnoll</td></tr><tr><td>7 de carreau</td><td>Un kobold</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>As de pique</td><td>Une liche</td></tr><tr><td>Roi de pique</td><td>Un prêtre et deux acolytes</td></tr><tr><td>Dame de pique</td><td>Une méduse</td></tr><tr><td>Valet de pique</td><td>Un vétéran de guerre</td></tr><tr><td>10 de pique</td><td>Un géant du givre</td></tr><tr><td>9 de pique</td><td>Un troll</td></tr><tr><td>8 de pique</td><td>Un hobgobelin</td></tr><tr><td>7 de pique</td><td>Un gobelin</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>As de trèfle</td><td>Un golem de fer</td></tr><tr><td>Roi de trèfle</td><td>Trois brigands et leur capitaine</td></tr><tr><td>Dame de trèfle</td><td>Une érinye</td></tr><tr><td>Valet de trèfle</td><td>Un berserker</td></tr><tr><td>10 de trèfle</td><td>Un géant des collines</td></tr><tr><td>9 de trèfle</td><td>Un ogre</td></tr><tr><td>8 de trèfle</td><td>Un orque</td></tr><tr><td>7 de trèfle</td><td>Un kobold</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>Jokers (2)</td><td>Vous (le propriétaire des cartes)</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Deck of Many Things",
+			"name": "Cartes merveilleuses",
+			"description": "<div class=\"description \">Généralement découvert dans un boitier ou une pochette, ce jeu de carte contient un certain nombre de cartes faites en ivoire ou en vélin. La plupart (75 %) de ces jeux de carte ne contiennent que 13 cartes, mais les autres en comptent 22.\n<br>Avant de tirer une carte, vous devez annoncer combien de cartes vous comptez tirer puis vous devez les tirer aléatoirement (vous pouvez utiliser un jeu de cartes à jouer modifié pour simuler ce paquet de cartes magiques). Toute carte tirée en plus du nombre annoncé n'a aucun effet. Pour les autres, dès que vous tirez une carte du paquet, sa magie prend effet. Après que vous ayez tiré une carte, vous avez une heure pour tirer la suivante. Si vous échouez à tirer le nombre annoncé de cartes, le nombre de cartes restantes s'envole du paquet d'elles-mêmes et prennent effet toutes en même temps.\n<br>Une fois qu'une carte est tirée, elle disparaît. Et, à moins que la carte ne soit le Fou ou le Bouffon, elle réapparaît dans le paquet, ce qui permet de piocher deux fois la même carte.\n<br><table><tbody><tr><th>Carte à jouer</th><th>Carte</th></tr><tr><td>As de carreau</td><td>Le Vizir*</td></tr><tr><td>Roi de carreau</td><td>Le Soleil</td></tr><tr><td>Dame de carreau</td><td>La Lune</td></tr><tr><td>Valet de carreau</td><td>L'Étoile</td></tr><tr><td>2 de carreau</td><td>La Comète*</td></tr><tr><td>As de cœur</td><td>Les Parques*</td></tr><tr><td>Roi de cœur</td><td>Le Trône</td></tr><tr><td>Dame de cœur</td><td>La Clef</td></tr><tr><td>Valet de cœur</td><td>Le Chevalier</td></tr><tr><td>2 de cœur</td><td>Le Joyau*</td></tr><tr><td>As de trèfle</td><td>Les Griffes*</td></tr><tr><td>Roi de trèfle</td><td>Le Néant</td></tr><tr><td>Dame de trèfle</td><td>Les Flammes</td></tr><tr><td>Valet de trèfle</td><td>Le Crâne</td></tr><tr><td>2 de trèfle</td><td>L'Idiot*</td></tr><tr><td>As de pique</td><td>Le Donjon*</td></tr><tr><td>Roi de pique</td><td>La Ruine</td></tr><tr><td>Dame de pique</td><td>Euryale</td></tr><tr><td>Valet de pique</td><td>Le Traître</td></tr><tr><td>2 de pique</td><td>La Balance*</td></tr><tr><td>Joker noir</td><td>Le Fou*</td></tr><tr><td>Joker rouge</td><td>Le Bouffon</td></tr></tbody></table>\n<br>* ne peuvent être trouvées que dans un jeu de 22 cartes.<br>\n<br><strong>La Balance</strong>. Votre esprit est complètement altéré, ce qui modifie votre alignement de manière radicale. Les loyaux deviennent chaotiques, les bons deviennent mauvais, et vice versa. Si vous êtes neutre ou non-aligné, cette carte n'a aucun effet sur vous.\n<br><strong>Le Bouffon</strong>. Vous gagnez 10 000 XP, ou vous pouvez tirer deux cartes supplémentaires par rapport au nombre de cartes annoncé.\n<br><strong>Le Chevalier</strong>. Vous gagnez les services d'un guerrier de niveau 4 qui apparaît dans un espace de votre choix dans un rayon de 9 mètres autour de vous. Le guerrier est de la même race que vous et vous sert loyalement jusqu'à sa mort, persuadé que les Parques ont lié son destin au vôtre. Vous contrôlez ce personnage.\n<br><strong>La Clef</strong>. Une arme magique rare, ou d'une rareté supérieure, dont vous avez la maîtrise, apparaît dans vos mains. Le MD choisit l'arme en question.\n<br><strong>La Comète</strong>. Si vous terrassez à vous seul le prochain monstre ou groupe de monstres que vous rencontrez, vous gagnez suffisamment de points de d'expérience pour gagner un niveau. Sinon cette carte n'a aucun effet.\n<br><strong>Le Crâne</strong>. Vous invoquez un <a href=\"https://www.aidedd.org/dnd/monstres.php?vf=avatar-de-la-mort\">avatar de la mort</a>, un squelette humanoïde fantomatique vêtu d'une robe noire en lambeaux et tenant une faux spectrale. Il apparaît dans un emplacement du choix du MD se trouvant à 3 mètres ou moins de vous et vous attaque, avertissant tout le monde que vous feriez mieux de remporter seul ce combat. L'avatar se bat jusqu'à ce que vous mourriez ou jusqu'à ce qu'il tombe à 0 point de vie, après quoi il disparaît. Si quelqu'un cherche à vous aider, il invoque malgré lui son propre avatar de la mort. Une créature vaincue par un avatar de la mort ne peut pas être ramenée à la vie.\n<br><strong>Le Donjon</strong>. Vous disparaissez et êtes enterré en état d'animation suspendue dans une sphère extradimensionnelle. Tout ce que vous portez ou transportez reste dans l'espace que vous occupiez au moment de votre disparition. Vous restez emprisonné jusqu'à ce qu'on vous trouve et vous sorte de cette sphère. Vous ne pouvez pas être localisé à l'aide de divinations magiques, mais un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> peut révéler la localisation de votre prison. Vous ne tirez pas d'autres cartes.\n<br><strong>L'Étoile</strong>. Augmente l'une de vos valeurs de caractéristique de 2. Cette valeur peut dépasser 20, mais ne peut pas dépenser 24.\n<br><strong>Euryale</strong>. Le visage de méduse représenté sur la carte vous maudit. Vous subissez un malus de -2 aux jets de sauvegarde tant que vous êtes maudit de la sorte. Seul un dieu ou la magie de la carte Les Parques peut mettre un terme à cette malédiction.\n<br><strong>Les Flammes</strong>. Une puissance maléfique devient votre ennemi. Ce mal recherche votre ruine et empoisonne votre vie, savourant de vous voir souffrir avant de tenter de vous abattre. Cette hostilité dure jusqu'à ce que vous, ou le la puissance maléfique, mourriez.\n<br><strong>Le Fou</strong>. Vous perdez 10 000 XP, jeter cette carte, et tirez de nouveau une carte du paquet. Le Fou et cette nouvelle carte comptent comme une seule carte tirée en ce qui concerne le nombre total de carte tirée. Si perdre un tel montant de XP devait vous faire perdre un niveau, vous perdez à la place juste assez de XP pour rester à votre niveau actuel.\n<br><strong>Les Griffes</strong>. Tout objet magique que vous portez ou transportez est désintégré. Les artéfacts en votre possession ne sont pas détruits mais ils disparaissent.\n<br><strong>L'Idiot</strong>. Votre valeur d'Intelligence est réduite de 1d4 + 1 de manière permanente (pour une valeur minimum de 1). Vous pouvez tirer une carte supplémentaire par rapport au nombre de cartes annoncé.\n<br><strong>Le Joyau</strong>. Vingt-cinq bijoux d'une valeur de 2 000 po chacun ou cinquante joyaux d'une valeur de 1 000 po chacun apparaissent à vos pieds.\n<br><strong>La Lune</strong>. Vous obtenez la capacité de lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> 1d3 fois.\n<br><strong>Le Néant</strong>. Cette carte noire présage bien des désastres. Votre âme est extirpée de votre corps et retenue prisonnière dans un objet localisé dans un lieu du choix du MD. Un ou plusieurs êtres très puissants gardent l'endroit. Tant que votre âme est piégée de la sorte, votre corps est incapable d'agir. Un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> ne peut pas vous rendre votre âme, mais le sort révèle le lieu où l'objet est conservé. Vous ne tirez plus d'autres cartes.\n<br><strong>Les Parques</strong>. La trame de la réalité se dénoue et se tisse à nouveau, vous permettant d'échapper ou d'effacer un évènement comme s'il ne s'était jamais produit. Vous pouvez utiliser la magie de cette carte aussitôt après l'avoir tiré ou à n'importe quel moment avant votre décès.\n<br><strong>La Ruine</strong>. Toute forme de richesse (à l'exception des objets magiques) que vous portez ou transportez est perdue. Les biens transportables disparaissent. Vos affaires et entreprises, vos bâtiments, et vos terres sont perdus de la manière qui modifie le moins possible la réalité. Tout document qui prouve que vous posséderiez quelque chose ayant disparu avec cette carte disparaît également.\n<br><strong>Le Soleil</strong>. Vous gagnez 50 000 XP, et un objet merveilleux (que le MD détermine aléatoirement) apparaît dans vos mains.\n<br><strong>Le Traître</strong>. Un Personnage-Non-Joueur du choix du MD devient hostile envers vous. L'identité de votre nouvel ennemi reste inconnue jusqu'à ce que le PNJ ou quelqu'un d'autre la révèle. Seul un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> ou une intervention divine peut mettre un terme à l'hostilité du PNJ à votre encontre.\n<br><strong>Le Trône</strong>. Vous gagnez la maîtrise de la compétence Persuasion, et vous doublez votre bonus de maîtrise sur les jets effectués avec cette compétence. De plus, vous devenez le propriétaire légitime d'un petit fortin quelque part dans le monde. Cependant, le fortin est actuellement occupé par des monstres que vous devrez vaincre pour faire valoir vos droits sur votre fortin.\n<br><strong>Le Vizir</strong>. À n'importe quel moment que vous choisissez dans l'année qui suit le tirage de cette carte, vous pouvez poser une question pendant que vous méditez, et recevoir mentalement la réponse juste à cette question. En plus de donner des informations, la réponse peut vous aider à résoudre une énigme ou tout autre dilemme. En d'autres mots, la connaissance vous parvient avec la sagesse nécessaire pour vous en servir.\n<br></div>"
+		},
+		{
+			"id": "Belt of Hill Giant Strength",
+			"name": "Ceinturon de force de géant des collines",
+			"description": "<div class=\"description \">Tant que vous portez ce ceinturon, votre valeur de Force change pour celle conférée par le ceinturon. L'objet n'a aucun effet sur vous si votre Force sans la ceinture est égale ou supérieure à celle du ceinturon.\n<br>Six variétés de ceinturon existent, chacune ayant sa propre rareté et correspondant à un des six types de géant véritable. Le <em>ceinturon de force du géant des pierres</em> et le <em>ceinturon de force du géant du givre</em> semblent différents, mais ils ont les mêmes effets.\n<br><table><tbody><tr><th>Type</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Rare</td></tr><tr><td>Géant des pierre/du givre</td><td class=\"center\">23</td><td>Très rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Très rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Légendaire</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Belt of Cloud Giant Strength",
+			"name": "Ceinturon de force de géant des nuages",
+			"description": "<div class=\"description \">Tant que vous portez ce ceinturon, votre valeur de Force change pour celle conférée par le ceinturon. L'objet n'a aucun effet sur vous si votre Force sans la ceinture est égale ou supérieure à celle du ceinturon.\n<br>Six variétés de ceinturon existent, chacune ayant sa propre rareté et correspondant à un des six types de géant véritable. Le <em>ceinturon de force du géant des pierres</em> et le <em>ceinturon de force du géant du givre</em> semblent différents, mais ils ont les mêmes effets.\n<br><table><tbody><tr><th>Type</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Rare</td></tr><tr><td>Géant des pierre/du givre</td><td class=\"center\">23</td><td>Très rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Très rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Légendaire</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Belt of Stone Giant Strength",
+			"name": "Ceinturon de force de géant des pierres",
+			"description": "<div class=\"description \">Tant que vous portez ce ceinturon, votre valeur de Force change pour celle conférée par le ceinturon. L'objet n'a aucun effet sur vous si votre Force sans la ceinture est égale ou supérieure à celle du ceinturon.\n<br>Six variétés de ceinturon existent, chacune ayant sa propre rareté et correspondant à un des six types de géant véritable. Le <em>ceinturon de force du géant des pierres</em> et le <em>ceinturon de force du géant du givre</em> semblent différents, mais ils ont les mêmes effets.\n<br><table><tbody><tr><th>Type</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Rare</td></tr><tr><td>Géant des pierre/du givre</td><td class=\"center\">23</td><td>Très rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Très rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Légendaire</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Belt of Storm Giant Strength",
+			"name": "Ceinturon de force de géant des tempêtes",
+			"description": "<div class=\"description \">Tant que vous portez ce ceinturon, votre valeur de Force change pour celle conférée par le ceinturon. L'objet n'a aucun effet sur vous si votre Force sans la ceinture est égale ou supérieure à celle du ceinturon.\n<br>Six variétés de ceinturon existent, chacune ayant sa propre rareté et correspondant à un des six types de géant véritable. Le <em>ceinturon de force du géant des pierres</em> et le <em>ceinturon de force du géant du givre</em> semblent différents, mais ils ont les mêmes effets.\n<br><table><tbody><tr><th>Type</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Rare</td></tr><tr><td>Géant des pierre/du givre</td><td class=\"center\">23</td><td>Très rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Très rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Légendaire</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Belt of Fire Giant Strength",
+			"name": "Ceinturon de force de géant du feu",
+			"description": "<div class=\"description \">Tant que vous portez ce ceinturon, votre valeur de Force change pour celle conférée par le ceinturon. L'objet n'a aucun effet sur vous si votre Force sans la ceinture est égale ou supérieure à celle du ceinturon.\n<br>Six variétés de ceinturon existent, chacune ayant sa propre rareté et correspondant à un des six types de géant véritable. Le <em>ceinturon de force du géant des pierres</em> et le <em>ceinturon de force du géant du givre</em> semblent différents, mais ils ont les mêmes effets.\n<br><table><tbody><tr><th>Type</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Rare</td></tr><tr><td>Géant des pierre/du givre</td><td class=\"center\">23</td><td>Très rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Très rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Légendaire</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Belt of Frost Giant Strength",
+			"name": "Ceinturon de force de géant du givre",
+			"description": "<div class=\"description \">Tant que vous portez ce ceinturon, votre valeur de Force change pour celle conférée par le ceinturon. L'objet n'a aucun effet sur vous si votre Force sans la ceinture est égale ou supérieure à celle du ceinturon.\n<br>Six variétés de ceinturon existent, chacune ayant sa propre rareté et correspondant à un des six types de géant véritable. Le <em>ceinturon de force du géant des pierres</em> et le <em>ceinturon de force du géant du givre</em> semblent différents, mais ils ont les mêmes effets.\n<br><table><tbody><tr><th>Type</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Rare</td></tr><tr><td>Géant des pierre/du givre</td><td class=\"center\">23</td><td>Très rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Très rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Légendaire</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Belt of Dwarvenkind",
+			"name": "Ceinturon des nains",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de cette ceinture, vous gagnez les bénéfices suivants :\n<br>• Votre valeur de Constitution augmente de 2, pour un maximum de 20.\n<br>• Vous avez un avantage aux jets de Charisme (Persuasion) effectués lorsque vous interagissez avec des nains.\n<br>De plus, tant que vous êtes lié à la ceinture, vous avez 50 % de chance, chaque jour au lever du soleil, qu'une barbe vous pousse (si vous êtes capable d'en avoir une), ou que votre barbe soit devenue visiblement plus épaisse si vous en avez déjà une.\n<br>Si vous n'êtes pas un nain, vous gagnez en plus les bénéfices suivants tant que vous portez ce ceinturon :\n<br>• Vous avez un avantage aux jets de sauvegarde contre les poisons, et vous avez la résistance contre les dégâts de poison.\n<br>• Vous obtenez la vision dans le noir à 36 mètres.\n<br>• Vous pouvez parler, lire, et écrire le nain.\n<br></div>"
+		},
+		{
+			"id": "Chain (10 feet)",
+			"name": "Chaîne (3 m)",
+			"description": "<p>Une chaîne dispose de 10 pv. Elle peut être brisée en réussissant un jet de Force de DD 20.</span></p>"
+		},
+		{
+			"id": "Shawm",
+			"name": "Chalemie",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Hat of Disguise",
+			"name": "Chapeau de déguisement",
+			"description": "<p><em>Tant que vous êtes équipé de ce chapeau, vous pouvez à volonté, par une action, l'utiliser pour lancer le sort déguisement. Le sort prend fin si le couvre-chef est retiré.</p>"
+		},
+		{
+			"id": "Caltrops",
+			"name": "Chausse-trappes (sac de 20)",
+			"description": "<p>Au prix d'une action, vous pouvez étaler le contenu d'un sac de chausse-trappes pour couvrir une zone de 1,50 m x 1,50 m. Toute créature qui entre dans la zone doit réussir un jet de sauvegarde de Dextérité DD 15 ou mettre fin à son mouvement et prendre 1 point de dégâts perforants. Jusqu'à ce que la créature retrouve au moins 1 point de vie, sa vitesse de marche est réduite de 3 mètres. Une créature se déplaçant à travers la zone à la moitié de sa vitesse n'a pas besoin de faire le jet de sauvegarde.</span></p>"
+		},
+		{
+			"id": "Slippers of Spider Climbing",
+			"name": "Chaussons de pattes d'araignée",
+			"description": "<div class=\"description \">Lorsque vous portez ces chaussures légères, vous pouvez monter, descendre et parcourir des surfaces verticales ou la tête à l'envers aux plafonds, tout en ayant les mains libres. Votre vitesse d'escalade est égale à votre vitesse de marche. Cependant, les chaussons ne vous permettent pas de vous déplacer de cette façon sur une surface glissante, comme sur de la glace ou de l'huile.\n<br></div>"
+		},
+		{
+			"id": "Adamantine Chain Shirt",
+			"name": "Chemise de maille en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Chain Shirt",
+			"name": "Chemise de mailles",
+			"description": "<p>Fait d'anneaux métalliques entrecroisés, la chemise de mailles est utilisée entre des couches de vêtements ou de cuir. Cette armure offre une protection modeste pour le haut du corps et permet au son provoqué par les anneaux frottant l'un contre l'autre d'être atténué par les couches de vêtements extérieures.</p>"
+		},
+		{
+			"id": "Chain Shirt +1",
+			"name": "Chemise de mailles +1",
+			"description": "Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Chain Shirt +2",
+			"name": "Chemise de mailles +2",
+			"description": "Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Chain Shirt +3",
+			"name": "Chemise de mailles +3",
+			"description": "Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Mithral Chain Shirt",
+			"name": "Chemise de mailles de mithral",
+			"description": "Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Chain Shirt Armor of Resistance",
+			"name": "chemise de mailles de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Signet Ring",
+			"name": "Chevalière",
+			"description": "<p>Une bague avec un design spécifique pour indiquer l'appartenance et le rang au sein d'une maison ou d'une organisation.</p>"
+		},
+		{
+			"id": "Tankard",
+			"name": "chope",
+			"description": "<p>Il s'agit d'une forme d'ustensile de boisson consistant en une grande tasse à boire, à peu près cylindrique, avec une seule anse.</span></p>"
+		},
+		{
+			"id": "Candle of Invocation",
+			"name": "Cierge d'invocation",
+			"description": "<div class=\"description \">Cette mince chandelle est dédiée à une divinité et partage l'alignement de cette divinité. L'alignement du cierge peut être détecté avec un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-du-mal-et-du-bien\">détection du mal et du bien</a></em>. Le MD choisit le dieu et l'alignement qui lui est associé ou détermine l'alignement du cierge de manière aléatoire.\n<br><table><tbody><tr><th class=\"center\">d20</th><th>Alignement</th></tr><tr><td class=\"center\">1-2</td><td>Chaotique mauvais</td></tr><tr><td class=\"center\">3-4</td><td>Chaotique neutre</td></tr><tr><td class=\"center\">5-7</td><td>Chaotique bon</td></tr><tr><td class=\"center\">8-9</td><td>Neutre mauvais</td></tr><tr><td class=\"center\">10-11</td><td>Neutre</td></tr><tr><td class=\"center\">12-13</td><td>Neutre bon</td></tr><tr><td class=\"center\">14-15</td><td>Loyal mauvais</td></tr><tr><td class=\"center\">16-17</td><td>Loyal neutre</td></tr><tr><td class=\"center\">18-20</td><td>Loyal bon</td></tr></tbody></table>\n<br>La magie du cierge est activée lorsque le cierge est allumé, ce qui nécessite une action. Après avoir brûlé pendant 4 heures, le cierge est détruit. Vous pouvez souffler sa flamme avant pour pouvoir l'utiliser plus tard. Déduisez la durée de combustion déjà écoulée (arrondie à la minute supérieure) de la durée totale maximale.\n<br>Tant qu'il est allumé le cierge émet une lumière faible dans un rayon de 9 mètres. Toute créature se trouvant dans cette lumière et partageant le même alignement que le cierge effectue ses jets d'attaque, de sauvegarde, et de caractéristique avec un avantage. De plus, un clerc ou un druide se trouvant dans cette lumière et partageant l'alignement du cierge peut lancer un sort de niveau 1 qu'il a préparé sans dépenser l'emplacement de sort associé, à la condition que ce sort de niveau 1 soit lancé en utilisant un emplacement de niveau 1.\n<br>Sinon, lorsque vous allumez le cierge pour la première fois, vous pouvez lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=portail\">portail</a></em> grâce à lui. Le cierge est cependant détruit lorsqu'il est utilisé de la sorte.\n<br></div>"
+		},
+		{
+			"id": "Scimitar",
+			"name": "Cimeterre",
+			"description": "<p>Cette lame incurvée est large près du manche mais s'arque et se rétrécit en une pointe.</p>"
+		},
+		{
+			"id": "Scimitar +1",
+			"name": "Cimeterre +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Scimitar +2",
+			"name": "Cimeterre +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Scimitar +3",
+			"name": "Cimeterre +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Flame Tongue Scimitar",
+			"name": "Cimeterre ardent",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action bonus pour prononcer le mot de commande de l'épée, ce qui fait jaillir des flammes de la lame. Ces flammes génèrent une lumière vive dans un rayon de 12 mètres et une lumière faible sur 12 mètres supplémentaires. Tant que l'épée est en feu, elle inflige 2d6 dégâts de feu supplémentaires à toute cible qu'elle touche. Les flammes perdurent jusqu'à ce que vous utilisiez une action bonus pour prononcer le mot de commande de nouveau, ou jusqu'à ce que vous lâchiez l'épée ou la rengainiez.\n<br></div>"
+		},
+		{
+			"id": "Dancing Scimitar",
+			"name": "Cimeterre Dansant",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous pouvez utiliser une action bonus pour lancer cette épée magique en l'air et prononcer son mot de commande. Elle se met alors à flotter et s'envole à une distance maximum de 9 mètres, attaquant la créature de votre choix située dans un rayon de 1,50 mètre autour d'elle. L'épée utilise votre jet d'attaque et votre modificateur de caractéristique aux jets de dégâts.</p>\n<p>Tant que l'épée flotte dans les airs, vous pouvez utiliser une action bonus pour l'envoyer voler sur une distance maximum de 9 mètres jusqu'à un emplacement situé dans un rayon de 9 mètres autour de vous. Lors de cette action bonus, vous pouvez demander à l'épée d'attaquer une créature située dans un rayon de 1,50 mètre autour d'elle.</p>\n<p>Une fois que l'épée a attaqué pour la quatrième fois, elle vole sur un maximum de 9 mètres et tente de retourner dans votre main. Si vous avez les deux mains prises, elle tombe à vos pieds. Si l'épée ne dispose d'aucun chemin d'accès pour vous rejoindre, elle se rapproche de vous autant que possible et tombe à terre. Elle cesse également de flotter dans les airs si vous l'attrapez ou si vous vous éloignez à plus de 9 mètres d'elle.</p>"
+		},
+		{
+			"id": "Frost Brand Scimitar",
+			"name": "Cimeterre de givre",
+			"description": "<div class=\"description \">Lorsque vous touchez avec une attaque utilisant cette épée magique, la cible subit 1d6 dégâts de froid supplémentaires. En outre, tant que vous tenez l'épée, vous avez la résistance aux dégâts de feu. Dans des températures de congélation, la lame émet en lumière vive dans un rayon de 3 mètres et une lumière faible sur 3 mètres supplémentaires.\n<br>Lorsque vous dégainez cette arme, vous pouvez éteindre toutes les flammes non magiques dans un rayon de 9 mètres autour de vous. Cette propriété ne peut pas être utilisée plus d'une fois par heure.\n<br></div>"
+		},
+		{
+			"id": "Holy Avenger Scimitar",
+			"name": "Cimeterre de justice",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 à l'attaque et aux dégâts réalisés avec cette arme magique. Lorsque vous touchez un fiélon ou un mort-vivant avec elle, cette créature subit 2d10 dégâts radiants supplémentaires.\n<br>Tant que vous tenez l'épée dégainée, elle crée une aura dans un rayon de 3 mètres autour de vous. Vous et toutes les créatures qui vous sont amicales dans l'aura ont un avantage aux jets de sauvegarde contre les sorts et autres effets magiques. Si vous avez 17 ou plus niveaux dans la classe de paladin, le rayon de l'aura augmente de 3 mètres.\n<br></div>"
+		},
+		{
+			"id": "Scimitar of Speed",
+			"name": "Cimeterre de rapidité",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, vous pouvez à chacun de vos tours effectuer une attaque avec cette arme en utilisant votre action bonus.\n<br></div>"
+		},
+		{
+			"id": "Defender Scimitar",
+			"name": "Cimeterre Gardienne",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>La première fois que vous attaquez avec l'épée au cours de chacun de vos tours, vous pouvez transférer tout ou partie du bonus de l'épée vers votre Classe d'Armure, plutôt que d'utiliser ce bonus sur vos attaques de ce tour. Par exemple, vous pourriez réduire le bonus à votre jet d'attaque et de dégâts à +1 et ainsi gagner un bonus de +2 à votre CA. La modification du bonus reste effective jusqu'au début de votre prochain tour, mais vous devez bien entendu avoir l'épée en main pour bénéficier de son bonus à la CA.\n<br></div>"
+		},
+		{
+			"id": "Scimitar of Wounding",
+			"name": "Cimeterre incisif",
+			"description": "<div class=\"description \">Les points de vie perdus à cause de dégâts infligés par cette arme ne peuvent être récupérés que par le biais d'un repos court ou long, mais pas à l'aide de capacités de régénération, de pouvoirs magiques, de sorts, ou de tout autre moyen.\n<br>Une fois par tour, lorsque vous touchez une créature avec une attaque utilisant cette arme magique, vous pouvez blesser profondément la cible. Au début de chacun des tours de la créature blessée, celle-ci subit 1d4 dégâts nécrotiques pour chaque blessure profonde que vous lui avez infligée, et elle peut ensuite effectuer un jet de sauvegarde de Constitution DD 15, mettant un terme à l'effet de toutes les blessures profondes que vous lui avez infligées en cas de réussite. Sinon, la créature blessée profondément, ou une créature se trouvant à 1,50 mètre d'elle, peut utiliser son action pour effectuer un jet de Sagesse (Médecine) DD 15, mettant un terme à l'effet des blessures profondes qui l'affectent en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Luck Blade Scimitar",
+			"name": "Cimeterre Lame porte-bonheur",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. Tant que vous portez l'épée sur vous, vous bénéficiez également d'un bonus de +1 aux jets de sauvegarde.\n<br><strong>Chance</strong>. Si vos portez l'épée sur vous, vous pouvez invoquer sa chance (aucune action n'est requise) pour relancer un jet d'attaque, de caractéristique ou de sauvegarde dont le résultat vous déplaît. Vous devez accepter le nouveau résultat. Cette propriété ne peut pas être utilisée de nouveau avant le prochain lever du soleil.\n<br><strong>Souhait</strong>. L'épée possède 1d4 - 1 charges. Tant que vous la tenez en main, vous pouvez utiliser une action pour dépenser une charge et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em>. Cette propriété ne peut plus être utilisée avant la prochaine aube. L'épée perd cette propriété si elle n'a plus de charges.\n<br></div>"
+		},
+		{
+			"id": "Scimitar of Sharpness",
+			"name": "Cimeterre tranchant",
+			"description": "<div class=\"description \">Lorsque vous attaquez un objet avec cette épée magique et le touchez, les dés de dégâts de votre arme sont maximisés contre cette cible.\n<br>Lorsque vous attaquez une créature avec cette épée et obtenez un 20 naturel à votre jet d'attaque, la cible subit 14 dégâts tranchants supplémentaires. Puis lancez un autre d20. Si vous obtenez de nouveau un 20 naturel, vous amputez la cible de l'un de ses membres, l'effet d'une telle perte est déterminé par le MD. Si la créature ne possède aucun membre à sectionner, vous tranchez une portion de son corps à la place.\n<br>De plus, vous pouvez prononcer le mot de commande de la lame pour qu'elle émette une lumière vive dans un rayon de 3 mètres et une lumière faible dans un rayon supplémentaire de 3 mètres. Répétez le mot de commande ou rengainez l'épée pour éteindre la lumière.\n<br></div>"
+		},
+		{
+			"id": "Dragon Slayer Scimitar",
+			"name": "Cimeterre Tueur de dragons",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 à l'attaque et aux dégâts fait avec cette arme magique.\n<br>Si vous touchez un dragon avec cette arme, le dragon subit 3d6 dégâts supplémentaires du type de l'arme. Pour cette arme, le terme « dragon » se réfère à toute créature qui possède le type dragon, y compris les tortues dragons et les wivernes.\n<br></div>"
+		},
+		{
+			"id": "Giant Slayer Scimitar",
+			"name": "Cimeterre Tueur de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Scimitar",
+			"name": "Cimeterre vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Scimitar of Life Stealing",
+			"name": "Cimeterre voleur de vie",
+			"description": "<div class=\"description \">Lorsque vous attaquez une créature avec cette arme magique et obtenez un 20 au jet d'attaque, la cible subit 10 dégâts nécrotiques supplémentaires, à condition qu'elle ne soit pas une créature artificielle ou un mort-vivant. Vous gagnez un nombre de points de vie temporaires égal aux dégâts supplémentaires infligés.\n<br></div>"
+		},
+		{
+			"id": "Nine Lives Stealer Scimitar",
+			"name": "Cimeterre Voleur des neuf vies",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>L'épée possède 1d8 + 1 charges. Quand vous obtenez un coup critique contre une créature à qui il reste moins de 100 points de vies, celle-ci doit réussir un jet de sauvegarde de Constitution DD 15 ou être tuée instantanément, sa force vitale étant arrachée de son corps (les morts-vivants et les créatures artificielles sont immunisés). L'épée perd 1 charge si la créature est tuée. Elle perd cette propriété une fois toutes les charges épuisées.\n<br></div>"
+		},
+		{
+			"id": "Vorpal Scimitar",
+			"name": "Cimeterre vorpal",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, l'arme ignore la résistance aux dégâts tranchants.\n<br>Lorsque vous attaquez une créature qui possède au moins une tête avec cette arme et que vous obtenez un 20 naturel sur votre jet d'attaque, vous décapitez la créature de l'une de ses têtes. La créature meurt si elle ne peut pas survivre après avoir perdu sa tête. Une créature est immunisée à cet effet si elle est immunisée aux dégâts tranchants, n'a pas besoin de sa tête, ou n'a pas de tête, possède des actions légendaires, ou si le MD décide que cette créature est trop grosse pour que sa tête puisse être amputée avec cette arme. De telles créatures subissent à la place 6d8 dégâts tranchants supplémentaires de ce coup.\n<br></div>"
+		},
+		{
+			"id": "Sealing Wax",
+			"name": "Cire à cacheter",
+			"description": "<p>Matériel à base de cire permettant d'appliquer un sceau qui, après avoir fondu, durcit rapidement et reste difficile à séparer sans altération notable.</p>"
+		},
+		{
+			"id": "Splint Armor",
+			"name": "Clibanion",
+			"description": "<p>Cette armure est faite d'étroites bandes verticales de métal rivetées sur un support de cuir qui est porté sur un rembourrage de tissu. Une cotte de mailles souple protège les articulations.</p>"
+		},
+		{
+			"id": "Splint Armor +1",
+			"name": "Clibanion +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Splint Armor +2",
+			"name": "Clibanion +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Splint Armor +3",
+			"name": "Clibanion +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Mithral Splint Armor",
+			"name": "Clibanion de mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Splint Armor of Resistance",
+			"name": "Clibanion de Résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Adamantine Splint Armor",
+			"name": "Clibanion en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, Un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Bell",
+			"name": "Cloche",
+			"description": "<p>Une petite cloche pour que vous la fassiez sonner.</p>"
+		},
+		{
+			"id": "Chest",
+			"name": "Coffre",
+			"description": "<p>Un coffre contient 150 kg (~0.5 m3) de matériel.</span></p>"
+		},
+		{
+			"id": "Sovereign Glue",
+			"name": "Colle universelle",
+			"description": "<div class=\"description \">Cette visqueuse substance d'un blanc laiteux peut créer un lien adhésif permanent entre deux objets. Elle doit être stockée dans un pot ou une flasque dont l'intérieur a été au préalable enduit d'une <em>huile d'insaisissabilité</em>. Lorsqu'il est découvert le contenant renferme 1d6 + 1 doses.\n<br>Une dose de glu peut recouvrir une surface carrée de 30 centimètres de côté. La glu sèche en 1 minute après application. Dès lors, le lien qu'elle crée ne peut être rompu que par l'application d'un <em>solvant universel</em> ou d'une <em>huile éthérée</em> ou grâce au sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Necklace of Adaptation",
+			"name": "Collier d'adaptation",
+			"description": "<div class=\"description \">Lorsque vous portez ce collier, vous pouvez respirer normalement dans tout environnement, et vous avez un avantage aux jets de sauvegarde contre les vapeurs et gaz nocifs (comme les effets de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=nuage-mortel\">nuage mortel</a></em> et de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=nuage-puant\">nuage puant</a></em>, les poisons inhalés et les armes de souffle de certains dragons).\n<br></div>"
+		},
+		{
+			"id": "Necklace of Fireballs",
+			"name": "Collier de boules de feu",
+			"description": "<div class=\"description \">Ce collier possède 1d6 + 3 perles. Vous pouvez utiliser une action pour détacher une perle et la jeter jusqu'à 18 mètres de distance. Quand elle atteint la fin de sa trajectoire, la perle explose comme une <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> de niveau 3 (sauvegarde DD 15).\n<br>Vous pouvez lancer plusieurs perles, ou même l'ensemble du collier, par une action. Lorsque vous procédez ainsi, augmentez le niveau de la <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> de 1 pour chaque perle au-delà de la première.\n<br></div>"
+		},
+		{
+			"id": "Necklace of Prayer Beads",
+			"name": "Collier de perles de prière",
+			"description": "<div class=\"description \">Ce collier possède 1d4 + 2 perles magiques fabriquées à partir d'aigue-marine, de perle noire ou de topaze. Il comporte également de nombreuses perles non magiques fabriquées à partir de pierres telles que l'ambre, l'héliotrope, la citrine, le corail, le jade, la perle ou le quartz. Si une perle magique est retirée du collier, celle-ci perd sa magie.\n<br>Six types de perles magiques existent. Le MD décide le type de chaque perle du collier ou le détermine de façon aléatoire. Un collier peut avoir plus d'une perle de même type. Pour en utiliser une, vous devez porter le collier. Chaque perle contient un sort que vous pouvez lancer à partir d'elle par une action bonus (en utilisant le DD de sauvegarde de vos sorts si une sauvegarde est nécessaire). Une fois que le sort d'une perle magique est lancé, cette perle ne peut plus être utilisée à nouveau jusqu'au prochain lever du soleil.\n<br><table><tbody><tr><th class=\"center\">d20</th><th>Perle de ...</th><th>Sort</th></tr><tr><td class=\"center\">1–6</td><td>Bénédiction</td><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=benediction\">bénédiction</a></em></td></tr><tr><td class=\"center\">7–12</td><td>Soins</td><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=soins\">soins</a></em> (niveau 2) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=restauration-partielle\">restauration partielle</a></em></td></tr><tr><td class=\"center\">13-16</td><td>Faveur</td><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=restauration-superieure\">restauration supérieure</a></em></td></tr><tr><td class=\"center\">17-18</td><td>Châtiment</td><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=chatiment-lumineux\">châtiment lumineux</a></em></td></tr><tr><td class=\"center\">19</td><td>Invocation</td><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=allie-planaire\">allié planaire</a></em></td></tr><tr><td class=\"center\">20</td><td>Vent</td><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=marche-sur-le-vent\">marche sur le vent</a></em></td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Horn",
+			"name": "Cor",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Horn of Blasting",
+			"name": "Cor de destruction",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour prononcer le mot de commande du cor puis souffler dedans. Le cor produit alors une explosion tonitruante dans un cône de 9 mètres et qui est audible à 180 mètres à la ronde. Chaque créature présente dans le cône doit effectuer un jet de sauvegarde de Constitution DD 15. En cas d'échec, une créature subit 5d6 dégâts de tonnerre et est assourdie pendant 1 minute. En cas de réussite au jet, une créature ne subit que la moitié des dégâts et n'est pas assourdie. Les créatures et les objets faits de verre ou de cristal ont un désavantage à leur jet de sauvegarde et subissent 10d6 dégâts de tonnerre au lieu de 5d6.\n<br>Chaque utilisation de la magie du cor a 20 % de risque d'entraîner sa propre explosion. L'explosion inflige 10d6 dégâts de feu à celui qui souffle dedans et détruit le cor.\n<br></div>"
+		},
+		{
+			"id": "Iron Horn of Valhalla",
+			"name": "Cor de fer du Valhalla",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour souffler dans ce cor. En réponse, des esprits guerriers venant du Valhalla apparaissent dans un rayon de 18 mètres autour de vous. Ils utilisent les statistiques du <a href=\"https://www.aidedd.org/dnd/monstres.php?vf=berserker\">berserker</a>. Ils retournent au Valhalla au bout d'une heure ou lorsqu'ils tombent à 0 point de vie. Une fois que vous avez utilisé le cor, il ne peut pas être réutilisé avant que 7 jours ne se soient écoulés.\n<br>On connait à ce jour l'existence de quatre types de cor du Valhalla, chacun fin d'un métal différent. Le type du cor détermine combien de berserkers répondent à sa convocation, de même que les conditions nécessaires à son utilisation. Le MD choisit le type du cor ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Type du cor</th><th>Berserkers<br>invoqués</th><th>Condition</th></tr><tr><td class=\"center\">01-40</td><td>Argent</td><td>2d4 + 2</td><td>Aucune</td></tr><tr><td class=\"center\">41-75</td><td>Airain</td><td>3d4 + 3</td><td>Maîtrise de toutes les armes courantes</td></tr><tr><td class=\"center\">76-90</td><td>Bronze</td><td>4d4 + 4</td><td>Maîtrise de toutes les armures intermédiaires</td></tr><tr><td class=\"center\">91-00</td><td>Fer</td><td>5d4 + 5</td><td>Maîtrise de toutes les armes de guerre</td></tr></tbody></table>\n<br>Si vous soufflez dans le cor sans remplir ses conditions d'utilisation, les berserkers invoqués vous attaquent. Si vous remplissez les conditions, ils sont amicaux envers vous et vos compagnons et suivent vos ordres.\n<br></div>"
+		},
+		{
+			"id": "Brass Horn of Valhalla",
+			"name": "Cor du Valhalla",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour souffler dans ce cor. En réponse, des esprits guerriers venant du Valhalla apparaissent dans un rayon de 18 mètres autour de vous. Ils utilisent les statistiques du <a href=\"https://www.aidedd.org/dnd/monstres.php?vf=berserker\">berserker</a>. Ils retournent au Valhalla au bout d'une heure ou lorsqu'ils tombent à 0 point de vie. Une fois que vous avez utilisé le cor, il ne peut pas être réutilisé avant que 7 jours ne se soient écoulés.\n<br>On connait à ce jour l'existence de quatre types de cor du Valhalla, chacun fin d'un métal différent. Le type du cor détermine combien de berserkers répondent à sa convocation, de même que les conditions nécessaires à son utilisation. Le MD choisit le type du cor ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Type du cor</th><th>Berserkers<br>invoqués</th><th>Condition</th></tr><tr><td class=\"center\">01-40</td><td>Argent</td><td>2d4 + 2</td><td>Aucune</td></tr><tr><td class=\"center\">41-75</td><td>Airain</td><td>3d4 + 3</td><td>Maîtrise de toutes les armes courantes</td></tr><tr><td class=\"center\">76-90</td><td>Bronze</td><td>4d4 + 4</td><td>Maîtrise de toutes les armures intermédiaires</td></tr><tr><td class=\"center\">91-00</td><td>Fer</td><td>5d4 + 5</td><td>Maîtrise de toutes les armes de guerre</td></tr></tbody></table>\n<br>Si vous soufflez dans le cor sans remplir ses conditions d'utilisation, les berserkers invoqués vous attaquent. Si vous remplissez les conditions, ils sont amicaux envers vous et vos compagnons et suivent vos ordres.\n<br></div>"
+		},
+		{
+			"id": "Silver Horn of Valhalla",
+			"name": "Cor en argent du Valhalla",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour souffler dans ce cor. En réponse, des esprits guerriers venant du Valhalla apparaissent dans un rayon de 18 mètres autour de vous. Ils utilisent les statistiques du <a href=\"https://www.aidedd.org/dnd/monstres.php?vf=berserker\">berserker</a>. Ils retournent au Valhalla au bout d'une heure ou lorsqu'ils tombent à 0 point de vie. Une fois que vous avez utilisé le cor, il ne peut pas être réutilisé avant que 7 jours ne se soient écoulés.\n<br>On connait à ce jour l'existence de quatre types de cor du Valhalla, chacun fin d'un métal différent. Le type du cor détermine combien de berserkers répondent à sa convocation, de même que les conditions nécessaires à son utilisation. Le MD choisit le type du cor ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Type du cor</th><th>Berserkers<br>invoqués</th><th>Condition</th></tr><tr><td class=\"center\">01-40</td><td>Argent</td><td>2d4 + 2</td><td>Aucune</td></tr><tr><td class=\"center\">41-75</td><td>Airain</td><td>3d4 + 3</td><td>Maîtrise de toutes les armes courantes</td></tr><tr><td class=\"center\">76-90</td><td>Bronze</td><td>4d4 + 4</td><td>Maîtrise de toutes les armures intermédiaires</td></tr><tr><td class=\"center\">91-00</td><td>Fer</td><td>5d4 + 5</td><td>Maîtrise de toutes les armes de guerre</td></tr></tbody></table>\n<br>Si vous soufflez dans le cor sans remplir ses conditions d'utilisation, les berserkers invoqués vous attaquent. Si vous remplissez les conditions, ils sont amicaux envers vous et vos compagnons et suivent vos ordres.\n<br></div>"
+		},
+		{
+			"id": "Bronze Horn of Valhalla",
+			"name": "Cor en Bronze du Valhalla",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour souffler dans ce cor. En réponse, des esprits guerriers venant du Valhalla apparaissent dans un rayon de 18 mètres autour de vous. Ils utilisent les statistiques du <a href=\"https://www.aidedd.org/dnd/monstres.php?vf=berserker\">berserker</a>. Ils retournent au Valhalla au bout d'une heure ou lorsqu'ils tombent à 0 point de vie. Une fois que vous avez utilisé le cor, il ne peut pas être réutilisé avant que 7 jours ne se soient écoulés.\n<br>On connait à ce jour l'existence de quatre types de cor du Valhalla, chacun fin d'un métal différent. Le type du cor détermine combien de berserkers répondent à sa convocation, de même que les conditions nécessaires à son utilisation. Le MD choisit le type du cor ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Type du cor</th><th>Berserkers<br>invoqués</th><th>Condition</th></tr><tr><td class=\"center\">01-40</td><td>Argent</td><td>2d4 + 2</td><td>Aucune</td></tr><tr><td class=\"center\">41-75</td><td>Airain</td><td>3d4 + 3</td><td>Maîtrise de toutes les armes courantes</td></tr><tr><td class=\"center\">76-90</td><td>Bronze</td><td>4d4 + 4</td><td>Maîtrise de toutes les armures intermédiaires</td></tr><tr><td class=\"center\">91-00</td><td>Fer</td><td>5d4 + 5</td><td>Maîtrise de toutes les armes de guerre</td></tr></tbody></table>\n<br>Si vous soufflez dans le cor sans remplir ses conditions d'utilisation, les berserkers invoqués vous attaquent. Si vous remplissez les conditions, ils sont amicaux envers vous et vos compagnons et suivent vos ordres.\n<br></div>"
+		},
+		{
+			"id": "Rope of Entanglement",
+			"name": "Corde d'enchevêtrement",
+			"description": "<div class=\"description \">Cette corde est longue de 9 mètres et pèse 1,50 kilo. Si vous tenez un bout de la corde et utilisez votre action pour prononcer le mot de commande, l'autre extrémité se précipite vers une créature que vous pouvez voir et se trouvant à 6 mètres de vous maximum pour l'enchevêtrer. La cible doit réussir un jet de sauvegarde de Dextérité DD 15 sous peine d'être entravée.\n<br>Vous pouvez relâcher la créature en utilisant votre action bonus pour prononcer un second mot de commande. Une créature entravée par la corde peut utiliser une action pour effectuer un jet de Force ou de Dextérité (au choix de la cible) DD 15. En cas de réussite, la créature n'est plus entravée par la corde.\n<br>La corde possède une CA de 20 et 20 points de vie. Elle récupère 1 point de vie toutes les 5 minutes aussi longtemps qu'il lui reste au moins 1 point de vie. Si la corde tombe à 0 point de vie, elle est détruite.\n<br></div>"
+		},
+		{
+			"id": "Rope of Climbing",
+			"name": "Corde d'escalade",
+			"description": "<div class=\"description \">Cette corde de soie longue de 18 mètres pèse 1,50 kilo et peut supporter un poids maximal de 1500 kilos. Si vous tenez un bout de la corde et utilisez une action pour prononcer le mot de commande, la corde s'anime. Par une action bonus, vous pouvez ordonner à l'autre extrémité de se déplacer jusqu'à la destination de votre choix. Cette extrémité se déplace alors de 3 mètres pendant votre tour au moment où vous lui avez donner votre premier ordre, puis elle continue de se déplacer de 3 mètres à chacun de vos tours suivants jusqu'à ce qu'elle atteigne sa destination, jusqu'à ce qu'elle ait parcouru une distance égale à sa longueur, ou jusqu'à ce que vous lui ordonniez de s'arrêter. Vous pouvez également demander à la corde de s'attacher en toute sécurité à un objet ou de se détacher, de se nouer ou de se dénouer, ou de s'enrouler pour pouvoir la ranger.\n<br>Si vous demandez à la corde de se nouer, de larges nœuds apparaissent tous les 30 centimètres le long de la corde. Tant qu'elle est nouée, la corde se raccourcit de 3 mètres et confère un avantage aux jets effectués pour l'escalader.\n<br>La corde possède une CA de 20 et 20 points de vie. Elle récupère 1 point de vie toutes les 5 minutes aussi longtemps qu'il lui reste au moins 1 point de vie. Si la corde tombe à 0 point de vie, elle est détruite.\n<br></div>"
+		},
+		{
+			"id": "Hempen Rope (50 ft.)",
+			"name": "Corde en chanvre (15 m)",
+			"description": "<p>Une corde, qu'elle soit faite de chanvre ou de soie, possède 2 pv et peut être cassée avec un jet de Force DD 17.</span></p>"
+		},
+		{
+			"id": "Silk Rope (50 ft.)",
+			"name": "Corde en soie (15 m)",
+			"description": "<p>Une corde, qu'elle soit faite de chanvre ou de soie, possède 2 pv et peut être cassée avec un jet de Force DD 17.</span></p>"
+		},
+		{
+			"id": "Bagpipes",
+			"name": "Cornemuse",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Costume Clothes",
+			"name": "Costume (vêtement)",
+			"description": "<p>Un costume complet généralement utilisé par les artistes et les interprètes dans toutes sortes de salles de spectacle ou pour ceux qui refusent simplement de sortir de leur personnage.</p>"
+		},
+		{
+			"id": "Adamantine Chain Mail",
+			"name": "Cotte de maille en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Chain Mail",
+			"name": "Cotte de mailles",
+			"description": "<p>Fait d'anneaux métalliques entrecroisés, la cotte de mailles comprend une couche de tissu matelassé porté sous la cotte pour éviter les frottements et amortir l'impact de coups. L'ensemble comprend des gantelets.</p>"
+		},
+		{
+			"id": "Chain Mail +1",
+			"name": "Cotte de mailles +1",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\"><em style=\"box-sizing: border-box; user-select: text;\">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Chain Mail +2",
+			"name": "Cotte de mailles +2",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\"><em style=\"box-sizing: border-box; user-select: text;\">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Chain Mail +3",
+			"name": "Cotte de mailles +3",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\"><em style=\"box-sizing: border-box; user-select: text;\">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Mithral Chain Mail",
+			"name": "Cotte de mailles de mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Chain Mail Armor of Resistance",
+			"name": "Cotte de mailles de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Glaive",
+			"name": "Coutille",
+			"description": "<p>Sabre court à deux tranchants au bout d'un grand manche.</p>"
+		},
+		{
+			"id": "Glaive +1",
+			"name": "Coutille +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Glaive +2",
+			"name": "Coutille +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Glaive +3",
+			"name": "Coutille +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Glaive",
+			"name": "Coutille vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Blanket",
+			"name": "Couverture",
+			"description": "<p>Une couverture pour vous tenir chaud la nuit.</p>"
+		},
+		{
+			"id": "Chalk",
+			"name": "Craie (un morceau)",
+			"description": "<p>Il s'agit d'une roche sédimentaire blanche, poreuse et tendre, de type acarbonate, une forme de calcaire composée de calcite minérale. Elle peut être utilisée pour dessiner des formes</p>"
+		},
+		{
+			"id": "Jug",
+			"name": "Cruche",
+			"description": "<p>Un pichet de 3,5 l.</p>"
+		},
+		{
+			"id": "Alchemy Jug",
+			"name": "Cruche alchimique",
+			"description": "<div><em>Objet merveilleux, peu commun</em></div>\n<div>&nbsp;</div>\n<div>Cette cruche en céramique semble être en mesure de contenir 4 litres de liquide et pèse 6 kilos, vide ou pleine. Des sons de ballonnements se font entendre de l'intérieur de la jarre quand elle est secouée, même si elle est vide.Vous pouvez utiliser une action et nommer un liquide de la table ci-dessous, et la cruche se remplit du liquide choisi. Ensuite, vous pouvez déboucher la jarre au prix d'une action et déverser ce liquide, jusqu'à 8 litres par minute. La quantité de liquide que la jarre peut produire dépend du liquide nommé.Une fois que la jarre a commencé à produire un liquide, elle ne peut pas en produire un autre, ni plus que son maximum, jusqu'à l'aube suivante.&nbsp;</div>\n<div><br>\n<table style=\"width: 183px;\">\n<tbody>\n<tr>\n<th style=\"width: 86.9097px;\">Liquide</th>\n<th style=\"width: 88.0208px;\">Quantité max</th>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Acide</td>\n<td style=\"width: 88.0208px;\">25 cl</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Poison simple</td>\n<td style=\"width: 88.0208px;\">15 ml</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Bière</td>\n<td style=\"width: 88.0208px;\">16 litres</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Miel</td>\n<td style=\"width: 88.0208px;\">1 litre</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Mayonnaise</td>\n<td style=\"width: 88.0208px;\">8 litres</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Huile</td>\n<td style=\"width: 88.0208px;\">1 litre</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Vinaigrer</td>\n<td style=\"width: 88.0208px;\">8 litres</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Eau douce</td>\n<td style=\"width: 88.0208px;\">32 litres</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Eau Salée</td>\n<td style=\"width: 88.0208px;\">48 litres</td>\n</tr>\n<tr>\n<td style=\"width: 86.9097px;\">Vin</td>\n<td style=\"width: 88.0208px;\">4 litres</td>\n</tr>\n</tbody>\n</table>\n</div>"
+		},
+		{
+			"id": "Cube of Force",
+			"name": "Cube de force",
+			"description": "<div class=\"description \">Ce cube fait environ 2,50 centimètres d'arête. Chaque face possède une marque distincte sur laquelle on peut appuyer. Le cube débute en possédant 36 charges, et il récupère 1d20 charges dépensées chaque jour au lever du soleil.\n<br>Vous pouvez utiliser une action pour appuyer sur l'une des faces du cube, tout en dépensant le nombre de charges associé à la face en question comme indiqué sur la table Faces du Cube de Force. Chaque face à son propre effet. Si le cube ne possède plus suffisamment de charges, rien ne se produit. Sinon, une barrière de force invisible apparaît, formant un cube de 4,50 mètres d'arête. La barrière est centrée sur vous, se déplace avec vous, et reste en place pendant 1 minute, jusqu'à ce que vous utilisiez une action pour appuyer sur la sixième face du cube, ou jusqu'à ce que le cube épuise toutes ses charges. Vous pouvez changer l'effet de la barrière en appuyant sur une face différente du cube et en dépensant les charges nécessaires, la durée d'apparition de la barrière est alors réinitialisée.\n<br>Si votre mouvement implique que la barrière entre en contact avec un objet solide qui ne peut pas passer au travers du cube, vous ne pouvez pas vous approcher plus de cet objet aussi longtemps que la barrière est activée.\n<br><table><tbody><tr><th class=\"center\">Face</th><th class=\"center\">Charges</th><th>Effet</th></tr><tr><td class=\"center\">1</td><td class=\"center\">1</td><td>Les gaz, vents, et brumes ne peuvent traverser la barrière.</td></tr><tr><td class=\"center\">2</td><td class=\"center\">2</td><td>Les matières non vivantes ne peuvent pas passer au travers de la barrière. Les murs, sols, et plafonds peuvent passer au travers à la discrétion du MD.</td></tr><tr><td class=\"center\">3</td><td class=\"center\">3</td><td>Les matières vivantes ne peuvent pas passer au travers de la barrière.</td></tr><tr><td class=\"center\">4</td><td class=\"center\">4</td><td>Les effets des sorts ne peuvent pas passer au travers de la barrière.</td></tr><tr><td class=\"center\">5</td><td class=\"center\">5</td><td>Rien ne peut passer au travers de la barrière. Les murs, sols, et plafonds peuvent passer au travers à la discrétion du MD.</td></tr><tr><td class=\"center\">6</td><td class=\"center\">0</td><td>La barrière est désactivée.</td></tr></tbody></table>\n<br>Le cube perd des charges lorsque la barrière est ciblée par certains sorts ou entre en contact avec certains effets de sorts ou d'objets magiques, comme indiqué dans la table ci-dessous.\n<br><table><tbody><tr><th>Sorts ou Objets</th><th>Charges perdues</th></tr><tr><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=desintegration\">Désintégration</a></em></td><td class=\"center\">1d12</td></tr><tr><td><em>Cor de destruction</em></td><td class=\"center\">1d10</td></tr><tr><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=passe-muraille\">Passe-muraille</a></em></td><td class=\"center\">1d6</td></tr><tr><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=rayons-prismatiques\">Rayons prismatiques</a></em></td><td class=\"center\">1d20</td></tr><tr><td><em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">Mur de feu</a></em></td><td class=\"center\">1d4</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Glamoured Studded Leather",
+			"name": "Cuir clouté glamour",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus de +1 à la CA. Vous pouvez également utiliser une action bonus pour prononcer le mot de commande de l'armure et faire que celle-ci prenne l'apparence de vêtements ou d'un autre type d'armure. Vous décidez l'apparence, les couleurs et le style, mais le poids et le volume restent les mêmes. L'illusion dure jusqu'à ce que vous utilisiez cette propriété de nouveau, ou que vous ôtiez l'armure.\n<br></div>"
+		},
+		{
+			"id": "Breastplate",
+			"name": "Cuirasse",
+			"description": "<p>Cette armure se compose d'une pièce principale de métal maintenue avec du cuir souple sur la poitrine. Bien qu'elle laisse les jambes et les bras relativement à découvert, cette armure offre une bonne protection pour les organes vitaux tout en ne gênant pas trop son porteur.</p>"
+		},
+		{
+			"id": "Breastplate +1",
+			"name": "Cuirasse +1",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\"><em style=\"box-sizing: border-box; user-select: text;\">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Breastplate +2",
+			"name": "Cuirasse +2",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\"><em style=\"box-sizing: border-box; user-select: text;\">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Breastplate +3",
+			"name": "Cuirasse +3",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\"><em style=\"box-sizing: border-box; user-select: text;\">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.</p>"
+		},
+		{
+			"id": "Mithral Breastplate",
+			"name": "Cuirasse de mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Breastplate Armor of Resistance",
+			"name": "Cuirasse de résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Dagger",
+			"name": "Dague",
+			"description": "<p>Une lame en métal courte montée sur une petite poignée avec une garde. La dague est efficace en arme secondaire pour les combattants agguéris ou pour en arme cachée pour les assassins et les voleurs.</p>"
+		},
+		{
+			"id": "Dagger +1",
+			"name": "Dague +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une fabrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Dagger +2",
+			"name": "Dague +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une fabrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Dagger +3",
+			"name": "Dague +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une fabrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Dagger of Venom",
+			"name": "Dague Venimeuse",
+			"description": "<p>Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p>Vous pouvez dépenser une action pour qu'un épais poison noir enduise la lame. Il persiste pendant 1 minute ou jusqu'à ce que l'arme touche une créature suite à une attaque. Cette créature doit réussir un jet de sauvegarde de Constitution DD 15 ou subir 2d10 dégâts de poison pendant 1 minute. Il faut attendre l'aube suivante pour pouvoir utiliser de nouveau la dague de cette manière.</p>"
+		},
+		{
+			"id": "Vicious Dagger",
+			"name": "Dague vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Adamantine Half Plate Armor",
+			"name": "Demi-plate en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Mithral Half Plate Armor",
+			"name": "Demi-plate mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Circlet of Blasting",
+			"name": "Diadème de destruction",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de ce diadème, vous pouvez l'utiliser en prenant une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=rayon-ardent\">rayon ardent</a></em>. Lorsque vous effectuez le jet d'attaque avec un sort, vous le faite en utilisant un bonus de +5 à l'attaque. Le diadème ne peut être réutilisé de la sorte avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Flask of Holy Water",
+			"name": "Eau bénite (flasque)",
+			"description": "<p>Au prix d'une action, vous pouvez lancer le contenu de cette flasque sur une créature à 1,50 mètre ou moins de vous, ou jeter le flacon jusqu'à 6 mètres, la brisant à l'impact. Dans les deux cas, faire une attaque à distance contre une créature, en considérant l'eau bénite comme une arme improvisée. Si la cible est un fiélon ou mort-vivant, elle reçoit 2d6 dégâts radiant. Un clerc ou un paladin peut créer de l'eau bénite lors d'un rituel spécial. Le rituel dure 1 heure, consomme pour 25 po de poudre d'argent, et nécessite que le lanceur dépense un emplacement de sort de niveau 1.</p>"
+		},
+		{
+			"id": "Mithral Scale Mail",
+			"name": "Ecailles de mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Ladder (10-foot)",
+			"name": "Échelle (3 m)",
+			"description": "<p>Une échelle de trois mètres de long, aussi robuste ou branlante que la main qui l'a fabriquée ou assemblée.</p>"
+		},
+		{
+			"id": "Efreeti Bottle",
+			"name": "Bouteille de l'éfrit",
+			"description": "<p><em>Objet merveilleux, très rare</em></p>\n<p>Cette bouteille en laiton peinte pèse 500 grammes. Lorsque vous utilisez une action pour en retirer le bouchon, un épais nuage de fumée se déverse de la bouteille. À la fin de votre tour, la fumée disparaît en une myriade de flammèches inoffensives, et un @Compendium[dnd5e.monsters.LTomFUTBrkRi0Pj5]{Éfrit} apparaît dans un espace inoccupé dans un rayon de 9 mètres autour de vous.</p>\n<p>La première fois que la bouteille est ouverte, la MD lance 1d100 pour déterminer ce qui se produit.</p>\n<table border=\"1\">\n<tbody>\n<tr>\n<td><strong>d100</strong></td>\n<td><strong>Effet</strong></td>\n</tr>\n<tr>\n<td>01-10</td>\n<td>L'éfrit vous attaque. Après avoir combattu pendant 5 tours, l'éfrit disparaît, et la bouteille perd sa magie.</td>\n</tr>\n<tr>\n<td>11-90</td>\n<td>L'éfrit vous sert pendant 1 heure, faisant ce que vous lui ordonnez de faire. Puis l'éfrit retourne dans la bouteille, et un nouveau bouchon l'y enferme. Le bouchon ne peut plus être retiré au cours des 24 heures qui suivent. Les deux fois suivantes que la bouteille est ouverte, il se produit la même chose. Si la bouteille est ouverte une quatrième fois, l'éfrit s'échappe et disparaît, puis la bouteille perd sa magie.</td>\n</tr>\n<tr>\n<td>91-00</td>\n<td>L'éfrit peut lancer le sort souhait trois fois pour vous. Il disparaît lorsqu'il a accordé le troisième souhait ou au bout d'une heure, puis la bouteille perd sa magie.</td>\n</tr>\n</tbody>\n</table>"
+		},
+		{
+			"id": "Emblem",
+			"name": "Emblème",
+			"description": "<p style=\"box-sizing: border-box; user-select: text;  font-size: 13px;\">Un symbole gravé ou soigneusement incrusté sur un bouclier ou tout autre dispositif représentant une divinité à travers laquelle un vrai croyant peut faire appel à son pouvoir et, ce faisant, répandre la foi.Un symbole sacré est une représentation d'un dieu ou d'un panthéon. Cela peut être une amulette avec un symbole représentant une divinité, ce même symbole gravé ou incrusté tel un emblème sur un bouclier, ou une toute petite boîte renfermant le fragment d'une relique sacrée. Un clerc ou paladin peut utiliser un symbole sacré comme focaliseur magique. Pour utiliser le symbole de cette manière, le lanceur doit le porter visiblement, en main ou sur un bouclier.</span></p>"
+		},
+		{
+			"id": "Censer",
+			"name": "Encensoir",
+			"description": "Généralement utilisé avec de l'encens pour parfumer l'air."
+		},
+		{
+			"id": "Censer of Controlling Air Elementals",
+			"name": "Encensoir de contrôle des élémentaires de l'air",
+			"description": "Tant que de l'encens brûle dans cet encensoir, vous pouvez utiliser une action pour prononcer le mot de commande de l'encensoir et invoquer un @Compendium[dnd5e.monsters.banHjKDMCegbUwYE]{élémentaire de l'air}, comme si vous aviez lancé le sort @Compendium[dnd5e.spells.1LkZvINag7KqBmDR]{invocation d'élémentaire}. L'encensoir ne peut être réutilisé de la sorte avant le prochain lever de soleil. Ce récipient de 30 centimètres de hauteur et de 15 centimètres de diamètre ressemble à un calice au couvercle ouvragé. Il pèse 500 grammes. "
+		},
+		{
+			"id": "Ink Bottle",
+			"name": "Encre (bouteille de 30 ml)",
+			"description": "<p>Une petite bouteille d'encre pour écrire sur le parchemin.</p>"
+		},
+		{
+			"id": "Flame Tongue Greatsword",
+			"name": "Épée à 2 mains ardente",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action bonus pour prononcer le mot de commande de l'épée, ce qui fait jaillir des flammes de la lame. Ces flammes génèrent une lumière vive dans un rayon de 12 mètres et une lumière faible sur 12 mètres supplémentaires. Tant que l'épée est en feu, elle inflige 2d6 dégâts de feu supplémentaires à toute cible qu'elle touche. Les flammes perdurent jusqu'à ce que vous utilisiez une action bonus pour prononcer le mot de commande de nouveau, ou jusqu'à ce que vous lâchiez l'épée ou la rengainiez.\n<br></div>"
+		},
+		{
+			"id": "Frost Brand Greatsword",
+			"name": "Épée à 2 mains de givre",
+			"description": "<div class=\"description \">Lorsque vous touchez avec une attaque utilisant cette épée magique, la cible subit 1d6 dégâts de froid supplémentaires. En outre, tant que vous tenez l'épée, vous avez la résistance aux dégâts de feu. Dans des températures de congélation, la lame émet en lumière vive dans un rayon de 3 mètres et une lumière faible sur 3 mètres supplémentaires.\n<br>Lorsque vous dégainez cette arme, vous pouvez éteindre toutes les flammes non magiques dans un rayon de 9 mètres autour de vous. Cette propriété ne peut pas être utilisée plus d'une fois par heure.\n<br></div>"
+		},
+		{
+			"id": "Holy Avenger Greatsword",
+			"name": "Épée à 2 mains de justice",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 à l'attaque et aux dégâts réalisés avec cette arme magique. Lorsque vous touchez un fiélon ou un mort-vivant avec elle, cette créature subit 2d10 dégâts radiants supplémentaires.\n<br>Tant que vous tenez l'épée dégainée, elle crée une aura dans un rayon de 3 mètres autour de vous. Vous et toutes les créatures qui vous sont amicales dans l'aura ont un avantage aux jets de sauvegarde contre les sorts et autres effets magiques. Si vous avez 17 ou plus niveaux dans la classe de paladin, le rayon de l'aura augmente de 3 mètres.\n<br></div>"
+		},
+		{
+			"id": "Defender Greatsword",
+			"name": "Epée à 2 mains Gardienne",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>La première fois que vous attaquez avec l'épée au cours de chacun de vos tours, vous pouvez transférer tout ou partie du bonus de l'épée vers votre Classe d'Armure, plutôt que d'utiliser ce bonus sur vos attaques de ce tour. Par exemple, vous pourriez réduire le bonus à votre jet d'attaque et de dégâts à +1 et ainsi gagner un bonus de +2 à votre CA. La modification du bonus reste effective jusqu'au début de votre prochain tour, mais vous devez bien entendu avoir l'épée en main pour bénéficier de son bonus à la CA.\n<br></div>"
+		},
+		{
+			"id": "Greatsword of Wounding",
+			"name": "Épée à 2 mains incisive",
+			"description": "<div class=\"description \">Les points de vie perdus à cause de dégâts infligés par cette arme ne peuvent être récupérés que par le biais d'un repos court ou long, mais pas à l'aide de capacités de régénération, de pouvoirs magiques, de sorts, ou de tout autre moyen.\n<br>Une fois par tour, lorsque vous touchez une créature avec une attaque utilisant cette arme magique, vous pouvez blesser profondément la cible. Au début de chacun des tours de la créature blessée, celle-ci subit 1d4 dégâts nécrotiques pour chaque blessure profonde que vous lui avez infligée, et elle peut ensuite effectuer un jet de sauvegarde de Constitution DD 15, mettant un terme à l'effet de toutes les blessures profondes que vous lui avez infligées en cas de réussite. Sinon, la créature blessée profondément, ou une créature se trouvant à 1,50 mètre d'elle, peut utiliser son action pour effectuer un jet de Sagesse (Médecine) DD 15, mettant un terme à l'effet des blessures profondes qui l'affectent en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Greatsword of Sharpness",
+			"name": "Épée à 2 mains tranchante",
+			"description": "<div class=\"description \">Lorsque vous attaquez un objet avec cette épée magique et le touchez, les dés de dégâts de votre arme sont maximisés contre cette cible.\n<br>Lorsque vous attaquez une créature avec cette épée et obtenez un 20 naturel à votre jet d'attaque, la cible subit 14 dégâts tranchants supplémentaires. Puis lancez un autre d20. Si vous obtenez de nouveau un 20 naturel, vous amputez la cible de l'un de ses membres, l'effet d'une telle perte est déterminé par le MD. Si la créature ne possède aucun membre à sectionner, vous tranchez une portion de son corps à la place.\n<br>De plus, vous pouvez prononcer le mot de commande de la lame pour qu'elle émette une lumière vive dans un rayon de 3 mètres et une lumière faible dans un rayon supplémentaire de 3 mètres. Répétez le mot de commande ou rengainez l'épée pour éteindre la lumière.\n<br></div>"
+		},
+		{
+			"id": "Dragon Slayer Greatsword",
+			"name": "Epée à 2 mains Tueuse de dragons",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 à l'attaque et aux dégâts fait avec cette arme magique.\n<br>Si vous touchez un dragon avec cette arme, le dragon subit 3d6 dégâts supplémentaires du type de l'arme. Pour cette arme, le terme « dragon » se réfère à toute créature qui possède le type dragon, y compris les tortues dragons et les wivernes.\n<br></div>"
+		},
+		{
+			"id": "Vicious Greatsword",
+			"name": "Epée à 2 mains vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Greatsword of Life Stealing",
+			"name": "Épée à 2 mains voleuse de vie",
+			"description": "<div class=\"description \">Lorsque vous attaquez une créature avec cette arme magique et obtenez un 20 au jet d'attaque, la cible subit 10 dégâts nécrotiques supplémentaires, à condition qu'elle ne soit pas une créature artificielle ou un mort-vivant. Vous gagnez un nombre de points de vie temporaires égal aux dégâts supplémentaires infligés.\n<br></div>"
+		},
+		{
+			"id": "Nine Lives Stealer Greatsword",
+			"name": "Épée à 2 mains Voleuse des neuf vies",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>L'épée possède 1d8 + 1 charges. Quand vous obtenez un coup critique contre une créature à qui il reste moins de 100 points de vies, celle-ci doit réussir un jet de sauvegarde de Constitution DD 15 ou être tuée instantanément, sa force vitale étant arrachée de son corps (les morts-vivants et les créatures artificielles sont immunisés). L'épée perd 1 charge si la créature est tuée. Elle perd cette propriété une fois toutes les charges épuisées.\n<br></div>"
+		},
+		{
+			"id": "Vorpal Greatsword",
+			"name": "Épée à 2 mains vorpale",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, l'arme ignore la résistance aux dégâts tranchants.\n<br>Lorsque vous attaquez une créature qui possède au moins une tête avec cette arme et que vous obtenez un 20 naturel sur votre jet d'attaque, vous décapitez la créature de l'une de ses têtes. La créature meurt si elle ne peut pas survivre après avoir perdu sa tête. Une créature est immunisée à cet effet si elle est immunisée aux dégâts tranchants, n'a pas besoin de sa tête, ou n'a pas de tête, possède des actions légendaires, ou si le MD décide que cette créature est trop grosse pour que sa tête puisse être amputée avec cette arme. De telles créatures subissent à la place 6d8 dégâts tranchants supplémentaires de ce coup.\n<br></div>"
+		},
+		{
+			"id": "Greatsword",
+			"name": "Épée à deux mains",
+			"description": "<p>Une puissante lame à deux mains mesure plus d'un mètre de long et presque cinq pouces de large. Cette arme nécessite un entraînement martial intensif, mais ceux qui savent s'en servir sont de redoutables guerriers.</p>"
+		},
+		{
+			"id": "Greatsword +1",
+			"name": "Épée à deux mains +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Greatsword +2",
+			"name": "Épée à deux mains +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Greatsword +3",
+			"name": "Épée à deux mains +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Dancing Greatsword",
+			"name": "Épée à deux mains Dansante",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous pouvez utiliser une action bonus pour lancer cette épée magique en l'air et prononcer son mot de commande. Elle se met alors à flotter et s'envole à une distance maximum de 9 mètres, attaquant la créature de votre choix située dans un rayon de 1,50 mètre autour d'elle. L'épée utilise votre jet d'attaque et votre modificateur de caractéristique aux jets de dégâts.</p>\n<p>Tant que l'épée flotte dans les airs, vous pouvez utiliser une action bonus pour l'envoyer voler sur une distance maximum de 9 mètres jusqu'à un emplacement situé dans un rayon de 9 mètres autour de vous. Lors de cette action bonus, vous pouvez demander à l'épée d'attaquer une créature située dans un rayon de 1,50 mètre autour d'elle.</p>\n<p>Une fois que l'épée a attaqué pour la quatrième fois, elle vole sur un maximum de 9 mètres et tente de retourner dans votre main. Si vous avez les deux mains prises, elle tombe à vos pieds. Si l'épée ne dispose d'aucun chemin d'accès pour vous rejoindre, elle se rapproche de vous autant que possible et tombe à terre. Elle cesse également de flotter dans les airs si vous l'attrapez ou si vous vous éloignez à plus de 9 mètres d'elle.</p>"
+		},
+		{
+			"id": "Luck Blade Greatsword",
+			"name": "Épée à deux mains Lame porte-bonheur",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. Tant que vous portez l'épée sur vous, vous bénéficiez également d'un bonus de +1 aux jets de sauvegarde.\n<br><strong>Chance</strong>. Si vos portez l'épée sur vous, vous pouvez invoquer sa chance (aucune action n'est requise) pour relancer un jet d'attaque, de caractéristique ou de sauvegarde dont le résultat vous déplaît. Vous devez accepter le nouveau résultat. Cette propriété ne peut pas être utilisée de nouveau avant le prochain lever du soleil.\n<br><strong>Souhait</strong>. L'épée possède 1d4 - 1 charges. Tant que vous la tenez en main, vous pouvez utiliser une action pour dépenser une charge et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em>. Cette propriété ne peut plus être utilisée avant la prochaine aube. L'épée perd cette propriété si elle n'a plus de charges.\n<br></div>"
+		},
+		{
+			"id": "Giant Slayer Greatsword",
+			"name": "Épée à deux mains Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Shortsword",
+			"name": "Épée courte",
+			"description": "<p> lame de taille moyenne avec une garde croisée ferme et un manche gainé de cuir. Une arme qui compense en polyvalence ce qui lui manque en termes de portée.</p>"
+		},
+		{
+			"id": "Shortsword +1",
+			"name": "Épée courte +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Shortsword +2",
+			"name": "Épée courte +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Shortsword +3",
+			"name": "Épée courte +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Flame Tongue Shortsword",
+			"name": "Épée courte ardente",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action bonus pour prononcer le mot de commande de l'épée, ce qui fait jaillir des flammes de la lame. Ces flammes génèrent une lumière vive dans un rayon de 12 mètres et une lumière faible sur 12 mètres supplémentaires. Tant que l'épée est en feu, elle inflige 2d6 dégâts de feu supplémentaires à toute cible qu'elle touche. Les flammes perdurent jusqu'à ce que vous utilisiez une action bonus pour prononcer le mot de commande de nouveau, ou jusqu'à ce que vous lâchiez l'épée ou la rengainiez.\n<br></div>"
+		},
+		{
+			"id": "Dancing Shortsword",
+			"name": "Épée courte Dansante",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous pouvez utiliser une action bonus pour lancer cette épée magique en l'air et prononcer son mot de commande. Elle se met alors à flotter et s'envole à une distance maximum de 9 mètres, attaquant la créature de votre choix située dans un rayon de 1,50 mètre autour d'elle. L'épée utilise votre jet d'attaque et votre modificateur de caractéristique aux jets de dégâts.</p>\n<p>Tant que l'épée flotte dans les airs, vous pouvez utiliser une action bonus pour l'envoyer voler sur une distance maximum de 9 mètres jusqu'à un emplacement situé dans un rayon de 9 mètres autour de vous. Lors de cette action bonus, vous pouvez demander à l'épée d'attaquer une créature située dans un rayon de 1,50 mètre autour d'elle.</p>\n<p>Une fois que l'épée a attaqué pour la quatrième fois, elle vole sur un maximum de 9 mètres et tente de retourner dans votre main. Si vous avez les deux mains prises, elle tombe à vos pieds. Si l'épée ne dispose d'aucun chemin d'accès pour vous rejoindre, elle se rapproche de vous autant que possible et tombe à terre. Elle cesse également de flotter dans les airs si vous l'attrapez ou si vous vous éloignez à plus de 9 mètres d'elle.</p>"
+		},
+		{
+			"id": "Frost Brand Shortsword",
+			"name": "Épée courte de givre",
+			"description": "<div class=\"description \">Lorsque vous touchez avec une attaque utilisant cette épée magique, la cible subit 1d6 dégâts de froid supplémentaires. En outre, tant que vous tenez l'épée, vous avez la résistance aux dégâts de feu. Dans des températures de congélation, la lame émet en lumière vive dans un rayon de 3 mètres et une lumière faible sur 3 mètres supplémentaires.\n<br>Lorsque vous dégainez cette arme, vous pouvez éteindre toutes les flammes non magiques dans un rayon de 9 mètres autour de vous. Cette propriété ne peut pas être utilisée plus d'une fois par heure.\n<br></div>"
+		},
+		{
+			"id": "Holy Avenger Shortsword",
+			"name": "Épée courte de justice",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 à l'attaque et aux dégâts réalisés avec cette arme magique. Lorsque vous touchez un fiélon ou un mort-vivant avec elle, cette créature subit 2d10 dégâts radiants supplémentaires.\n<br>Tant que vous tenez l'épée dégainée, elle crée une aura dans un rayon de 3 mètres autour de vous. Vous et toutes les créatures qui vous sont amicales dans l'aura ont un avantage aux jets de sauvegarde contre les sorts et autres effets magiques. Si vous avez 17 ou plus niveaux dans la classe de paladin, le rayon de l'aura augmente de 3 mètres.\n<br></div>"
+		},
+		{
+			"id": "Defender Shortsword",
+			"name": "Epée courte Gardienne",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>La première fois que vous attaquez avec l'épée au cours de chacun de vos tours, vous pouvez transférer tout ou partie du bonus de l'épée vers votre Classe d'Armure, plutôt que d'utiliser ce bonus sur vos attaques de ce tour. Par exemple, vous pourriez réduire le bonus à votre jet d'attaque et de dégâts à +1 et ainsi gagner un bonus de +2 à votre CA. La modification du bonus reste effective jusqu'au début de votre prochain tour, mais vous devez bien entendu avoir l'épée en main pour bénéficier de son bonus à la CA.\n<br></div>"
+		},
+		{
+			"id": "Shortsword of Wounding",
+			"name": "Épée courte incisive",
+			"description": "<div class=\"description \">Les points de vie perdus à cause de dégâts infligés par cette arme ne peuvent être récupérés que par le biais d'un repos court ou long, mais pas à l'aide de capacités de régénération, de pouvoirs magiques, de sorts, ou de tout autre moyen.\n<br>Une fois par tour, lorsque vous touchez une créature avec une attaque utilisant cette arme magique, vous pouvez blesser profondément la cible. Au début de chacun des tours de la créature blessée, celle-ci subit 1d4 dégâts nécrotiques pour chaque blessure profonde que vous lui avez infligée, et elle peut ensuite effectuer un jet de sauvegarde de Constitution DD 15, mettant un terme à l'effet de toutes les blessures profondes que vous lui avez infligées en cas de réussite. Sinon, la créature blessée profondément, ou une créature se trouvant à 1,50 mètre d'elle, peut utiliser son action pour effectuer un jet de Sagesse (Médecine) DD 15, mettant un terme à l'effet des blessures profondes qui l'affectent en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Luck Blade Shortsword",
+			"name": "Épée courte Lame porte-bonheur",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. Tant que vous portez l'épée sur vous, vous bénéficiez également d'un bonus de +1 aux jets de sauvegarde.\n<br><strong>Chance</strong>. Si vos portez l'épée sur vous, vous pouvez invoquer sa chance (aucune action n'est requise) pour relancer un jet d'attaque, de caractéristique ou de sauvegarde dont le résultat vous déplaît. Vous devez accepter le nouveau résultat. Cette propriété ne peut pas être utilisée de nouveau avant le prochain lever du soleil.\n<br><strong>Souhait</strong>. L'épée possède 1d4 - 1 charges. Tant que vous la tenez en main, vous pouvez utiliser une action pour dépenser une charge et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em>. Cette propriété ne peut plus être utilisée avant la prochaine aube. L'épée perd cette propriété si elle n'a plus de charges.\n<br></div>"
+		},
+		{
+			"id": "Dragon Slayer Shortsword",
+			"name": "Epée courte Tueuse de dragons",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 à l'attaque et aux dégâts fait avec cette arme magique.\n<br>Si vous touchez un dragon avec cette arme, le dragon subit 3d6 dégâts supplémentaires du type de l'arme. Pour cette arme, le terme « dragon » se réfère à toute créature qui possède le type dragon, y compris les tortues dragons et les wivernes.\n<br></div>"
+		},
+		{
+			"id": "Giant Slayer Shortsword",
+			"name": "Épée courte Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Shortsword",
+			"name": "Epée courte vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Shortsword of Life Stealing",
+			"name": "Épée courte voleuse de vie",
+			"description": "<div class=\"description \">Lorsque vous attaquez une créature avec cette arme magique et obtenez un 20 au jet d'attaque, la cible subit 10 dégâts nécrotiques supplémentaires, à condition qu'elle ne soit pas une créature artificielle ou un mort-vivant. Vous gagnez un nombre de points de vie temporaires égal aux dégâts supplémentaires infligés.\n<br></div>"
+		},
+		{
+			"id": "Nine Lives Stealer Shortsword",
+			"name": "Épée courte Voleuse des neuf vies",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>L'épée possède 1d8 + 1 charges. Quand vous obtenez un coup critique contre une créature à qui il reste moins de 100 points de vies, celle-ci doit réussir un jet de sauvegarde de Constitution DD 15 ou être tuée instantanément, sa force vitale étant arrachée de son corps (les morts-vivants et les créatures artificielles sont immunisés). L'épée perd 1 charge si la créature est tuée. Elle perd cette propriété une fois toutes les charges épuisées.\n<br></div>"
+		},
+		{
+			"id": "Longsword",
+			"name": "Épée longue",
+			"description": "<p>L'épée longue est une arme très polyvalente qui peut également être maniée à deux mains pour des coups plus punitifs.</p>"
+		},
+		{
+			"id": "Longsword +1",
+			"name": "Épée longue +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Longsword +2",
+			"name": "Épée longue +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Longsword +3",
+			"name": "Épée longue +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Flame Tongue Longsword",
+			"name": "Épée longue ardente",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action bonus pour prononcer le mot de commande de l'épée, ce qui fait jaillir des flammes de la lame. Ces flammes génèrent une lumière vive dans un rayon de 12 mètres et une lumière faible sur 12 mètres supplémentaires. Tant que l'épée est en feu, elle inflige 2d6 dégâts de feu supplémentaires à toute cible qu'elle touche. Les flammes perdurent jusqu'à ce que vous utilisiez une action bonus pour prononcer le mot de commande de nouveau, ou jusqu'à ce que vous lâchiez l'épée ou la rengainiez.\n<br></div>"
+		},
+		{
+			"id": "Dancing Longsword",
+			"name": "Épée longue Dansante",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous pouvez utiliser une action bonus pour lancer cette épée magique en l'air et prononcer son mot de commande. Elle se met alors à flotter et s'envole à une distance maximum de 9 mètres, attaquant la créature de votre choix située dans un rayon de 1,50 mètre autour d'elle. L'épée utilise votre jet d'attaque et votre modificateur de caractéristique aux jets de dégâts.</p>\n<p>Tant que l'épée flotte dans les airs, vous pouvez utiliser une action bonus pour l'envoyer voler sur une distance maximum de 9 mètres jusqu'à un emplacement situé dans un rayon de 9 mètres autour de vous. Lors de cette action bonus, vous pouvez demander à l'épée d'attaquer une créature située dans un rayon de 1,50 mètre autour d'elle.</p>\n<p>Une fois que l'épée a attaqué pour la quatrième fois, elle vole sur un maximum de 9 mètres et tente de retourner dans votre main. Si vous avez les deux mains prises, elle tombe à vos pieds. Si l'épée ne dispose d'aucun chemin d'accès pour vous rejoindre, elle se rapproche de vous autant que possible et tombe à terre. Elle cesse également de flotter dans les airs si vous l'attrapez ou si vous vous éloignez à plus de 9 mètres d'elle.</p>"
+		},
+		{
+			"id": "Frost Brand Longsword",
+			"name": "Épée longue de givre",
+			"description": "<div class=\"description \">Lorsque vous touchez avec une attaque utilisant cette épée magique, la cible subit 1d6 dégâts de froid supplémentaires. En outre, tant que vous tenez l'épée, vous avez la résistance aux dégâts de feu. Dans des températures de congélation, la lame émet en lumière vive dans un rayon de 3 mètres et une lumière faible sur 3 mètres supplémentaires.\n<br>Lorsque vous dégainez cette arme, vous pouvez éteindre toutes les flammes non magiques dans un rayon de 9 mètres autour de vous. Cette propriété ne peut pas être utilisée plus d'une fois par heure.\n<br></div>"
+		},
+		{
+			"id": "Holy Avenger Longsword",
+			"name": "Épée longue de justice",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 à l'attaque et aux dégâts réalisés avec cette arme magique. Lorsque vous touchez un fiélon ou un mort-vivant avec elle, cette créature subit 2d10 dégâts radiants supplémentaires.\n<br>Tant que vous tenez l'épée dégainée, elle crée une aura dans un rayon de 3 mètres autour de vous. Vous et toutes les créatures qui vous sont amicales dans l'aura ont un avantage aux jets de sauvegarde contre les sorts et autres effets magiques. Si vous avez 17 ou plus niveaux dans la classe de paladin, le rayon de l'aura augmente de 3 mètres.\n<br></div>"
+		},
+		{
+			"id": "Defender Longsword",
+			"name": "Epée Longue Gardienne",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>La première fois que vous attaquez avec l'épée au cours de chacun de vos tours, vous pouvez transférer tout ou partie du bonus de l'épée vers votre Classe d'Armure, plutôt que d'utiliser ce bonus sur vos attaques de ce tour. Par exemple, vous pourriez réduire le bonus à votre jet d'attaque et de dégâts à +1 et ainsi gagner un bonus de +2 à votre CA. La modification du bonus reste effective jusqu'au début de votre prochain tour, mais vous devez bien entendu avoir l'épée en main pour bénéficier de son bonus à la CA.\n<br></div>"
+		},
+		{
+			"id": "Longsword of Wounding",
+			"name": "Épée longue incisive",
+			"description": "<div class=\"description \">Les points de vie perdus à cause de dégâts infligés par cette arme ne peuvent être récupérés que par le biais d'un repos court ou long, mais pas à l'aide de capacités de régénération, de pouvoirs magiques, de sorts, ou de tout autre moyen.\n<br>Une fois par tour, lorsque vous touchez une créature avec une attaque utilisant cette arme magique, vous pouvez blesser profondément la cible. Au début de chacun des tours de la créature blessée, celle-ci subit 1d4 dégâts nécrotiques pour chaque blessure profonde que vous lui avez infligée, et elle peut ensuite effectuer un jet de sauvegarde de Constitution DD 15, mettant un terme à l'effet de toutes les blessures profondes que vous lui avez infligées en cas de réussite. Sinon, la créature blessée profondément, ou une créature se trouvant à 1,50 mètre d'elle, peut utiliser son action pour effectuer un jet de Sagesse (Médecine) DD 15, mettant un terme à l'effet des blessures profondes qui l'affectent en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Luck Blade Longsword",
+			"name": "Épée longue Lame porte-bonheur",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. Tant que vous portez l'épée sur vous, vous bénéficiez également d'un bonus de +1 aux jets de sauvegarde.\n<br><strong>Chance</strong>. Si vos portez l'épée sur vous, vous pouvez invoquer sa chance (aucune action n'est requise) pour relancer un jet d'attaque, de caractéristique ou de sauvegarde dont le résultat vous déplaît. Vous devez accepter le nouveau résultat. Cette propriété ne peut pas être utilisée de nouveau avant le prochain lever du soleil.\n<br><strong>Souhait</strong>. L'épée possède 1d4 - 1 charges. Tant que vous la tenez en main, vous pouvez utiliser une action pour dépenser une charge et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em>. Cette propriété ne peut plus être utilisée avant la prochaine aube. L'épée perd cette propriété si elle n'a plus de charges.\n<br></div>"
+		},
+		{
+			"id": "Longsword of Sharpness",
+			"name": "Épée longue tranchante",
+			"description": "<div class=\"description \">Lorsque vous attaquez un objet avec cette épée magique et le touchez, les dés de dégâts de votre arme sont maximisés contre cette cible.\n<br>Lorsque vous attaquez une créature avec cette épée et obtenez un 20 naturel à votre jet d'attaque, la cible subit 14 dégâts tranchants supplémentaires. Puis lancez un autre d20. Si vous obtenez de nouveau un 20 naturel, vous amputez la cible de l'un de ses membres, l'effet d'une telle perte est déterminé par le MD. Si la créature ne possède aucun membre à sectionner, vous tranchez une portion de son corps à la place.\n<br>De plus, vous pouvez prononcer le mot de commande de la lame pour qu'elle émette une lumière vive dans un rayon de 3 mètres et une lumière faible dans un rayon supplémentaire de 3 mètres. Répétez le mot de commande ou rengainez l'épée pour éteindre la lumière.\n<br></div>"
+		},
+		{
+			"id": "Dragon Slayer Longsword",
+			"name": "Epée longue Tueuse de dragons",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 à l'attaque et aux dégâts fait avec cette arme magique.\n<br>Si vous touchez un dragon avec cette arme, le dragon subit 3d6 dégâts supplémentaires du type de l'arme. Pour cette arme, le terme « dragon » se réfère à toute créature qui possède le type dragon, y compris les tortues dragons et les wivernes.\n<br></div>"
+		},
+		{
+			"id": "Giant Slayer Longsword",
+			"name": "Épée longue Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Longsword",
+			"name": "Epée longue vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Longsword of Life Stealing",
+			"name": "Épée longue voleuse de vie",
+			"description": "<div class=\"description \">Lorsque vous attaquez une créature avec cette arme magique et obtenez un 20 au jet d'attaque, la cible subit 10 dégâts nécrotiques supplémentaires, à condition qu'elle ne soit pas une créature artificielle ou un mort-vivant. Vous gagnez un nombre de points de vie temporaires égal aux dégâts supplémentaires infligés.\n<br></div>"
+		},
+		{
+			"id": "Nine Lives Stealer Longsword",
+			"name": "Épée longue Voleuse des neuf vies",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>L'épée possède 1d8 + 1 charges. Quand vous obtenez un coup critique contre une créature à qui il reste moins de 100 points de vies, celle-ci doit réussir un jet de sauvegarde de Constitution DD 15 ou être tuée instantanément, sa force vitale étant arrachée de son corps (les morts-vivants et les créatures artificielles sont immunisés). L'épée perd 1 charge si la créature est tuée. Elle perd cette propriété une fois toutes les charges épuisées.\n<br></div>"
+		},
+		{
+			"id": "Vorpal Longsword",
+			"name": "Épée longue vorpale",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, l'arme ignore la résistance aux dégâts tranchants.\n<br>Lorsque vous attaquez une créature qui possède au moins une tête avec cette arme et que vous obtenez un 20 naturel sur votre jet d'attaque, vous décapitez la créature de l'une de ses têtes. La créature meurt si elle ne peut pas survivre après avoir perdu sa tête. Une créature est immunisée à cet effet si elle est immunisée aux dégâts tranchants, n'a pas besoin de sa tête, ou n'a pas de tête, possède des actions légendaires, ou si le MD décide que cette créature est trop grosse pour que sa tête puisse être amputée avec cette arme. De telles créatures subissent à la place 6d8 dégâts tranchants supplémentaires de ce coup.\n<br></div>"
+		},
+		{
+			"id": "Sun Blade",
+			"name": "Épée radieuse",
+			"description": "<div class=\"description \">Cet objet semble être une poignée d'épée longue. Lorsque vous saisissez la poignée, vous pouvez utiliser une action bonus pour faire apparaitre une lame de pure radiance, ou pour faire disparaître la lame. Lorsque la lame est sortie, l'épée longue magique a la propriété finesse. Si vous maîtrisez les épées longues ou courtes, vous maîtrisez l'épée radieuse.\n<br>Vous gagnez un bonus de +2 à l'attaque et aux dégâts infligés avec cette arme, qui inflige des dégâts radiants au lieu de dégâts tranchants. Quand vous frappez un mort-vivant avec cette arme, la cible subit 1d8 dégâts radiants supplémentaires.\n<br>La lame de l'épée émet une lumière vive dans un rayon de 4,50 mètres et une lumière faible sur 4,50 mètres supplémentaires. La lumière est semblable à la lumière du soleil. Tant que la lame persiste, vous pouvez utiliser une action pour augmenter ou réduire le rayon de lumière vive et de lumière faible de 1,50 mètre chacun, jusqu'à un maximum de 9 mètres ou un minimum de 3 mètres chacun.\n<br></div>"
+		},
+		{
+			"id": "Crossbow Bolt Case",
+			"name": "Étui à carreaux",
+			"description": "<p>Cet étui en bois peut contenir jusqu'à vingt carreaux d'arbalète.</p>"
+		},
+		{
+			"id": "Map or Scroll Case",
+			"name": "Étui à cartes ou parchemins",
+			"description": "<p>Cet étui en cuir cylindrique peut contenir jusqu'à dix feuilles de papier enroulées ou cinq feuilles de parchemin enroulées.</span></p>"
+		},
+		{
+			"id": "Wind Fan",
+			"name": "Éventail enchanté",
+			"description": "<div class=\"description \">Lorsque vous tenez l'éventail, vous pouvez utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=bourrasque\">bourrasque</a></em> (sauvegarde DD 13 contre celui-ci). Une fois utilisé, l'éventail ne devrait plus être utilisé à nouveau jusqu'au prochain lever du soleil. Chaque fois qu'il est utilisé à nouveau avant ce moment, il y a une chance cumulative de 20 % qu'il ne fonctionne pas et se déchire en lambeaux, inutiles non magiques.\n<br></div>"
+		},
+		{
+			"id": "Exotic Saddle",
+			"name": "Selle exotique",
+			"description": "<p>Type de siège fixé sur le dos d'une monture, conçu pour soutenir le cavalier et fixer une partie de l'équipement de la monture, comme les étriers.<br /><br />Une selle exotique est nécessaire pour monter toute monture aquatique ou volante.</p>"
+		},
+		{
+			"id": "Feed",
+			"name": "Fourrage",
+			"description": "<p>Aliment standard convenant à une monture ou à un autre animal, souvent composé de céréales ou de foin.</p>"
+		},
+		{
+			"id": "Horseshoes of Speed",
+			"name": "Fers à cheval de rapidité",
+			"description": "<div class=\"description \">Ces fers à cheval se trouvent par lot de quatre. Tant que les quatre fers sont fixés aux sabots d'un cheval ou d'une créature similaire, ils augmentent la vitesse de déplacement de la créature de 9 mètres.\n<br></div>"
+		},
+		{
+			"id": "Alchemist's Fire",
+			"name": "Feu grégeois (flasque)",
+			"description": "<p>Ce liquide adhésif et collant s'enflamme lorsqu'il est exposé à l'air. Au prix d'une action, vous pouvez jeter cette flasque jusqu'à 6 mètres, la brisant à l'impact. Faire une attaque à distance contre une créature ou un objet, en considérant le feu grégeois comme une arme improvisée. En cas de succès, la cible reçoit 1d4 dégâts de feu au début de chacun de ses tours. Une créature peut mettre fin à ces dégâts en utilisant son action pour faire un jet de Dextérité DD 10 pour éteindre les flammes.</span></p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Bronze Griffon)",
+			"name": "Figurine merveilleuse (Griffon de bronze)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A <em>Une figurine merveilleuse</em> est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Griffon de bronze</strong>. Cette statuette de bronze représente un griffon rampant. Elle peut devenir un @Compendium[dnd5e.monsters.h052EIIUmRwJum65]{Griffon} pour une durée maximale de 6 heures. Une fois utilisée, elle ne peut l'être de nouveau avant 5 jours..</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Ebony Fly)",
+			"name": "Figurine merveilleuse (Mouche d'ébène)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Mouche d'ébène</strong>. Cette statuette d'ébène est sculptée en forme de taon. Elle devient une @Compendium[dnd5e.monsters.rLl22hYeAH3ljhdI]{Mouche géante} qui peut être utilisée comme monture, pour une durée maximale de 12 heures. Une fois utilisée, elle ne peut l'être de nouveau avant 2 jours.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Golden Lions)",
+			"name": "Figurine merveilleuse (Lions d'or)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Lions d'or</strong>. Ces statuettes de lions en or sont toujours créées en paires. Vous pouvez utiliser une statuette ou les deux en même temps. Chacune peut devenir un @Compendium[dnd5e.monsters.hjhERRzafCiFFVLA]{Lion} pendant un maximum d'une heure. Une fois utilisé, un lion ne peut l'être de nouveau avant 7 jours.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Ivory Goat of Terror)",
+			"name": "Figurine merveilleuse (Boucs d'ivoire de terreur)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Boucs d'ivoire</strong>. Ces statuettes de boucs en ivoire sont toujours créées par ensemble de trois pièces. Chaque bouc est unique et fonctionne différemment des autres.</p>\n<p>Le bouc de terreur devient un @Compendium[dnd5e.monsters.rjqk7ToMD8sGr3n4]{Bouc géant} pour une durée maximal de 3 heures. Il ne peut pas attaquer mais vous pouvez retirer ses cornes pour vous en servir comme des armes. Une corne devient une @Compendium[dnd5e.items.l88FXiodYofrJT8a]{Lance d'arçon +1}, l'autre devient une @Compendium[dnd5e.items.bcv7J9culilK68zp]{Épée longue +2}. Retirer une corne nécessite une action et l'arme disparait, la corne retrouvant sa place, quand le bouc reprend sa forme de statuette.</p>\n<p>De plus, le bouc irradie d'une aura de terreur dans un rayon de 9 mètres quand vous le chevauchez. Chaque créature hostile qui débute son tour dans l'aura doit réussir un jet de sauvegarde de Sagesse DD 15 ou être effrayée par le bouc pour une durée d'une minute ou jusqu'à ce que le bouc reprenne sa forme de statuette. La créature effrayée peut répéter le jet de sauvegarde à la fin de chacun de ses tours, mettant un terme à l'effet en cas de réussite. Une fois que le jet de sauvegarde est réussi, la créature est immunisée contre l'aura du bouc pour une durée de 24 heures.</p>\n<p>Une fois utilisée, la figurine ne peut l'être de nouveau avant 15 jours.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Ivory Goat of Travail)",
+			"name": "Figurine merveilleuse (Boucs d'ivoire de labeur)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Boucs d'ivoire</strong>. Ces statuettes de boucs en ivoire sont toujours créées par ensemble de trois pièces. Chaque bouc est unique et fonctionne différemment des autres.</p>\n<p>Le bouc de labeur devient un @Compendium[dnd5e.monsters.rjqk7ToMD8sGr3n4]{Bouc géant} pour une durée maximale de 3 heures. Une fois utilisé, il ne peut l'être de nouveau avant 30 jours.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Ivory Goat of Traveling)",
+			"name": "Figurine merveilleuse (Boucs d'ivoire de voyage)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Boucs d'ivoire</strong>. Ces statuettes de boucs en ivoire sont toujours créées par ensemble de trois pièces. Chaque bouc est unique et fonctionne différemment des autres.</p>\n<p>Le bouc de voyage peut devenir un grand bouc avec les mêmes caractéristiques qu'un @Compendium[dnd5e.monsters.rz8UTUnFT87BsAFR]{Cheval}. Il dispose de 24 charges et chaque période inférieure ou égale à une heure passée sous sa forme animale coute une charge. Tant qu'il possède des charges, vous pouvez l'utiliser aussi souvent que souhaité. Lorsque toutes les charges sont dépensées, il reprend la forme d'une statuette et celle-ci ne peut plus être utilisée de nouveau avant 7 jours, quand elle récupère toutes ses charges.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Marble Elephant)",
+			"name": "Figurine merveilleuse (Éléphant de marbre)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Éléphant de marbre</strong>. Cette statuette de marbre mesure environ 10 cm de haut et de long. Elle peut devenir un @Compendium[dnd5e.monsters.jLPhaBnMtAbB5dp1]{Éléphant} pour une durée maximale de 24 heures. Une fois utilisée, elle ne peut l'être de nouveau avant 7 jours.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Obsidian Steed)",
+			"name": "Figurine merveilleuse (Cheval d'obsidienne)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Cheval d'obsidienne</strong>. Ce cheval en obsidienne poli peut devenir un @Compendium[dnd5e.monsters.5SgVGhQBswgWRwsF]{Destrier noir} pour une durée maximale de 24 heures. Le destrier noir ne se bat que pour se défendre. Une fois utilisé, il ne peut l'être de nouveau avant 5 jours.</p>\n<p>Si votre alignement est bon, la statuette a 10 % de chance, chaque fois que vous l'utilisez, d'ignorer vos ordres, y compris pour le mot de commande pour lui rendre sa forme de statuette. Si vous chevauchez le destrier noir alors qu'il ignore vos ordres, vous êtes instantanément transporté avec le destrier noir dans un lieu aléatoire du plan d'Hadès, où la statuette reprendra sa forme.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Onyx Dog)",
+			"name": "Figurine merveilleuse (Chien d'onyx)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Chien d'onyx</strong>. Cette statuette de chien en onyx peut devenir un @Compendium[dnd5e.monsters.YTpL2c3NO4sOn2UA]{Mastiff} pour une durée maximale de 6 heures. Le molosse a une Intelligence de 8 et peut parler le commun. Il peut voir dans le noir, ainsi que les objets et créatures invisibles, jusqu'à une portée de 18 mètres. Une fois utilisé, il ne peut l'être de nouveau avant 7 jours.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Serpentine Owl)",
+			"name": "Figurine merveilleuse (Chouette en serpentine)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Chouette en serpentine</strong>. Cette statuette de chouette en serpentine peut devenir une @Compendium[dnd5e.monsters.VVXly3ue0i3YgGrB]{Chouette géante} pour une durée maximale de 8 heures. Une fois utilisée, elle ne peut l'être de nouveau avant 2 jours. La chouette peut communiquer par télépathie avec vous, quelle que soit la distance qui vous sépare, tant que vous vous trouvez sur le même plan d'existence.</p>"
+		},
+		{
+			"id": "Figurine of Wondrous Power (Silver Raven)",
+			"name": "Figurine merveilleuse (Corbeau d'argent)",
+			"description": "<p><em>Objet merveilleux, rareté selon le type de statuette</em></p>\n<p>A&nbsp;<em>Une figurine merveilleuse</em>&nbsp;est une statuette de bête suffisamment petite pour être placée dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, celle-ci devient une créature vivante. Si l'espace est déjà occupé par une autre créature ou s'il n'y a pas assez d'espace, la figurine ne prend pas la forme d'une créature.</p>\n<p>La créature est amicale avec vous et vos compagnons. Elle comprend vos langues et obéit à vos ordres audibles. Si vous ne donnez aucun ordre, la créature se défend mais n'effectue aucune autre action. Se reporter au Manuel des Monstres pour les caractéristiques, sauf pour la mouche géante.</p>\n<p>La créature existe pour une durée spécifique à chaque statuette. À la fin de cette durée, la créature reprend la forme de la statuette. Elle reprend la forme de la figurine plus tôt si elle tombe à 0 pv ou si vous utilisez une action pour prononcer le mot de commande tout en la touchant. Quand la créature redevient une statuette, ses propriétés ne peuvent être de nouveau utilisées avant un certain temps, spécifié dans la description de la statuette.</p>\n<p><strong>Corbeau d'argent</strong>. Cette statuette de corbeau en argent peut devenir un @Compendium[dnd5e.monsters.LPdX5YLlwci0NDZx]{Corbeau} pour une durée maximale de 12 heures. Une fois utilisée, elle ne peut plus l'être avant 2 jours. Dans sa forme animale, la statuette vous permet de lancer sur elle le sort @Compendium[dnd5e.spells.X8w9EzYLGc4vQ1H2]{Messager animal} à volonté.</p>"
+		},
+		{
+			"id": "Net",
+			"name": "Filet",
+			"description": "<p>Une créature de taille G ou plus petite qui est touchée par un filet est entravée jusqu'à ce qu'elle soit libérée. Un filet n'a aucun effet sur les créatures sans forme ou de taille supérieure à G. Une créature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se libérer ou de libérer une autre créature à sa portée en cas de succès. Infliger 5 points de dégâts tranchants à un filet (CA 10) permet également de libérer une créature sans la blesser, mettant fin à l'effet tout en détruisant le filet. Lorsque vous utilisez une action, une action bonus ou une réaction pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement réaliser.</p>"
+		},
+		{
+			"id": "Net +1",
+			"name": "Filet +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special.</strong><p>Une créature de taille G ou plus petite qui est touchée par un filet est entravée jusqu'à ce qu'elle soit libérée. Un filet n'a aucun effet sur les créatures sans forme ou de taille supérieure à G. Une créature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se libérer ou de libérer une autre créature à sa portée en cas de succès. Infliger 5 points de dégâts tranchants à un filet (CA 10) permet également de libérer une créature sans la blesser, mettant fin à l'effet tout en détruisant le filet. Lorsque vous utilisez une action, une action bonus ou une réaction pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement réaliser.</p>"
+		},
+		{
+			"id": "Net +2",
+			"name": "Filet +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special.</strong><p>Une créature de taille G ou plus petite qui est touchée par un filet est entravée jusqu'à ce qu'elle soit libérée. Un filet n'a aucun effet sur les créatures sans forme ou de taille supérieure à G. Une créature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se libérer ou de libérer une autre créature à sa portée en cas de succès. Infliger 5 points de dégâts tranchants à un filet (CA 10) permet également de libérer une créature sans la blesser, mettant fin à l'effet tout en détruisant le filet. Lorsque vous utilisez une action, une action bonus ou une réaction pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement réaliser.</p>"
+		},
+		{
+			"id": "Net +3",
+			"name": "Filet +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special.</strong><p>Une créature de taille G ou plus petite qui est touchée par un filet est entravée jusqu'à ce qu'elle soit libérée. Un filet n'a aucun effet sur les créatures sans forme ou de taille supérieure à G. Une créature peut utiliser son action pour effectuer un jet de Force DD 10 afin de se libérer ou de libérer une autre créature à sa portée en cas de succès. Infliger 5 points de dégâts tranchants à un filet (CA 10) permet également de libérer une créature sans la blesser, mettant fin à l'effet tout en détruisant le filet. Lorsque vous utilisez une action, une action bonus ou une réaction pour attaquer avec un filet, vous ne pouvez effectuer qu'une seule attaque, et ce quel que soit le nombre d'attaques que vous pouvez normalement réaliser.</p>"
+		},
+		{
+			"id": "Vial",
+			"name": "Fiole (10 cl)",
+			"description": "<p>Une fiole qui peut contenir 10 cl de liquide.</span></p>"
+		},
+		{
+			"id": "Iron Flask",
+			"name": "Flasque de fer",
+			"description": "<div class=\"description \">Cette urne en fer possède un bouchon en laiton. Vous pouvez utiliser une action pour prononcer le mot de commande de la flasque, tout en ciblant une créature que vous pouvez voir et se trouvant à 18 mètres de vous maximum. Si la cible est native d'un autre plan d'existence que celui sur lequel vous vous trouvez, la cible doit réussir un jet de sauvegarde de Sagesse DD 17 sous peine d'être emprisonnée dans la flasque. Si la cible a déjà été emprisonnée dans la flasque par le passé, elle a un avantage à son jet de sauvegarde. Une fois capturée, une créature reste dans la flasque jusqu'à ce qu'elle soit libérée. La flasque ne peut contenir qu'une seule créature à la fois. Une créature prisonnière de la flasque n'a pas besoin de respirer, manger, ou boire, et ne vieillit pas.\n<br>Vous pouvez utiliser une action pour enlever le bouchon de la flasque et libérer la créature qu'elle contient. La créature est amicale envers vous et vos compagnons pendant 1 heure et obéit à vos ordres pendant toute cette durée. Si vous ne lui donnez aucun ordre ou si vous lui donnez un ordre qu'il la mènera vers une mort certaine, la créature se défend elle-même mais n'entreprend aucune autre action. À la fin de cette durée, la créature agit conformément à ses dispositions naturelles et à son alignement.\n<br>Un sort d'<em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=identification\">identification</a></em> révèle si une créature se trouve dans la flasque, mais le seul moyen de déterminer le type de la créature est d'ouvrir la flasque. Une urne nouvellement découverte pourrait déjà contenir une créature choisie par le MD ou déterminée aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Contenu</th></tr><tr><td class=\"center\">1-50</td><td>Vide</td></tr><tr><td class=\"center\">51</td><td>Arcanaloth</td></tr><tr><td class=\"center\">52</td><td>Cambion</td></tr><tr><td class=\"center\">53-54</td><td>Dao</td></tr><tr><td class=\"center\">55-57</td><td>Démon (type 1)</td></tr><tr><td class=\"center\">58-60</td><td>Démon (type 2)</td></tr><tr><td class=\"center\">61-62</td><td>Démon (type 3)</td></tr><tr><td class=\"center\">63-64</td><td>Démon (type 4)</td></tr><tr><td class=\"center\">65</td><td>Démon (type 5)</td></tr><tr><td class=\"center\">66</td><td>Démon (type 6)</td></tr><tr><td class=\"center\">67</td><td>Déva</td></tr><tr><td class=\"center\">68-69</td><td>Diable (supérieur)</td></tr><tr><td class=\"center\">70-72</td><td>Diable (inférieur)</td></tr><tr><td class=\"center\">73-74</td><td>Djinn</td></tr><tr><td class=\"center\">75-76</td><td>Éfrit</td></tr><tr><td class=\"center\">77-78</td><td>Élémentaire (tous types)</td></tr><tr><td class=\"center\">79</td><td>Githyanki, chevalier</td></tr><tr><td class=\"center\">80</td><td>Githzerai, zerth</td></tr><tr><td class=\"center\">81-82</td><td>Traqueur invisible</td></tr><tr><td class=\"center\">83-84</td><td>Maride</td></tr><tr><td class=\"center\">85-86</td><td>Mezzoloth</td></tr><tr><td class=\"center\">87-88</td><td>Guenaude nocturne</td></tr><tr><td class=\"center\">89-90</td><td>Nycaloth</td></tr><tr><td class=\"center\">91</td><td>Planétar</td></tr><tr><td class=\"center\">92-93</td><td>Salamandre</td></tr><tr><td class=\"center\">94-95</td><td>Slaad (tous types)</td></tr><tr><td class=\"center\">96</td><td>Solar</td></tr><tr><td class=\"center\">97-98</td><td>Succube/incube</td></tr><tr><td class=\"center\">99</td><td>Ultroloth</td></tr><tr><td class=\"center\">100</td><td>Xorn</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Flask",
+			"name": "Flasque ou chope (50 cl)",
+			"description": "<p>Un flacon contient 1/2 litre de liquide.</p>"
+		},
+		{
+			"id": "Flail",
+			"name": "Fléau d'armes",
+			"description": "<p>Un ensemble de boules à pointes reliées par une chaîne et attachées à un solide manche en bois. Le fléau provoque des dégâts dévastateurs lorsqu'il tourne en arc de cercle mortel.</p>"
+		},
+		{
+			"id": "Flail +1",
+			"name": "Fléau d'armes +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Flail +2",
+			"name": "Fléau d'armes +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Flail +3",
+			"name": "Fléau d'armes +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Flail",
+			"name": "Fléau d'armes vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Arrow",
+			"name": "Flèche",
+			"description": "Munitions standard utilisées pour les arcs de toutes sortes. Ces flèches banales sont fabriquées à partir d'un manche en bois lisse, avec des plumes d'oie et un revêtement en métal martelé."
+		},
+		{
+			"id": "Arrow +1",
+			"name": "Flèche +1",
+			"description": "<p>Munition utilisée par les arcs.&nbsp; Elle a été imprégée par de la magie.</p>\n<p>Vous avez un bonus aux jets d'attaque et de dégats avec cette munition magique. La munition n'est plus magique après avoir toucher une cible.</p>"
+		},
+		{
+			"id": "Arrow +2",
+			"name": "Flèche +2",
+			"description": "<p>Munition utilisée par les arcs.&nbsp; Elle a été imprégée par de la magie.</p>\n<p>Vous avez un bonus aux jets d'attaque et de dégats avec cette munition magique. La munition n'est plus magique après avoir toucher une cible.</p>"
+		},
+		{
+			"id": "Arrow +3",
+			"name": "Flèche +3",
+			"description": "<p>Munition utilisée par les arcs.&nbsp; Elle a été imprégée par de la magie.</p>\n<p>Vous avez un bonus aux jets d'attaque et de dégats avec cette munition magique. La munition n'est plus magique après avoir toucher une cible.</p>"
+		},
+		{
+			"id": "Arrow of Slaying",
+			"name": "Flèche tueuse",
+			"description": "<p>An&nbsp;Flèche tueuse&nbsp;est une munition magique destinée à abattre un type de créature en particulier. Certaines sont plus spécifiques que d'autres ; par exemple, il existe des flèches tueuses de dragons et des flèches tueuses de dragons bleu. Si une créature appartenant au type, à la race ou au groupe associé à la flèche tueuse subit des dégâts de cette flèche, cette créature doit effectuer un jet de sauvegarde de Constitution DD 17, subissant 6d10 dégâts perforants supplémentaires en cas d'échec, ou la moitié de ces dégâts supplémentaires en cas de réussite.<br />une fois qu'une&nbsp;arrow of slaying&nbsp;a infligé ses dégâts supplémentaires à une créature, elle devient une simple flèche non magique.</p>"
+		},
+		{
+			"id": "Dart",
+			"name": "Fléchette",
+			"description": "<p>Un petit outil de lancé fabriqué en bois avec un empennage en plume en forme de croix ainsi qu'une extrémité pointue en bois ou en métal. Avec suffisament de force, une fléchette peut percer la peau.</p>"
+		},
+		{
+			"id": "Dart +1",
+			"name": "Fléchette +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Dart +2",
+			"name": "Fléchette +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Dart +3",
+			"name": "Fléchette +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Dart",
+			"name": "Fléchette vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Flute",
+			"name": "Flûte",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Pan Flute",
+			"name": "Flûte de Pan",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Pipes of the Sewers",
+			"name": "Flûte des égouts",
+			"description": "<div class=\"description \">Vous devez avoir la maîtrise des instruments à vent pour utiliser cette flûte. Tant que vous êtes lié à cette flûte, les rats ordinaires et les rats géants sont indifférent à votre égard à moins que vous ne les attaquiez, les menaciez ou les blessiez.\n<br>La flûte possède 3 charges. Si vous utilisez une action pour jouer de la flûte, vous pouvez, en tant qu'action bonus, dépenser 1 à 3 charges pour appeler une nuée de rat par charges pour autant qu'il y ait suffisamment des rats dans un rayon de 800 mètres à la ronde. S'il n'y a pas assez de rats pour faire une nuée, la charge est perdue. La nuée se contente de suivre la musique par le chemin le plus court mais n'est pas sous votre contrôle. la flûte récupère 1d3 charges dépensées chaque jour à l'aube.\n<br>Quand une nuée de rat qui n'est pas sous le contrôle d'une autre créature se trouve à 6 mètres ou moins de vous alors que vous jouez de la flûte, vous pouvez faire un jet de Charisme contre la Sagesse de la nuée. Si vous échouez, la nuée se comporte normalement et ne peut plus être charmée par la flûte pendant 24 heures. Si vous remportez l'opposition, la nuée est subjuguée par la mélodie qui émane de la flûte et devient amicale envers vous et vos compagnons tant que vous jouez (ce qui vous coûte votre action chaque tour). Une nuée amicale obéit à vos ordres. Si vous ne lui en donnez aucun, elle se contente de se défendre sans entreprendre d'autres actions. Une nuée amicale qui commence son tour sans entendre la musique de la flûte se libère de votre contrôle, adopte son comportement normal et ne peut plus être charmé de la sorte avant 24 heures.\n<br></div>"
+		},
+		{
+			"id": "Pipes of Haunting",
+			"name": "Flûte terrifiante",
+			"description": "<div class=\"description \">Vous devez avoir la maîtrise des instruments à vent pour pouvoir utiliser cette flûte. Elle a 3 charges. Par une action vous pouvez jouer de cette flûte et dépenser une charge pour produire un air envoûtant et mystérieux. Chaque créature dans les 6 mètres qui vous entend jouer doit réussir un jet de sauvegarde de Sagesse DD 15 ou être effrayée pendant 1 minute. Si vous le souhaitez, toutes les créatures à portée qui ne vous sont pas hostiles peuvent réussir automatiquement ce jet de sauvegarde. Une créature qui échoue peut retenter le jet de sauvegarde à la fin de chacun de ses tours, mettant ainsi fin à l'effet en cas de réussite. Une créature qui réussit le jet de sauvegarde devient immunisée contre cette flûte pour 24 heures. La flûte regagne 1d3 charges dépensées chaque jour à l'aube.\n<br></div>"
+		},
+		{
+			"id": "Instant Fortress",
+			"name": "Forteresse instantanée de Daern",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour poser sur le sol ce cube métallique de 2,50 centimètres d'arête et prononcer le mot de commande. Le cube grandit rapidement jusqu'à prendre la forme d'une forteresse qui reste en place jusqu'à ce que vous utilisiez une action pour prononcer le mot de commande qui l'annule (mot de commande qui ne fonctionne que lorsque la forteresse est vide).\n<br>La forteresse est une tour carrée de 6 mètres de côté et de 9 mètres de haut, qui possède des meurtrières sur chacune de ses faces et des créneaux à son sommet. Son intérieur est divisé en deux niveaux, reliés par une échelle qui court le long d'un mur. L'échelle se termine au niveau d'une trappe donnant sur le toit. Lorsqu'elle est activée, la tour possède une porte sur le mur qui vous fait face. La porte ne s'ouvre que sur votre demande, ce qui vous prend une action bonus. Elle est immunisée au sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=deblocage\">déblocage</a></em> ou à toute autre magie similaire, comme un carillon d'ouverture.\n<br>Chaque créature présente dans la zone où la forteresse apparaît doit effectuer un jet de sauvegarde de Dextérité DD 15, subissant 10d10 dégâts contondants en cas d'échec, ou la moitié de ces dégâts en cas de réussite.\n<br>Dans les deux cas, la créature est repoussée dans un espace inoccupé en dehors, mais à côté, de la forteresse. Les objets dans la zone qui ne sont pas portés ni transportés subissent ces dégâts et sont repoussés automatiquement.\n<br>La tour est faite en adamantium, et sa magie l'empêche d'être renversée. Le toit, la porte, et les murs ont chacun 100 points de vie, une immunité aux dégâts des armes non magiques à l'exception des armes de siège, et la résistance à tous les autres types de dégâts. Seul un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> peut réparer la forteresse (cette utilisation du sort compte comme une imitation d'un sort de niveau 8 ou supérieur). Chaque sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em> lancé rend 50 points de vie à un mur, au toit, ou à la porte.\n<br></div>"
+		},
+		{
+			"id": "Whip",
+			"name": "Fouet",
+			"description": "<p>Une corde tendue faîte de cuir, de corde ou de chaîne qui peut attraper des ennemis proches, les lacérant et les harcelant à distance.</p>"
+		},
+		{
+			"id": "Whip +1",
+			"name": "Fouet +1",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Whip +2",
+			"name": "Fouet +2",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Whip +3",
+			"name": "Fouet +3",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Vicious Whip",
+			"name": "Fouet vicieux",
+			"description": "<p>A tensile lash made of leather, cord, or chain which can lash out at nearby enemies, dealing lacerations and harrying them from a distance.</p>\n<p>When you roll a 20 on your attack roll with this magic weapon, your critical hit deals an extra 2d6 damage of the weapon's type.</p>"
+		},
+		{
+			"id": "Sling",
+			"name": "Fronde",
+			"description": "<p>Une lanière de cuir flexible fixée à un manche en bois qui est capable de projeter des pierres ou des balles métalliques à une vitesse mortelle.</p>"
+		},
+		{
+			"id": "Sling +1",
+			"name": "Fronde +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Sling +2",
+			"name": "Fronde +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Sling +3",
+			"name": "Fronde +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Sling",
+			"name": "Fronde vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Mess Kit",
+			"name": "Gamelle",
+			"description": "<p>Cette boîte en étain contient une tasse et des couverts. Faite de deux parties qui s'assemblent, un côté de la boîte peut être utilisé pour cuire des aliments et l'autre comme une assiette ou une petite cuvette.</p>"
+		},
+		{
+			"id": "Gauntlets of Ogre Power",
+			"name": "Gantelets de puissance d'ogre",
+			"description": "<div class=\"description \">Votre Force est de 19 tant que vous portez ces gantelets. Les gantelets n'ont aucun effet sur vous si votre Force est de 19 ou plus sans eux.\n<br></div>"
+		},
+		{
+			"id": "Gloves of Missile Snaring",
+			"name": "Gants antiprojectiles",
+			"description": "<div class=\"description \">Ces gants semblent fusionner avec vos mains lorsque vous les enfilez. Lorsqu'une attaque à distance avec une arme vous touche alors que vous avez équipé ces gants, vous pouvez utiliser votre réaction pour réduire les dégâts de 1d10 + votre modificateur de Dextérité, à condition que vous ayez au moins une main de libre. Si vous réduisez les dégâts à 0, vous pouvez attraper le projectile s'il est suffisamment petit pour que vous le teniez dans une main.\n<br></div>"
+		},
+		{
+			"id": "Gloves of Swimming and Climbing",
+			"name": "Gants de nage et d'escalade",
+			"description": "<div class=\"description \">Lorsque vous portez ces gants, escalader et nager ne vous coûte pas de mouvement supplémentaire, et vous obtenez un bonus de +5 aux jets de Force (Athlétisme) pour escalader ou nager.\n<br></div>"
+		},
+		{
+			"id": "Gem of Brightness",
+			"name": "Gemme d'illumination",
+			"description": "<div class=\"description \">Ce prisme possède 50 charges. Tant que vous le tenez, vous pouvez utiliser une action pour prononcer l'un des trois mots de commande et ainsi provoquer l'un des trois effets suivants :\n<br>• Premier mot de commande : la gemme se met à émettre une forte lueur dans un rayon de 9 mètres et une faible lueur dans un rayon supplémentaire de 9 mètres. Cet effet ne dépense pas de charge. Il perdure jusqu'à ce que vous utilisiez une action bonus pour répéter le mot de commande ou jusqu'à ce que vous utilisiez une autre fonction de la gemme.\n<br>• Second mot de commande : Ce mot dépense 1 charge. La gemme tire un puissant rayon de lumière sur une créature que vous pouvez voir et se trouvant dans un rayon de 18 mètres de vous. La créature doit réussir un jet de sauvegarde de Constitution DD 15 sous peine d'être aveuglée pendant 1 minute. La créature peut retenter son jet de sauvegarde à la fin de chacun de ses tours, mettant un terme à l'effet qui l'affecte en cas de réussite au jet.\n<br>• Troisième mot de commande : Ce mot dépense 5 charges. La gemme rayonne d'une lumière aveuglante dans un cône de 9 mètres dont elle est l'origine. Chaque créature présente dans le cône doit effectuer un jet de sauvegarde comme si elle était la cible d'un rayon lumineux créé par le second mot de commande.\n<br>Lorsque toutes les charges de la gemme sont dépensées, la gemme devient un joyau non magique d'une valeur de 50 po.\n<br></div>"
+		},
+		{
+			"id": "Gem of Seeing",
+			"name": "Gemme de vision",
+			"description": "<div class=\"description \">Cette gemme possède 3 charges. En utilisant une action, vous pouvez prononcer le mot de commande de la gemme et dépenser 1 charge. Pour les 10 minutes qui suivent, vous obtenez la vision véritable à 36 mètres lorsque vous regardez au travers de la gemme. La gemme récupère 1d3 charges dépensées chaque jour au lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Elemental Gem of Air",
+			"name": "Gemme élémentaire d'air",
+			"description": "<div class=\"description \">Cette gemme contient un brin d'énergie élémentaire. Lorsque vous utilisez une action pour briser la gemme, un élémentaire est invoqué comme si vous aviez jeté le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>, et la magie de la gemme est perdue. Le type de gemme détermine l'élémentaire invoqué par le sort.\n<br><table><tbody><tr><th>Gemme</th><th>Élémentaire invoqué</th></tr><tr><td>Saphir bleu</td><td>Élémentaire de l'air</td></tr><tr><td>Diamant jaune</td><td>Élémentaire de la terre</td></tr><tr><td>Corindon rouge</td><td>Élémentaire du feu</td></tr><tr><td>Émeraude</td><td>Élémentaire de l'eau</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Elemental Gem of Water",
+			"name": "Gemme élémentaire d'eau",
+			"description": "<div class=\"description \">Cette gemme contient un brin d'énergie élémentaire. Lorsque vous utilisez une action pour briser la gemme, un élémentaire est invoqué comme si vous aviez jeté le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>, et la magie de la gemme est perdue. Le type de gemme détermine l'élémentaire invoqué par le sort.\n<br><table><tbody><tr><th>Gemme</th><th>Élémentaire invoqué</th></tr><tr><td>Saphir bleu</td><td>Élémentaire de l'air</td></tr><tr><td>Diamant jaune</td><td>Élémentaire de la terre</td></tr><tr><td>Corindon rouge</td><td>Élémentaire du feu</td></tr><tr><td>Émeraude</td><td>Élémentaire de l'eau</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Elemental Gem of Fire",
+			"name": "Gemme élémentaire de feu",
+			"description": "<div class=\"description \">Cette gemme contient un brin d'énergie élémentaire. Lorsque vous utilisez une action pour briser la gemme, un élémentaire est invoqué comme si vous aviez jeté le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>, et la magie de la gemme est perdue. Le type de gemme détermine l'élémentaire invoqué par le sort.\n<br><table><tbody><tr><th>Gemme</th><th>Élémentaire invoqué</th></tr><tr><td>Saphir bleu</td><td>Élémentaire de l'air</td></tr><tr><td>Diamant jaune</td><td>Élémentaire de la terre</td></tr><tr><td>Corindon rouge</td><td>Élémentaire du feu</td></tr><tr><td>Émeraude</td><td>Élémentaire de l'eau</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Elemental Gem of Earth",
+			"name": "Gemme élémentaire de terre",
+			"description": "<div class=\"description \">Cette gemme contient un brin d'énergie élémentaire. Lorsque vous utilisez une action pour briser la gemme, un élémentaire est invoqué comme si vous aviez jeté le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>, et la magie de la gemme est perdue. Le type de gemme détermine l'élémentaire invoqué par le sort.\n<br><table><tbody><tr><th>Gemme</th><th>Élémentaire invoqué</th></tr><tr><td>Saphir bleu</td><td>Élémentaire de l'air</td></tr><tr><td>Diamant jaune</td><td>Élémentaire de la terre</td></tr><tr><td>Corindon rouge</td><td>Élémentaire du feu</td></tr><tr><td>Émeraude</td><td>Élémentaire de l'eau</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Waterskin",
+			"name": "Gourde (pleine)",
+			"description": "<p>Une peau de cuir cousue dans une peau fermée qui peut contenir jusqu'à 3 litres de liquide. Elle pèse 3,5 kg lorsqu'elle est pleine.</p>"
+		},
+		{
+			"id": "Club",
+			"name": "Gourdin",
+			"description": "<p>Un gros bout de bois de forme un simple, mais efficace, aussi appelée calebasse. Ces armes sont utilisées pour matraquer les ennemis, meurtrir la chair et briser les os.</p>"
+		},
+		{
+			"id": "Club +1",
+			"name": "Gourdin +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Club +2",
+			"name": "Gourdin +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Club +3",
+			"name": "Gourdin +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Club",
+			"name": "Gourdin vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Grappling Hook",
+			"name": "Grappin",
+			"description": "<p>Un appareil avec des griffes en fer, peut être utilisé avec une corde pour traîner ou saisir.</p>"
+		},
+		{
+			"id": "Spellbook",
+			"name": "Grimoire",
+			"description": "<p>Essentiel pour les magiciens, un grimoire est un livre relié en cuir qui contient 100 pages de vélin blanc, et sur lesquelles on peut recopier des sorts.</p>\n<p>&nbsp;</p>"
+		},
+		{
+			"id": "Giant Slayer Greataxe",
+			"name": "Hache à 2 mains Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Greataxe",
+			"name": "Hache à 2 mains vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Greataxe",
+			"name": "Hache à deux mains",
+			"description": "Cette énorme hache comporte deux lames en double croissant montées de chaque côté d'un grand arbre à pointes. Conçue pour être maniée à deux mains et pour fendre les ennemis en deux"
+		},
+		{
+			"id": "Greataxe +1",
+			"name": "Hache à deux mains +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Greataxe +2",
+			"name": "Hache à deux mains +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Greataxe +3",
+			"name": "Hache à deux mains +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Berserker Greataxe",
+			"name": "Hache à deux mains de Berserker",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, tant que vous êtes lié à cette arme, vos points de vie maximums augmentent de 1 pour chaque niveau de classe que vous possédez.</p>\n<p><strong>Malédiction</strong>. Cette hache est maudite, et vous lier à elle revient à partager sa malédiction. Tant que vous êtes maudit, vous ne voulez pas vous séparer de la hache, la gardant à portée de main à tout instant. Vous avez également un désavantage aux jets d'attaque effectués avec d'autres armes que cette hache, à moins qu'aucun ennemi, que vous pouvez voir ou entendre, ne se trouve dans un rayon de 18 mètres autour de vous.</p>\n<p>À chaque fois qu'une créature hostile vous inflige des dégâts alors que la hache est en votre possession, vous devez réussir un jet de sauvegarde de Sagesse DD 15 sous peine de devenir fou furieux. Tant que vous êtes fou furieux, vous devez utiliser votre action à chaque tour pour attaquer avec la hache la créature la plus proche de vous. Si vous pouvez effectuer des attaques supplémentaires avec votre action Attaquer, vous utilisez ses attaques supplémentaires, vous déplaçant pour attaquer la créature suivante la plus proche une fois que votre première cible est tombée au combat.</p>\n<p>Si vous avez plusieurs cibles potentielles, vous en attaquez une au hasard. Vous êtes fou furieux jusqu'à ce que votre tour ne commence et qu'aucune créature que vous pouvez voir ou entendre ne se trouve dans un rayon de 18 mètres autour de vous.</p>"
+		},
+		{
+			"id": "Battleaxe",
+			"name": "Hache d'armes",
+			"description": "<p>Une lame en croissant robuste montée sur un manche épais entouré de cuir pour une meilleur prise. Cette hache est assez grande pour être maniée à deux mains et est ornée de pointes sur le côté opposé de la lame et au bout du manche.</p>"
+		},
+		{
+			"id": "Battleaxe +1",
+			"name": "Hache d'armes +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Battleaxe +2",
+			"name": "Hache d'armes +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Battleaxe +3",
+			"name": "Hache d'armes +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Berserker Battleaxe",
+			"name": "Hache d'armes de Berserker",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, tant que vous êtes lié à cette arme, vos points de vie maximums augmentent de 1 pour chaque niveau de classe que vous possédez.</p>\n<p><strong>Malédiction</strong>. Cette hache est maudite, et vous lier à elle revient à partager sa malédiction. Tant que vous êtes maudit, vous ne voulez pas vous séparer de la hache, la gardant à portée de main à tout instant. Vous avez également un désavantage aux jets d'attaque effectués avec d'autres armes que cette hache, à moins qu'aucun ennemi, que vous pouvez voir ou entendre, ne se trouve dans un rayon de 18 mètres autour de vous.</p>\n<p>À chaque fois qu'une créature hostile vous inflige des dégâts alors que la hache est en votre possession, vous devez réussir un jet de sauvegarde de Sagesse DD 15 sous peine de devenir fou furieux. Tant que vous êtes fou furieux, vous devez utiliser votre action à chaque tour pour attaquer avec la hache la créature la plus proche de vous. Si vous pouvez effectuer des attaques supplémentaires avec votre action Attaquer, vous utilisez ses attaques supplémentaires, vous déplaçant pour attaquer la créature suivante la plus proche une fois que votre première cible est tombée au combat.</p>\n<p>Si vous avez plusieurs cibles potentielles, vous en attaquez une au hasard. Vous êtes fou furieux jusqu'à ce que votre tour ne commence et qu'aucune créature que vous pouvez voir ou entendre ne se trouve dans un rayon de 18 mètres autour de vous.</p>"
+		},
+		{
+			"id": "Giant Slayer Battleaxe",
+			"name": "Hache d'armes Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Battleaxe",
+			"name": "Hache d'armes vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Handaxe",
+			"name": "Hachette",
+			"description": "<p>Cette hache à une main est légère et équilibrée pour le lancer tout en restant utile dans le combat au contact.</p>"
+		},
+		{
+			"id": "Handaxe +1",
+			"name": "Hachette +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Handaxe +2",
+			"name": "Hachette +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Handaxe +3",
+			"name": "Hachette +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Berserker Handaxe",
+			"name": "Hachette de Berserker",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. De plus, tant que vous êtes lié à cette arme, vos points de vie maximums augmentent de 1 pour chaque niveau de classe que vous possédez.</p>\n<p><strong>Malédiction</strong>. Cette hache est maudite, et vous lier à elle revient à partager sa malédiction. Tant que vous êtes maudit, vous ne voulez pas vous séparer de la hache, la gardant à portée de main à tout instant. Vous avez également un désavantage aux jets d'attaque effectués avec d'autres armes que cette hache, à moins qu'aucun ennemi, que vous pouvez voir ou entendre, ne se trouve dans un rayon de 18 mètres autour de vous.</p>\n<p>À chaque fois qu'une créature hostile vous inflige des dégâts alors que la hache est en votre possession, vous devez réussir un jet de sauvegarde de Sagesse DD 15 sous peine de devenir fou furieux. Tant que vous êtes fou furieux, vous devez utiliser votre action à chaque tour pour attaquer avec la hache la créature la plus proche de vous. Si vous pouvez effectuer des attaques supplémentaires avec votre action Attaquer, vous utilisez ses attaques supplémentaires, vous déplaçant pour attaquer la créature suivante la plus proche une fois que votre première cible est tombée au combat.</p>\n<p>Si vous avez plusieurs cibles potentielles, vous en attaquez une au hasard. Vous êtes fou furieux jusqu'à ce que votre tour ne commence et qu'aucune créature que vous pouvez voir ou entendre ne se trouve dans un rayon de 18 mètres autour de vous.</p>"
+		},
+		{
+			"id": "Giant Slayer Handaxe",
+			"name": "Hachette Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Handaxe",
+			"name": "Hachette vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Halberd",
+			"name": "Hallebarde",
+			"description": "<p>La hallebarde est une arme défensive puissante qui permet à un guerrier de repousser ses ennemis en utilisant la longue portée du manche et ainsi attaquer à distance de sécurité.</p>"
+		},
+		{
+			"id": "Halberd +1",
+			"name": "Hallebarde +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Halberd +2",
+			"name": "Hallebarde +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Halberd +3",
+			"name": "Hallebarde +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Halberd",
+			"name": "Hallebarde vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Plate Armor",
+			"name": "Harnois",
+			"description": "<p>Le harnois est constitué de plaques de métal entrecroisées qui couvrent l'ensemble du corps. L'ensemble inclut des gants, des bottes en cuir épais, un casque à visière, et d'épaisses couches de rembourrage sous l'armure. Des boucles et des sangles distribuent le poids sur le corps.</p>"
+		},
+		{
+			"id": "Plate Armor +1",
+			"name": "Harnois +1",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Plate Armor +2",
+			"name": "Harnois +2",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Plate Armor +3",
+			"name": "Harnois +3",
+			"description": "<div class=\"description \">Lorsque vous portez cette armure, vous obtenez un bonus à la CA. Le bonus dépend de la rareté.\n<br></div>"
+		},
+		{
+			"id": "Mithral Plate Armor",
+			"name": "Harnois de mithral",
+			"description": "<div class=\"description \">Le mithral est un métal souple et léger. Une chemise de mailles ou une cuirasse en mithral peuvent être portées sous des vêtements normaux. Si l'armure impose normalement un désavantage aux jets de Dextérité (Discrétion) ou a un prérequis de Force, la version en mithral de l'armure ne l'a pas.\n<br></div>"
+		},
+		{
+			"id": "Plate Armor of Resistance",
+			"name": "Harnois de Résistance",
+			"description": "<div class=\"description \">Vous avez la résistance à un type de dégâts tant que vous êtes équipé de cette armure. Le MD choisit le type de dégâts ou le détermine aléatoirement grâce à la table ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Adamantine Plate Armor",
+			"name": "Harnois en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Dwarven Plate",
+			"name": "Harnois nain",
+			"description": "<p>Lorsque vous portez cette armure, vous gagnez un bonus de +2 à la CA. En outre, si un effet vous déplace contre votre volonté au sol, vous pouvez utiliser votre réaction pour réduire la distance sur laquelle vous êtes déplacé de 3 mètres ou moins.</p>"
+		},
+		{
+			"id": "Handy Haversack",
+			"name": "Havresac magique d'Hévard",
+			"description": "<div class=\"description \">Ce sac à dos possède une poche centrale et deux poches latérales, chacune d'entre elles étant un espace extradimensionnel. Chaque poche latérale peut contenir jusqu'à 10 kilos de matériel, pour un volume cubique maximum de 60 centimètres d'arête. La large poche centrale peut contenir un volume cubique maximum de 2,40 mètres d'arêtes ou 40 kilos de matériel. Le sac à dos pèse au total 2,5 kilos, quel que soit son contenu.\n<br>Mettre un objet dans le havresac utilise les règles habituelles d'interaction avec les objets. Sortir un objet du havresac nécessite que vous utilisiez une action. Lorsque vous mettez la main dans le sac à la recherche d'un objet spécifique, cet objet se trouve comme par magie sur le dessus.\n<br>Le havresac a certaines limites. S'il se retrouve surchargé, ou si un objet tranchant le perce ou le déchire, le havresac s'éventre et est détruit. Si le havresac est détruit, son contenu est perdu pour toujours, à l'exception des artéfacts qui, eux, réapparaissent toujours quelque part. Si le fond du havresac est retourné, son contenu se déverse, sain et sauf, et le havresac doit être remis dans le bon sens pour être de nouveau utilisé. Si une créature ayant besoin de respirer est placée dans le havresac, cette créature peut y survivre 10 minutes, après quoi elle commence à suffoquer. Mettre le havresac dans un espace extradimensionnel créé par un <em>sac sans fond</em>, un <em><a href=\"https://www.aidedd.org/dnd/om.php?vf=puits-portatif\">puits portatif</a></em> ou un objet similaire détruit instantanément les deux objets et ouvre un portail à destination du plan Astral. Le portail prend naissance à l'endroit où l'un des deux objets a été mis dans l'autre. Toute créature se trouvant dans un rayon de 3 mètres du portail est aspirée de l'autre côté et déposée dans un lieu aléatoire du plan Astral. Puis le portail se referme. Le portail est à sens unique et ne peut pas être rouvert.\n<br></div>"
+		},
+		{
+			"id": "Helm of Comprehending Languages",
+			"name": "Heaume de compréhension des langues",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de ce heaume, vous pouvez à volonté, par une action, l'utiliser pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=comprehension-des-langues\">compréhension des langues</a></em>.\n<br></div>"
+		},
+		{
+			"id": "Helm of Telepathy",
+			"name": "Heaume de télépathie",
+			"description": "<div class=\"description \">Tant que vous êtes équipé de ce casque, vous pouvez l'utiliser, par une action, pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 13). Aussi longtemps que vous maintenez votre concentration sur le sort, vous pouvez utiliser une action bonus pour envoyer un message télépathique à une créature sur laquelle vous vous concentrez. Elle peut répondre, en utilisant une action bonus, tant que vous continuez de vous concentrer sur elle. Tant que vous êtes concentré sur une créature en utilisant <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em>, vous pouvez utiliser le casque, par une action, pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> (sauvegarde DD 13) sur cette créature. Une fois utilisée, la capacité de suggestion ne peut être réutilisée avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Helm of Teleportation",
+			"name": "Heaume de téléportation",
+			"description": "<div class=\"description \">Ce heaume possède 3 charges. Tant que vous en êtes équipé, vous pouvez l'utiliser, par une action et en dépensant 1 charge, pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=teleportation\">téléportation</a></em>. Le heaume récupère 1d3 charges dépensées chaque jour au lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Helm of Brilliance",
+			"name": "Heaume scintillant",
+			"description": "<div class=\"description \">Ce heaume éclatant est serti de 1d10 diamants, 2d10 rubis, 3d10 opales de feu et 4d10 opales. Toute gemme prélevée du heaume tombe en poussière. Lorsque toutes les gemmes sont enlevées ou détruites, le heaume perd sa magie.\n<br>Tant que vous en êtes équipé vous bénéficiez des avantages suivants :\n<br>• Vous pouvez utiliser une action pour lancer l'un des sorts suivants (sauvegarde DD 18), en utilisant l'une des gemmes du heaume d'un type donné comme composante : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lumiere-du-jour\">lumière du jour</a></em> (opale), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=boule-de-feu\">boule de feu</a></em> (opale de feu), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=rayons-prismatiques\">rayons prismatiques</a></em> (diamant) ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=mur-de-feu\">mur de feu</a></em> (rubis). La gemme est détruite lorsque le sort est lancé et disparaît du casque.\n<br>• Tant qu'il possède au moins un diamant, le heaume émet une lumière faible dans un rayon de 9 mètres lorsqu'au moins un mort-vivant se trouve dans cette zone. Tout mort-vivant qui débute son tour dans la zone subit 1d6 dégâts radiants.\n<br>• Tant que le heaume possède au moins un rubis, vous avez la résistance aux dégâts de feu.\n<br>• Tant que le heaume possède au moins une opale de feu, vous pouvez utiliser une action et prononcer le mot de commande pour qu'une des armes que vous tenez s'embrase. Les flammes émettent une lumière vive dans un rayon de 3 mètres et une lumière faible dans un rayon supplémentaire de 3 mètres. Les flammes sont inoffensives pour vous et pour l'arme en question. Lorsque vous touchez lors d'une attaque avec l'arme enflammée, la cible subit 1d6 dégâts de feu supplémentaire. Les flammes restent actives jusqu'à ce que vous utilisiez votre action bonus pour répéter le mot de commande ou jusqu'à ce que vous lâchiez ou rangiez l'arme.\n<br>Si vous êtes équipé du casque, lancez un d20 lorsque vous subissez des dégâts de feu dus à un jet de sauvegarde échoué contre un sort. Sur un résultat de 1 au dé, le heaume émet des rayons de lumière de toutes les gemmes restantes. Chaque créature, autre que vous, se trouvant dans un rayon de 18 mètres du heaume doit réussir un jet de sauvegarde de Dextérité DD 17 sous peine d'être frappée par un rayon, subissant un nombre de dégâts radiants égal au nombre de gemmes encore présentes sur le casque. Le heaume et les gemmes sont alors détruits.\n<br></div>"
+		},
+		{
+			"id": "Horseshoes of a Zephyr",
+			"name": "Fers de zéphyr",
+			"description": "<p><em>Objet merveilleux, très rare</em></p>\n<p>Ces fers à cheval se trouvent par lot de quatre. Tant que les quatre fers sont fixés aux sabots d'un cheval ou d'une créature similaire, ils permettent à la créature de se déplacer normalement tout en flottant à 10 centimètres du sol. Grâce à cet effet, la créature peut traverser ou rester au-dessus de surfaces non solides ou instables, comme l'eau ou la lave. La créature ne laisse aucune trace et ignore les terrains difficiles. De plus, la créature peut se déplacer à sa vitesse de déplacement normale pendant une durée maximale de 12 heures par jour sans souffrir de l'épuisement dû à une marche forcée.</p>"
+		},
+		{
+			"id": "Oil Flask",
+			"name": "Huile (flasque)",
+			"description": "<p> L'huile vient habituellement dans une flasque d'argile de 50 cl. Au prix d'une action, vous pouvez lancer le contenu de cette flasque sur une créature à 1,50 mètre ou moins de vous, ou jeter la flasque jusqu'à 6 mètres, la brisant à l'impact. Dans les deux cas, faire une attaque à distance contre une créature ou un objet, en considérant l'huile comme une arme improvisée. En cas de succès, la cible est couverte d'huile. Si la cible reçoit des dégâts de feu avant que l'huile ne sèche (après 1 minute), la cible prend 5 points de dégâts de feu supplémentaire dus à l'huile brûlante. Vous pouvez aussi verser une flasque d'huile sur le sol pour couvrir une zone de 1,50 m x 1,50 m, à condition que la surface soit plane. Une fois allumée, l'huile brûle pendant 2 rounds et inflige 5 points de dégâts de feu à toute créature qui pénètre dans la zone ou qui y termine son tour. Une créature ne peut prendre ces dégâts qu'une fois par tour.</p>"
+		},
+		{
+			"id": "Oil of Sharpness",
+			"name": "Huile d'affûtage",
+			"description": "<div class=\"description \">Cette huile gélatineuse et claire produit de minuscules éclats d'argent. L'huile peut recouvrir une arme tranchante ou perforante, ou jusqu'à 5 projectiles tranchants ou perforants. Appliquer l'huile prend 1 minute. Pour 1 heure, l'objet enduit est magique et donne un bonus de +3 à l'attaque et aux dégâts.\n<br></div>"
+		},
+		{
+			"id": "Oil of Slipperiness",
+			"name": "Huile d'insaisissabilité",
+			"description": "<div class=\"description \">Cet onguent noir collant est épais et pèse lourd dans le contenant, mais coule rapidement quand on le verse. L'huile peut couvrir une créature de taille M ou inférieure, ainsi que tout l'équipement qu'elle porte (un flacon supplémentaire est nécessaire pour chaque catégorie de taille au-dessus de M). L'application de l'huile prend 10 minutes. La créature affectée gagne alors l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=liberte-de-mouvement\">liberté de mouvement</a></em> pendant 8 heures.\n<br>L'huile peut aussi être versée au sol au prix d'une action, et couvre un carré de 3 mètres de côté, dupliquant l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=graisse\">graisse</a></em> dans cette zone pendant 8 heures.\n<br></div>"
+		},
+		{
+			"id": "Oil of Etherealness",
+			"name": "Huile éthérée",
+			"description": "<div class=\"description \">Des perles de cette huile grise se forment à l'extérieur de son contenant et semblent s'évaporer rapidement. L'huile pour recouvrir une créature de taille M ou plus petite, ainsi que tout l'équipement qu'elle porte ou transporte (une fiole supplémentaire est nécessaire pour chaque catégorie de taille au-delà de M). Appliquer l'huile prend 10 minutes. La créature affectée gagne alors les effets du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=forme-etheree\">forme éthérée</a></em> pendant 1 heure.\n<br></div>"
+		},
+		{
+			"id": "Javelin",
+			"name": "Javeline",
+			"description": "<p>Cette lance légère et flexible est conçue pour être lancée, mais elle est aussi suffisamment polyvalente pour être utilisée en combat en mêlée.</p>"
+		},
+		{
+			"id": "Javelin +1",
+			"name": "Javeline +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Javelin +2",
+			"name": "Javeline +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Javelin +3",
+			"name": "Javeline +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Javelin of Lightning",
+			"name": "Javeline de foudre",
+			"description": "<div class=\"description \">Cette javeline est une arme magique. Quand vous la lancez et prononcez son mot de commande, elle se transforme en un éclair formant une ligne de 1,50 mètre de large qui s'étend de vous jusqu'à une cible éloignée de 36 mètres au maximum. Chaque créature sur la ligne à l'exception de vous et de la cible subit 4d6 dégâts de foudre. Un jet de sauvegarde de Dextérité DD 13 réussit permet de réduire ces dégâts de moitié.\n<br>L'éclair se retransforme en javeline une fois qu'il atteint sa cible. Faites une attaque à distance contre la cible. Si vous la touchez, elle subit les dégâts de la javeline plus 4d6 dégâts de foudre. Ce pouvoir ne peut plus être utilisé jusqu'au prochain lever du soleil. Entre temps la javeline peut toujours être utilisée comme une arme magique.\n<br></div>"
+		},
+		{
+			"id": "Vicious Javelin",
+			"name": "javeline vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Chess Set",
+			"name": "Jeu d'échecs draconiques",
+			"description": "<p>Si vous maîtrisez un type de jeu, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique lorsque vous jouez à ce jeu. Chaque type de jeu nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Playing Cards Set",
+			"name": "Jeu de cartes",
+			"description": "<p>Si vous maîtrisez un type de jeu, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique lorsque vous jouez à ce jeu. Chaque type de jeu nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Dice Set",
+			"name": "Jeux de dés",
+			"description": "<p>Si vous maîtrisez un type de jeu, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique lorsque vous jouez à ce jeu. Chaque type de jeu nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Poisoner's Kit",
+			"name": "Kit d'empoisonneur",
+			"description": "<p>Ce kit comprend les flacons, produits chimiques et autres appareils nécessaires à la création de poisons. Si vous maîtrisez le kit d'empoisonneur, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour créer et manipuler des poisons.</p>"
+		},
+		{
+			"id": "Herbalism Kit",
+			"name": "Kit d'herboriste",
+			"description": "<p>Ce kit contient une variété d'instruments, tels des pinces, un pilon, des sachets et des flacons que les herboristes utilisent pour créer des remèdes et des potions. Si vous maîtrisez le kit d'herboriste, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour identifier des herbes ou concocter des mélanges et des infusions. Maîtriser le kit d'herboriste est indispensable pour créer des potions de soins et des antidotes.</p>"
+		},
+		{
+			"id": "Forgery Kit",
+			"name": "Kit de contrefaçon",
+			"description": "<p>Cette petite boîte contient une variété de papiers et parchemins, plumes et encres, sceaux et cire à cacheter, feuilles d'argent et d'or, et autres fournitures nécessaires à la création de faux documents physiques convaincants. La maîtrise de ce kit vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique pour créer un faux d'un document physique.</p>"
+		},
+		{
+			"id": "Disguise Kit",
+			"name": "Kit de déguisement",
+			"description": "<p>Ce kit comprend des produits cosmétiques, de la teinture pour les cheveux et de petits accessoires pour vous permettre de créer des déguisements qui changent votre apparence physique. Si vous maîtrisez le kit de déguisement, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristiques pour créer un déguisement visuel.</p>"
+		},
+		{
+			"id": "Lamp",
+			"name": "Lampe",
+			"description": "<p>Une lampe projette une lumière vive dans un rayon de 4,50 mètres et une lumière faible sur 9 mètres supplémentaires. Une fois allumée, elle brûle pendant 6 heures tout en consommant une flasque d'huile (50 cl).</span></p>"
+		},
+		{
+			"id": "Spear",
+			"name": "Lance",
+			"description": "<p>Une pointe d'acier étincelante au sommet d'un solide manche en bois, la lance peut être maniée à une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle.</p>"
+		},
+		{
+			"id": "Spear +1",
+			"name": "Lance +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special</strong>. Une pointe d'acier étincelante au sommet d'un solide manche en bois, la lance peut être maniée à une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle.</p>"
+		},
+		{
+			"id": "Spear +2",
+			"name": "Lance +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special</strong>. Une pointe d'acier étincelante au sommet d'un solide manche en bois, la lance peut être maniée à une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle.</p>"
+		},
+		{
+			"id": "Spear +3",
+			"name": "Lance +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special</strong>. Une pointe d'acier étincelante au sommet d'un solide manche en bois, la lance peut être maniée à une ou deux mains et peut transpercer les armures les plus lourdes avec une force mortelle.</p>"
+		},
+		{
+			"id": "Lance",
+			"name": "Lance d'harçon",
+			"description": "<p>Une pointe d'acier brillante pour percer les défenses les plus dures de l'ennemi, enfoncée par la force d'un coursier au galop. Bien que mieux adaptée au combat à cheval, la lance peut être utilisée à pieds. Vous êtes désavantagé lorsque vous utilisez une lance pour attaquer une cible située à moins de 1,5 mètre de vous. De plus, une lance nécessite deux mains pour être maniée lorsque vous n'êtes pas monté.Vous avez un désavantage lorsque vous utilisez une lance d'arçon pour attaquer une cible à 1,50 mètre ou moins de vous. En outre, une lance d'arçon requiert deux mains pour être maniée lorsque vous n'êtes pas sur une monture.</p>"
+		},
+		{
+			"id": "Lance +1",
+			"name": "Lance d'harçon +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special</strong>. Vous êtes désavantagé lorsque vous utilisez une lance pour attaquer une cible située à moins de 1,5 mètre de vous. De plus, une lance nécessite deux mains pour être maniée lorsque vous n'êtes pas monté.Vous avez un désavantage lorsque vous utilisez une lance d'arçon pour attaquer une cible à 1,50 mètre ou moins de vous. En outre, une lance d'arçon requiert deux mains pour être maniée lorsque vous n'êtes pas sur une monture.</p>"
+		},
+		{
+			"id": "Lance +2",
+			"name": "Lance d'harçon +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special</strong>. Vous êtes désavantagé lorsque vous utilisez une lance pour attaquer une cible située à moins de 1,5 mètre de vous. De plus, une lance nécessite deux mains pour être maniée lorsque vous n'êtes pas monté.Vous avez un désavantage lorsque vous utilisez une lance d'arçon pour attaquer une cible à 1,50 mètre ou moins de vous. En outre, une lance d'arçon requiert deux mains pour être maniée lorsque vous n'êtes pas sur une monture.</p>"
+		},
+		{
+			"id": "Lance +3",
+			"name": "Lance d'harçon +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>\n<p><strong>Special</strong>. Vous êtes désavantagé lorsque vous utilisez une lance pour attaquer une cible située à moins de 1,5 mètre de vous. De plus, une lance nécessite deux mains pour être maniée lorsque vous n'êtes pas monté.Vous avez un désavantage lorsque vous utilisez une lance d'arçon pour attaquer une cible à 1,50 mètre ou moins de vous. En outre, une lance d'arçon requiert deux mains pour être maniée lorsque vous n'êtes pas sur une monture.</p>"
+		},
+		{
+			"id": "Vicious Lance",
+			"name": "Lance d'harçon vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br>Vous avez un désavantage lorsque vous utilisez une lance d'arçon pour attaquer une cible à 1,50 mètre ou moins de vous. En outre, une lance d'arçon requiert deux mains pour être maniée lorsque vous n'êtes pas sur une monture.</div>"
+		},
+		{
+			"id": "Vicious Spear",
+			"name": "Lance vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Hooded Lantern",
+			"name": "Lanterne à capote",
+			"description": "<p>Une lanterne à capote projette une lumière vive dans un rayon de 9 mètres et une lumière faible sur 9 mètres supplémentaires. Une fois allumée, elle brûle pendant 6 heures tout en consommant une flasque d'huile (50 cl). Au prix d'une action, vous pouvez ajuster la capote, ce qui réduit la lumière à une lumière faible dans un rayon de 1,50 mètre.</span></p>"
+		},
+		{
+			"id": "Lantern of Revealing",
+			"name": "Lanterne de révélation",
+			"description": "<div class=\"description \">Tant qu'elle est allumée, cette lanterne à capote brûle un demi-litre d'huile en 6 heures et produit une lumière vive dans un rayon de 9 mètres et une lumière faible dans les 9 mètres suivants. Les créature et objets invisibles deviennent visible tant qu'ils sont dans le halo de la lumière vive. Vous pouvez utiliser une action pour rabattre la capote de la lanterne, réduisant la luminosité à un halo de lumière réduite de 1,50 mètre de rayon.\n<br></div>"
+		},
+		{
+			"id": "Bullseye Lantern",
+			"name": "Lanterne sourde",
+			"description": "<p>Une lanterne sourde projette une lumière vive dans un cône de 18 mètres et une lumière faible sur 18 mètres supplémentaires. Une fois allumée, elle brûle pendant 6 heures tout en consommant une flasque d'huile (50 cl).</span></p>"
+		},
+		{
+			"id": "Iron Bands of Binding",
+			"name": "Liens de fer de Bilarro",
+			"description": "<div class=\"description \">Cette sphère de fer rouillé mesure 7,50 centimètres de diamètre et pèse 500 grammes. Vous pouvez utiliser une action pour prononcer le mot de commande et lancer la sphère sur une créature de taille G ou inférieure que vous pouvez voir et située dans un rayon de 18 mètres autour de vous. Alors que la sphère progresse dans les airs, elle s'ouvre en un enchevêtrement de bandelettes métalliques.\n<br>Effectuez un jet d'attaque à distance avec un bonus à l'attaque égal à votre modificateur de Dextérité + votre bonus de maîtrise. Si vous touchez, la cible est entravée jusqu'à ce que vous utilisiez une action bonus pour répéter le mot de commande et ainsi la libérer. En faisant cela, ou en échouant votre jet d'attaque, les bandelettes se rétractent et reprennent une nouvelle fois l'aspect d'une sphère.\n<br>Une créature, dont celle qui est entravée, peut utiliser une action pour effectuer un jet de Force DD 20 pour briser les bandelettes métalliques. En cas de réussite, l'objet est détruit, et la créature entravée est libérée. Si le jet échoue, toute tentative future tentée par la même créature échouera automatiquement au cours des 24 prochaines heures. Une fois que les bandelettes sont utilisées, elles ne peuvent être réutilisées avant le prochain lever le soleil.\n<br></div>"
+		},
+		{
+			"id": "Book",
+			"name": "Livre",
+			"description": "<p>Un livre peut contenir de la poésie, des récits historiques, des informations relatives à un domaine particulier de connaissance, des diagrammes et des notes sur une invention gnome, ou n'importe quoi d'autre qui peut être représenté en utilisant du texte ou des images. Un livre de sorts est un grimoire (voir la description plus loin ci-dessus).</p>"
+		},
+		{
+			"id": "Book of Lore",
+			"name": "Livre de l'histoire",
+			"description": "<p>Un livre contenant des récits historiques, des informations relatives à un domaine particulier de l'histoire, du mythe ou de la légende.</p>"
+		},
+		{
+			"id": "Prayer Book",
+			"name": "Livre de prières",
+			"description": "<p>Un livre contenant des prières et des incantations dédiées à un pouvoir spécifique que les fidèles doivent suivre.</p>"
+		},
+		{
+			"id": "Book of Shadows",
+			"name": "Livre des Ombres",
+			"description": "Votre patron vous offre un grimoire appelé un Livre des Ombres. Dès lors que vous bénéficiez de cette capacité, choisissez trois sorts mineurs dans la liste de sorts de n'importe quelles classes. Tant que vous portez le grimoire sur vous, vous pouvez lancer ces sorts mineurs à volonté. Ils ne comptent pas dans votre nombre de sorts mineurs connus. Même s'ils ne sont pas sur la liste de sorts d'occultiste, vous pouvez les considérer comme des sorts d'occultiste. Si vous perdez votre Livre des Ombres, vous pouvez réaliser une cérémonie de 1 heure pour en recevoir un nouveau de la part de votre patron. Cette cérémonie détruit le grimoire précédent et peut être réalisée durant un repos court ou long. Le grimoire se transforme en cendre quand vous mourrez."
+		},
+		{
+			"id": "Spyglass",
+			"name": "Longue-vue",
+			"description": "<p>Les objets vus à travers une longue-vue sont amplifiés de deux fois leur taille.</p>\n<p>&nbsp;</p>"
+		},
+		{
+			"id": "Magnifying Glass",
+			"name": "Loupe",
+			"description": "<p>Ce verre permet un examen plus minutieux des petits objets. Il est également utile comme substitut au silex pour allumer un feu. Allumer un feu avec une loupe nécessite une lumière aussi vive que celle du soleil pour faire prendre l'amadou, et environ 5 minutes pour que le feu prenne. Une loupe donne un avantage aux jets de caractéristique pour évaluer ou inspecter un objet de petite taille ou très détaillé.</p>"
+		},
+		{
+			"id": "Goggles of Night",
+			"name": "Lunettes de nuit",
+			"description": "<div class=\"description \">Lorsque vous portez ces lunettes noires, vous obtenez vision dans le noir dans un rayon de 18 mètres. Si vous possédez déjà vision dans le noir, porter ces lunettes augmente le rayon de vision de 18 mètres.\n<br></div>"
+		},
+		{
+			"id": "Lute",
+			"name": "Luth",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Lyre",
+			"name": "Lyre",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Elven Chain",
+			"name": "Mailles elfiques",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 à la CA lorsque vous portez cette armure.\n<br>Vous êtes considéré comme ayant la maîtrise de cette armure, même si vous ne maîtrisez pas les armures intermédiaires.\n<br></div>"
+		},
+		{
+			"id": "Maul",
+			"name": "Maillet",
+			"description": "<p>Cette masse lourde à deux mains écrase le métal et les os avec une force tonitruante.</p>"
+		},
+		{
+			"id": "Maul +1",
+			"name": "Maillet +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Maul +2",
+			"name": "Maillet +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Maul +3",
+			"name": "Maillet +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Maul",
+			"name": "Maillet vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Unarmed Strike",
+			"name": "Mains Nues",
+			"description": "Un coup de poing, un coup de pied, un coup de tête ou un coup violent similaire (aucun de ces coups ne compte comme une arme). En cas de succès, une frappe à mains nues inflige des dégâts égaux à 1 + votre modificateur de Force. Vous êtes compétent en matière de frappes à mains nues."
+		},
+		{
+			"id": "Unarmed Strike (Monk)",
+			"name": "Mains Nues (Moine)",
+			"description": "<p>Au niveau 1, votre pratique des arts martiaux vous donne la maîtrise des styles de combat utilisant les attaques à mains nues et les armes de moine, qui sont l'épée courte et toutes les armes de corps à corps courantes qui n'ont ni la propriété à deux mains, ni la propriété lourde. Vous gagnez les avantages suivants lorsque vous êtes à mains nues ou ne maniez que des armes de moine et que vous n'êtes équipé ni d'armure ni de bouclier :</p>\n<p>Vous pouvez utiliser la Dextérité à la place de la Force aux jets d'attaque et de dégâts de vos attaques à mains nues et avec des armes de moine.</p>\n<p>Vous pouvez lancer un d4 à la place des dégâts normaux de votre attaque à mains nues ou de vos armes de moine. Ce dé change lorsque vous gagnez des niveaux de moine, comme indiqué dans la colonne Arts martiaux de la table ci-dessus.</p>\n<p>Lorsque vous utilisez l'action Attaquer avec une attaque à mains nues ou une arme de moine au cours de votre tour, vous pouvez effectuer une attaque à mains nues au prix d'une action bonus. Par exemple, si vous prenez l'action Attaque et attaquez avec un bâton, vous pouvez également effectuer une attaque à mains nues avec votre action bonus, à condition que vous n'ayez pas déjà utilisé votre action bonus pour ce tour.</p>\n<table border=\"1\">\n<tbody>\n<tr>\n<td><strong>Niveau de Moine</strong></td>\n<td><strong>Arts Martiaux</strong></td>\n</tr>\n<tr>\n<td>1er - 4ème</td>\n<td>1d4</td>\n</tr>\n<tr>\n<td>5ème - 10ème</td>\n<td>1d6</td>\n</tr>\n<tr>\n<td>11ème - 16ème</td>\n<td>1d8</td>\n</tr>\n<tr>\n<td>17ème - 20ème</td>\n<td>1d10</td>\n</tr>\n</tbody>\n</table>\n<p><em>**Note Foundry : Notez que le dé de dégâts est réglé sur la base par défaut de 1d4. Veuillez l'ajuster manuellement si nécessaire.</em></p>"
+		},
+		{
+			"id": "Mantle of Spell Resistance",
+			"name": "Manteau de résistance aux sorts",
+			"description": "<div class=\"description \">Vous avez un avantage à tous les jets de sauvegarde contre les sorts tant que vous portez cette cape.\n<br></div>"
+		},
+		{
+			"id": "Manual of Bodily Health",
+			"name": "Manuel de bonne santé",
+			"description": "<div class=\"description \">Ce livre contient des conseils de santé et d'alimentation, et ses mots sont chargés de magie. Si vous passez 48 heures sur une période de 6 jours ou moins à étudier le contenu du livre et pratiquez ses lignes directrices, votre Constitution augmente de 2, tout comme votre maximum pour cette caractéristique. Le manuel perd alors sa magie, mais la retrouvera dans un siècle.\n<br></div>"
+		},
+		{
+			"id": "Manual of Gainful Exercise",
+			"name": "Manuel de remise en forme",
+			"description": "<div class=\"description \">Ce livre contient des exercices de remise en forme physique, et ses mots sont chargés de magie. Si vous passez 48 heures sur une période de 6 jours ou moins à étudier le contenu du livre et pratiquez ses lignes directrices, votre Force augmente de 2, tout comme votre maximum pour cette caractéristique. Le manuel perd alors sa magie, mais la retrouvera dans un siècle.\n<br></div>"
+		},
+		{
+			"id": "Manual of Quickness of Action",
+			"name": "Manuel de vivacité",
+			"description": "<div class=\"description \">Ce livre contient des exercices de coordination et d'équilibre, et ses mots sont chargés de magie. Si vous passez 48 heures sur une période de 6 jours ou moins à étudier le contenu du livre et pratiquez ses lignes directrices, votre Dextérité augmente de 2, tout comme votre maximum pour cette caractéristique. Le manuel perd alors sa magie, mais la retrouvera dans un siècle.\n<br></div>"
+		},
+		{
+			"id": "Manual of Golems",
+			"name": "Manuel des golems",
+			"description": "<div class=\"description \">Ce livre contient les informations et incantations nécessaires pour créer un golem d'un type particulier. Le MD choisit le type ou le détermine aléatoirement. Pour déchiffrer le manuel et l'utiliser, vous devez être un lanceur de sorts possédant au moins deux emplacements de sorts de niveau 5. Une créature qui ne peut pas utiliser le <em>manuel des golems</em> et qui tente de le lire subit 6d6 dégâts psychiques.\n<br><table><tbody><tr><th class=\"center\">d20</th><th>Golem</th><th>Temps</th><th>Coût</th></tr><tr><td class=\"center\">1-5</td><td>Argile</td><td>30 jours</td><td>65 000 po</td></tr><tr><td class=\"center\">6-17</td><td>Chair</td><td>60 jours</td><td>50 000 po</td></tr><tr><td class=\"center\">18</td><td>Fer</td><td>120 jours</td><td>100 000 po</td></tr><tr><td class=\"center\">19-20</td><td>Pierre</td><td>90 jours</td><td>80 000 po</td></tr></tbody></table>\n<br>Pour créer un golem, vous devez y passer le temps indiqué sur la table ci-dessus, travaillant sans interruption avec le manuel en main et en ne vous reposant pas plus de 8 heures par jour. Vous devez également dépenser le montant indiqué en achat de fournitures et autres matériels nécessaires. Une fois que vous avez terminé de créer le golem, le livre est consumé par des flammes occultes. Le golem s'anime lorsque les cendres du manuel sont répandues au-dessus de lui. Le golem est sous votre contrôle, et il comprend et obéit aux ordres oraux que vous lui donnez.\n<br></div>"
+		},
+		{
+			"id": "Hammer",
+			"name": "Marteau",
+			"description": "<p>Un outil avec une tête métallique lourde montée à angle droit au bout d'un manche, utilisé pour casser des objets et enfoncer des clous.</p>"
+		},
+		{
+			"id": "Sledgehammer",
+			"name": "Marteau de forgeron",
+			"description": "<p>Outil à tête large, plate, souvent métallique, attaché à un long manche.&nbsp;</p>"
+		},
+		{
+			"id": "Warhammer",
+			"name": "Marteau de guerre",
+			"description": "<p>Un marteau en métal lourd pouvant être manié d'une seule main avec un bouclier ou à deux mains pour délivrer des coups écrasants.</p>"
+		},
+		{
+			"id": "Warhammer +1",
+			"name": "Marteau de guerre +1",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Warhammer +2",
+			"name": "Marteau de guerre +2",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Warhammer +3",
+			"name": "Marteau de guerre +3",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Vicious Warhammer",
+			"name": "Marteau de guerre vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Dwarven Thrower",
+			"name": "Marteau de lancer nain",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +3 à l'attaque et aux dégâts fait avec cette arme magique. Elle a la propriété lancer avec une portée normale de 6 mètres et une portée longue de 18 mètres.\n<br>Si vous touchez avec une attaque à distance en utilisant cette arme, elle inflige 1d8 dégâts supplémentaires ou, si la cible est un géant, 2d8. Immédiatement après l'attaque, l'arme vole pour revenir dans votre main.\n<br></div>"
+		},
+		{
+			"id": "Hammer of Thunderbolts",
+			"name": "Marteau de tonnerre",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +1 à l'attaque et aux dégâts réalisés avec cette arme magique.\n<br><strong>Fléau des géants (nécessite un lien)</strong>. Vous devez porter un <em><a href=\"https://www.aidedd.org/dnd/om.php?vf=ceinturon-de-force-de-geant\">ceinturon de force de géant</a></em><a href=\"https://www.aidedd.org/dnd/om.php?vf=ceinturon-de-force-de-geant\"> (n'importe laquelle) et des <em></em></a><em><a href=\"https://www.aidedd.org/dnd/om.php?vf=gantelets-de-puissance-d-ogre\">gantelets de puissance d'ogre</a></em> pour vous lier avec cette arme. Le lien se termine si vous enlevez l'un ou l'autre de ces objets. Tant que vous êtes lié avec cette arme et que vous la portez, votre Force augmente de 4 et peut dépasser 20, mais pas 30. Lorsque vous faites un 20 naturel sur un jet d'attaque réalisée avec cette arme contre un géant, le géant doit réussir un jet de sauvegarde de Constitution DD 17 ou mourir.\n<br>Le marteau possède également 5 charges. Tant que vous êtes lié avec lui, vous pouvez dépenser une charge et réaliser une attaque à distance avec le marteau, en le lançant comme s'il avait la propriété Lancer avec une portée nominale de 6 mètres et une portée maximale de 18 mètres. Si l'attaque réussit, le marteau déclenche un coup de tonnerre audible à 90 mètres. La cible et toute autre créature dans un rayon de 9 mètres autour doivent réussir un jet de sauvegarde de Constitution DD 17 ou être étourdis jusqu'à la fin de votre prochain tour. Le marteau récupère 1d4 + 1 charges dépensées chaque jour au lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Light Hammer",
+			"name": "Marteau léger",
+			"description": "<p>Ce solide marteau est suffisamment petit pour être manié avec agilité ou utilisé en combinaison avec une autre arme.</p>"
+		},
+		{
+			"id": "Light Hammer +1",
+			"name": "Marteau léger +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Light Hammer +2",
+			"name": "Marteau léger +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Light Hammer +3",
+			"name": "Marteau léger +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Light Hammer",
+			"name": "Marteau léger vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Mace of Disruption",
+			"name": "Masse d'anéantissement",
+			"description": "<div class=\"description \">Quand vous frappez un fiélon ou un mort-vivant avec cette arme magique, cette créature subit 2d6 dégâts radiants supplémentaires. Si elle a 25 points de vie ou moins après avoir subi ces dégâts elle doit réussir un jet de sauvegarde de Sagesse DD 15 ou être détruite. En cas de réussite vous effrayez la créature jusqu'à la fin de votre prochain tour.\n<br>Tant que vous tenez cette arme, elle émet une lumière vive dans un rayon de 6 mètres et une lumière faible sur 6 mètres supplémentaires.\n<br></div>"
+		},
+		{
+			"id": "Mace",
+			"name": "Masse d'armes",
+			"description": "<p>Une lourde boule de métal montée au bout d'une massue également de métal. La tête est munie de pointes et de lames conçues pour perforer l'armure et briser les os situés en dessous.</p>"
+		},
+		{
+			"id": "Mace +1",
+			"name": "Masse d'armes +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Mace +2",
+			"name": "Masse d'armes +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Mace +3",
+			"name": "Masse d'armes +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Mace",
+			"name": "Masse d'armes vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Mace of Smiting",
+			"name": "Masse destructrice",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. Ce bonus passe à +3 quand vous l'utilisez contre une créature artificielle.\n<br>Quand vous obtenez un 20 naturel sur un jet d'attaque avec cette arme, la cible subit 7 dégâts contondants supplémentaires, ou 14 dégâts contondants si c'est une créature artificielle. Si une créature artificielle a 25 points de vie ou moins après avoir subi ces dégâts, elle est détruite.\n<br></div>"
+		},
+		{
+			"id": "Mace of Terror",
+			"name": "Masse terrifiante",
+			"description": "<div class=\"description \">Cette arme magique possède 3 charges. Tant que vous la tenez vous pouvez utiliser une action et dépenser une charge pour relâcher une vague de terreur. Toutes les créatures de votre choix dans un rayon de 6 mètres centré sur vous doivent réussir un jet de sauvegarde de Sagesse DD 15 ou vous les effrayez pour une minute.\n<br>Tant qu'elle est effrayée à cause de cet effet, une créature doit utiliser son tour pour essayer de s'éloigner le plus possible de vous et elle ne peut pas volontairement se rapprocher à 6 mètres ou moins de vous ni prendre de réaction. En tant qu'action elle peut seulement utiliser l'action Foncer ou tenter de se libérer d'un effet qui l'empêcherait de se déplacer. Si elle n'a aucun endroit où fuir, elle peut Esquiver.\n<br>À la fin de chacun de ses tours, une créature victime de cet effet peut retenter le jet de sauvegarde, s'en libérant en cas de réussite.\n<br>Chaque jour à l'aube, la masse récupère 1d3 charges dépensées.\n<br></div>"
+		},
+		{
+			"id": "Greatclub",
+			"name": "Massue",
+			"description": "<p>Une variante plus grande du gourdin simple, un lourd manche en bois avec un énorme nœud de bois au bout, inflige des dommages paralysants aux malheureux ennemis.</p>"
+		},
+		{
+			"id": "Greatclub +1",
+			"name": "Massue +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Greatclub +2",
+			"name": "Massue +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Greatclub +3",
+			"name": "Massue +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Greatclub",
+			"name": "Massue vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Alchemist's Supplies",
+			"name": "Matériel d'alchimiste",
+			"description": "<p>Les outils vous aident à faire quelque chose que vous ne pourriez pas faire autrement, comme de l'artisanat, réparer un objet, falsifier un document ou crocheter une serrure. Votre race, votre classe, votre historique ou bien encore vos dons vous donnent la maîtrise de certains outils. La maîtrise d'un outil vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous réalisez avec cet outil. L'utilisation de l'outil n'est pas liée à une seule caractéristique, car la maîtrise d'un outil représente une connaissance qui va au-delà de sa simple utilisation. Par exemple, le MD peut vous demander de faire un jet de Dextérité pour sculpter un détail sur du bois avec des outils de menuisier, puis un jet de Force pour faire quelque chose sur un bois particulièrement dur.</p>"
+		},
+		{
+			"id": "Climber's Kit",
+			"name": "Matériel d'escalade",
+			"description": "<p>Ce kit comprend des pitons spéciaux, des pointes pour les chaussures, des gants et un harnais. Vous pouvez utiliser le matériel d'escalade pour vous accrocher au prix d'une action ; une fois fait, vous ne pouvez pas tomber de plus de 7,50 mètres de l'endroit où vous êtes ancré, et ne pouvez pas monter de plus de 7,50 mètres de ce point sans devoir défaire l'ancrage.</span></p>"
+		},
+		{
+			"id": "Brewer's Supplies",
+			"name": "Matériel de brasseur",
+			"description": "<p>Les outils vous aident à faire quelque chose que vous ne pourriez pas faire autrement, comme de l'artisanat, réparer un objet, falsifier un document ou crocheter une serrure. Votre race, votre classe, votre historique ou bien encore vos dons vous donnent la maîtrise de certains outils. La maîtrise d'un outil vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous réalisez avec cet outil. L'utilisation de l'outil n'est pas liée à une seule caractéristique, car la maîtrise d'un outil représente une connaissance qui va au-delà de sa simple utilisation. Par exemple, le MD peut vous demander de faire un jet de Dextérité pour sculpter un détail sur du bois avec des outils de menuisier, puis un jet de Force pour faire quelque chose sur un bois particulièrement dur.</p>"
+		},
+		{
+			"id": "Calligrapher's Supplies",
+			"name": "Matériel de calligraphe",
+			"description": "<p>Les outils vous aident à faire quelque chose que vous ne pourriez pas faire autrement, comme de l'artisanat, réparer un objet, falsifier un document ou crocheter une serrure. Votre race, votre classe, votre historique ou bien encore vos dons vous donnent la maîtrise de certains outils. La maîtrise d'un outil vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous réalisez avec cet outil. L'utilisation de l'outil n'est pas liée à une seule caractéristique, car la maîtrise d'un outil représente une connaissance qui va au-delà de sa simple utilisation. Par exemple, le MD peut vous demander de faire un jet de Dextérité pour sculpter un détail sur du bois avec des outils de menuisier, puis un jet de Force pour faire quelque chose sur un bois particulièrement dur.</p>"
+		},
+		{
+			"id": "Fishing Tackle",
+			"name": "Matériel de pêche",
+			"description": "<p>Ce kit comprend une tige en bois, une ligne de soie, des flotteurs en liège, des hameçons en acier, des plombs, des leurres en velours et un petit filet.</p>"
+		},
+		{
+			"id": "Painter's Supplies",
+			"name": "Matériel de peintre",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Medallion of Thoughts",
+			"name": "Médaillon des pensées",
+			"description": "<div class=\"description \">Le médaillon possède 3 charges. Lorsque vous le portez, vous pouvez utiliser une action et dépenser 1 charge pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 13) depuis le médaillon. Le médaillon regagne 1d3 charges dépensées chaque jour au lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Manacles",
+			"name": "Menottes",
+			"description": "<p>Ces menottes métalliques servent pour une créature de taille Petite ou Moyenne. Se libérer des menottes nécessite un jet de Dextérité DD 20 réussi. Briser les menottes nécessite un jet de Force DD 20 réussi. Chaque paire de menottes est livrée avec une clé. Sans la clé, une créature qui maîtrise les outils de voleur peut ouvrir les menottes en réussissant un jet de Dextérité DD 15. Les menottes ont 15 points de vie.</span></p>"
+		},
+		{
+			"id": "Dimensional Shackles",
+			"name": "Menottes dimensionnelles",
+			"description": "<div class=\"description \">Vous pouvez utiliser votre action pour mettre ses menottes à une créature incapable d'agir. Les menottes s'ajustent pour convenir à des créatures de taille P, M ou G. En plus de servir de menottes banales, les menottes empêchent la créature qu'elles attachent d'utiliser tout moyen de déplacement extradimensionnel, ce qui inclut la téléportation ou le voyage vers d'autres plans d'existence. Elles n'empêchent pas la créature de passer au travers d'un portail interdimensionnel.\n<br>Vous, et toutes les créatures que vous désignez lorsque vous utilisez les chaînes, pouvez utiliser une action pour les enlever. Une fois tous les 30 jours, une créature attachée peut effectuer un jet de Force (Athlétisme) DD 30. En cas de réussite au jet, la créature brise les menottes et se libère. Les menottes sont détruites.\n<br></div>"
+		},
+		{
+			"id": "Military Saddle",
+			"name": "Selle militaire",
+			"description": "<p>Un type de siège fixé au dos d'une monture, conçu pour soutenir le cavalier et fixer une partie de l'équipement de la monture, comme les étriers.<br /><br />Une selle militaire soutient le cavalier, vous aidant à garder votre siège sur une monture active au combat. Elle vous donne un avantage sur tous les jets que vous effectuez pour rester monté.</p>"
+		},
+		{
+			"id": "Mirror of Life Trapping",
+			"name": "Miroir d'emprisonnement",
+			"description": "<div class=\"description \">Quand ce miroir de 1,20 mètre de haut est regardé indirectement, sa surface montre de pâles images de créatures. Le miroir pèse 25 kg et a une CA de 11, 10 points de vie et la vulnérabilité aux dégâts contondants. Il se brise en éclats et est détruit s'il tombe à 0 point de vie.\n<br>Si le miroir est accroché à une surface verticale et que vous êtes à 1,50 mètre ou moins de lui, vous pouvez utiliser une action pour prononcer son mot de commande et l'activer. Il reste actif tant que vous n'utilisez pas une autre action pour le désactiver de la même façon.\n<br>Toute créature autre que vous qui voit son reflet dans le miroir alors qu'il est actif et se situe à 6 mètres ou moins du miroir doit réussir un jet de sauvegarde de Charisme DD 15 ou être emprisonnée avec tout ce qu'elle porte dans une des douze cellules extradimensionnelles du miroir. Ce jet de sauvegarde se fait avec un avantage si la créature connaît la vraie nature du miroir. Les créatures artificielles réussissent automatiquement le jet de sauvegarde.\n<br>Une cellule extradimensionnelle est un espace infini rempli d'un épais brouillard réduisant la visibilité à 3 mètres. Les créatures emprisonnées dans le miroir ne vieillissent pas et n'ont pas besoin de boire, de manger ou de dormir. Il est possible de s'échapper de l'intérieur de ces cellules avec l'aide d'une magie permettant le voyage interplanaire, sinon toute créature y est coincée jusqu'à ce qu'on l'en libère.\n<br>Si le miroir piège quelqu'un alors que les douze cellules sont déjà occupées, il libère aléatoirement un des prisonniers pour faire de la place au nouvel arrivant. Une créature libérée apparaît dos à la glace dans l'espace inoccupé le plus proche du miroir. Toutes les créatures sont libérées si le miroir est brisé.\n<br>Tant que vous êtes à 1,50 mètre ou moins du miroir, vous pouvez utiliser une action pour prononcer le nom d'une créature emprisonnée ou le numéro d'une des cellules. La créature appelée ou la cellule choisie apparaît alors sous forme d'image à la surface du miroir. Vous pouvez alors communiquer normalement avec la créature. De la même façon vous pouvez utiliser une action pour prononcer un second mot de commande et libérer la créature piégée. Elle apparaît alors dos au miroir dans l'espace inoccupé le plus proche, avec toutes ses possessions.\n<br></div>"
+		},
+		{
+			"id": "Steel Mirror",
+			"name": "Miroir en acier",
+			"description": "<p>Un mirroir fabriqué à partir d'une plaque d'acier.</p>"
+		},
+		{
+			"id": "Morningstar",
+			"name": "Morgenstern",
+			"description": "<p>Un globe de métal vicieusement pointu, monté au bout d'un manche robuste, constitue une arme mortelle qui peut perforer aussi bien l'armure que la chair.</p>"
+		},
+		{
+			"id": "Morningstar +1",
+			"name": "Morgenstern +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Morningstar +2",
+			"name": "Morgenstern +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Morningstar +3",
+			"name": "Morgenstern +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Morningstar",
+			"name": "Morgenstern vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Prayer Wheel",
+			"name": "Moulin à prière",
+			"description": "<p>Une aide pour les fidèles, ce cylindre peut être tourné sur un fuseau en métal, bois, os, pierre, cuir ou coton grossier lorsque l'utilisateur suit un mantra ou une cantate sculpté ou incrusté dessus.</p>"
+		},
+		{
+			"id": "Orb",
+			"name": "Orbe",
+			"description": "<p>Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Orb of Dragonkind",
+			"name": "Orbe des dragons",
+			"description": "<div class=\"description \">Au cours des siècles passés, les elfes et les humains menèrent une terrible guerre contre les dragons malfaisants. Mais alors que le monde semblait courir à sa perte, de puissants magiciens se rassemblèrent et combinèrent leurs pouvoirs les plus puissants pour forger les cinq <em>Orbes des dragons</em> (ou <em>Orbes draconiques</em>) afin d'aider les armées humanoïdes à vaincre les dragons. Un orbe fut amené dans chacune des tours des cinq magiciens, où ils les utilisèrent pour remporter rapidement le conflit. Les magiciens se servirent des orbes pour attirer les dragons jusqu'à eux, puis, grâce à leur puissante magie, détruire les grands reptiles.\n<br>Comme les tours des magiciens s'effondrèrent quelques siècles plus tard, les orbes furent détruits ou relégués au rang de simple légende. Seuls trois d'entre eux existent encore. Leur magie a été altérée et pervertie au fil des siècles, et bien que leur capacité première d'appel des dragons fonctionne encore, ils permettent également, dans une certaine mesure, de contrôler les dragons.\n<br>Chaque orbe contient l'essence d'un dragon mauvais, une présence qui ne tolère pas qu'on tente de se servir de la magie de l'orbe. Ceux qui n'ont pas une personnalité suffisamment forte pourraient bien se retrouver asservis à l'orbe.\n<br>Un orbe est un globe de cristal sculpté de 25 centimètres de diamètres. Lorsqu'il est utilisé, il grandit jusqu'à atteindre un diamètre de 50 centimètres, et de la fumée apparaît et se met à tourbillonner à l'intérieur.\n<br>Tant que vous êtes lié à un orbe, vous pouvez utiliser une action pour fixer les profondeurs de l'orbe et prononcer son mot de commande. Vous devez ensuite effectuer un jet de Charisme DD 15. Si le jet est réussi, vous contrôlez l'orbe aussi longtemps que vous restez lié à lui. En cas d'échec au jet, vous êtes charmé par l'orbe aussi longtemps que vous restez lié à lui.\n<br>Tant que vous êtes charmé par l'orbe, vous ne pouvez pas volontairement mettre fin à votre lien, de plus l'orbe lance le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=suggestion\">suggestion</a></em> sur vous à volonté (sauvegarde DD 18), vous exhortant à travailler d'arrache-pied à ses propres objectifs maléfiques. L'essence du dragon se trouvant dans l'orbe pourrait vouloir de nombreuses choses : le génocide d'un peuple particulier, être libéré de l'orbe, répandre la souffrance et la destruction sur le monde, développer le culte de Tiamat, ou quelque chose d'autre suivant la décision du MD.\n<br><strong>Propriétés aléatoires</strong>. Un <em>Orbe des dragons</em> possède les propriétés aléatoires suivantes :\n<br>• 2 propriétés mineures bénéfiques\n<br>• 1 propriété mineure préjudiciable\n<br>• 1 propriété majeure préjudiciable\n<br><strong>Sorts</strong>. L'orbe possède 7 charges et récupère 1d4 + 3 charges dépensées chaque jour au lever du soleil. Si vous contrôlez l'orbe, vous pouvez utiliser une action et dépenser 1 charge ou plus pour lancer l'un des sorts suivants (sauvegarde DD 18) grâce à lui : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=soins\">soins</a></em> (emplacement de sort niveau 5, 3 charges), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lumiere-du-jour\">lumière du jour</a></em> (1 charge), <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=protection-contre-la-mort\">protection contre la mort</a></em> (2 charges), ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=scrutation\">scrutation</a></em> (3 charges).\n<br>Vous pouvez également utiliser une action pour lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-de-la-magie\">détection de la magie</a></em> depuis l'orbe sans utiliser de charge.\n<br><strong>Appel des dragons</strong>. Tant que vous contrôlez l'orbe, vous pouvez utiliser une action pour que l'orbe lance un appel télépathique dans toutes les directions à 60 kilomètres à la ronde. Les dragons mauvais à portée se sentent obligés de venir vers l'orbe aussi vite que possible et par le chemin le plus direct. Les divinités dragons, comme Tiamat, ne sont pas affectées par cet appel. Les dragons que vous avez contraints par l'orbe pourraient bien vous être hostiles à leur arrivée. Une fois que vous avez utilisé cette propriété, elle ne peut plus être utilisée pendant 1 heure.\n<br><strong>Détruire un orbe</strong>. Un <em>Orbe des Dragons</em> semble fragile mais il est en réalité insensible à la plupart des dégâts, dont les attaques et souffles des dragons. Cependant, un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=desintegration\">désintégration</a></em> ou un bon coup infligé par une arme magique +3 sont suffisants pour détruire l'orbe.\n<br></div>"
+		},
+		{
+			"id": "Jeweler's Tools",
+			"name": "Outils de bijoutier",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Tinker's Tools",
+			"name": "Outils de bricoleur",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Cartographer's Tools",
+			"name": "Outils de cartographe",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Carpenter's Tools",
+			"name": "Outils de charpentier",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Cobbler's Tools",
+			"name": "Outils de cordonnier",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Smith's Tools",
+			"name": "Outils de forgeron",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Mason's Tools",
+			"name": "Outils de maçon",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Woodcarver's Tools",
+			"name": "Outils de menuisier",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Navigator's Tools",
+			"name": "Outils de navigateur",
+			"description": "<p>Ces outils sont utilisés pour la navigation en mer. La maîtrise des outils de navigateur vous permet de tracer le parcours d'un navire et de suivre des cartes de navigation. En outre, ces outils vous permettent d'ajouter votre bonus de maîtrise à tous les jets de caractéristique pour éviter de se perdre en mer.</p>"
+		},
+		{
+			"id": "Potter's Tools",
+			"name": "Outils de potier",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Glassblower's Tools",
+			"name": "Outils de souffleur de verre",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Leatherworker's Tools",
+			"name": "Outils de tanneur",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Weaver's Tools",
+			"name": "Outils de tisserand",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Thieves' Tools",
+			"name": "Outils de voleur",
+			"description": "<p>Ces outils comprennent une petite lime, divers outils de crochetage, un petit miroir monté sur une poignée en métal, une paire de ciseaux à lames fines et une paire de pinces. Si vous maîtrisez les outils de voleur, vous pouvez ajouter votre bonus de maîtrise à tous les jets de caractéristique pour désactiver un piège ou crocheter une serrure.</p>"
+		},
+		{
+			"id": "Pack Saddle",
+			"name": "Selle de bât",
+			"description": "<p>Type de siège fixé sur le dos d'une monture, conçu pour soutenir le cavalier et fixer une partie de l'équipement de la monture, comme les étriers. Ce type de selle convient aux montures de bât.</p>"
+		},
+		{
+			"id": "Block and Tackle",
+			"name": "Palan",
+			"description": "<p>Ensemble de poulies avec un câble et un crochet pour attacher des objets, un palan permet de hisser jusqu'à quatre fois le poids que vous pouvez normalement soulever.</span></p>"
+		},
+		{
+			"id": "Basket",
+			"name": "Panier",
+			"description": "<p>Un panier contient 20 kg</span></p>"
+		},
+		{
+			"id": "Paper",
+			"name": "Papier (une feuille)",
+			"description": "<p>Une simple feuille de papier.</p>"
+		},
+		{
+			"id": "Parchment",
+			"name": "Parchemin (une feuille)",
+			"description": "<p>Une simple feuille de parchemin.</p>"
+		},
+		{
+			"id": "Spell Scroll 1st Level",
+			"name": "Parchemin de sort de 1er niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 2nd Level",
+			"name": "Parchemin de sort de 2ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 3rd Level",
+			"name": "Parchemin de sort de 3ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 4th Level",
+			"name": "Parchemin de sort de 4ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 5th Level",
+			"name": "Parchemin de sort de 5ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 6th Level",
+			"name": "Parchemin de sort de 6ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 7th Level",
+			"name": "Parchemin de sort de 7ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 8th Level",
+			"name": "Parchemin de sort de 8ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll 9th Level",
+			"name": "Parchemin de sort de 9ème niveau",
+			"description": "<div class=\"description \">Un <em>parchemin de sort</em> contient les mots d'un seul sort, écrit dans un langage mystique. Si le sort est sur la liste de sorts de votre classe, vous pouvez lire le parchemin et lancer son sort sans avoir à fournir les composantes matérielles. Sinon, le parchemin est inintelligible. Lancer le sort en lisant le parchemin demande le temps d'incantation normal du sort. Une fois que le sort est lancé, les mots sur le parchemin disparaissent, et il tombe en poussière. Si l'incantation est interrompue, le parchemin n'est pas perdu.\n<br>Si le sort est sur la liste des sorts de votre classe mais d'un niveau supérieur à celui que vous pouvez normalement lancer, vous devez effectuer un jet de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous le lancez avec succès. Le DD est égal à 10 + le niveau du sort. Si le jet échoue, le sort disparaît du parchemin, sans autre effet.\n<br>Le niveau du sort du parchemin détermine le DD du jet de sauvegarde et le bonus d'attaque, ainsi que sa rareté, comme indiqué dans le tableau suivant :\n<br><table><tbody><tr><th class=\"center\">Niveau<br>du sort</th><th>Rareté</th><th class=\"center\">DD de<br> sauvegarde</th><th class=\"center\">Bonus<br>d'attaque</th></tr><tr><td class=\"center\">Sort mineur</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">1</td><td>Commun</td><td class=\"center\">13</td><td class=\"center\">+5</td></tr><tr><td class=\"center\">2</td><td>Peu commun</td><td class=\"center\">13</td><td class=\"center\"> +5</td></tr><tr><td class=\"center\">3</td><td>Peu commun</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">4</td><td>Rare</td><td class=\"center\">15</td><td class=\"center\">+7</td></tr><tr><td class=\"center\">5</td><td>Rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">6</td><td>Très rare</td><td class=\"center\">17</td><td class=\"center\">+9</td></tr><tr><td class=\"center\">7</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">8</td><td>Très rare</td><td class=\"center\">18</td><td class=\"center\">+10</td></tr><tr><td class=\"center\">9</td><td>Légendaire</td><td class=\"center\">19</td><td class=\"center\">+11</td></tr></tbody></table>\n<br>Un sort de magicien sur un <em>parchemin de sort</em> peut être recopié de la même manière que les sorts d'un grimoire. Quand un sort est copié à partir d'un <em>parchemin de sort</em>, le copieur doit réussir un jet d'Intelligence (Arcanes) d'un DD égal à 10 + le niveau du sort. Si le jet est réussi, le sort est copié avec succès. Dans tous les cas, le <em>parchemin de sort</em> est détruit.\n<br></div>"
+		},
+		{
+			"id": "Perfume",
+			"name": "Parfum (fiole)",
+			"description": "<p>Un flacon de parfum.</p>"
+		},
+		{
+			"id": "Shovel",
+			"name": "Pelle",
+			"description": "<p>Outil ressemblant à une bêche avec une large lame et des côtés généralement retournés, utilisé pour déplacer du charbon, de la terre, de la neige ou d'autres matériaux.</p>"
+		},
+		{
+			"id": "Pole",
+			"name": "Perche (3 m)",
+			"description": "<p>Un poteau de 3 mètre de long en bois solide.</p>"
+		},
+		{
+			"id": "Bead of Force",
+			"name": "Perle de force",
+			"description": "<div class=\"description \">Cette petite sphère noire mesure 2 centimètres de diamètre et pèse 30 grammes. Généralement, 1d4 + 4 perles de force sont trouvées en même temps.\n<br>Vous pouvez utiliser une action pour lancer la perle jusqu'à 18 mètres. La perle explose à l'impact et est détruite. Chaque créature se trouvant dans un rayon de 3 mètres du lieu d'impact doit réussir un jet de sauvegarde de Dextérité DD 15 sous peine de subir 5d4 dégâts de force. Puis une sphère de force transparente englobe la zone pendant une minute. Chaque créature qui échoue à son jet de sauvegarde et se trouve complètement dans la zone est alors piégée dans la sphère. Les créatures qui réussissent leur jet de sauvegarde, ou celles qui ne sont que partiellement présentes dans la zone, sont repoussées depuis le centre de la sphère jusqu'à ce qu'elles en soient complètement sorties. Seul l'air respirable peut traverser le mur de la sphère. Aucune attaque, ou quoi que ce soit d'autre, ne le peut.\n<br>Une créature enfermée peut utiliser son action pour pousser contre les parois de la sphère, déplaçant alors la sphère de la moitié de sa vitesse de déplacement au sol. La sphère peut être soulevée, et la magie qui l'a créé fait qu'elle ne pèse au total pas plus de 500 grammes, quel que soit le poids des créatures qu'elle contient.\n<br></div>"
+		},
+		{
+			"id": "Pearl of Power",
+			"name": "Perle de pouvoir",
+			"description": "<div class=\"description \">Tant que cette perle est sur vous, vous pouvez utiliser une action pour prononcer son mot de commande et récupérer un emplacement de sort dépensé. Si l'emplacement de sort était de niveau 4 ou supérieur, le nouvel emplacement est de niveau 3. Une fois que vous avez utilisé la perle, elle ne peut plus être utilisée de nouveau jusqu'au prochain lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Small Knife",
+			"name": "Petit couteau",
+			"description": "<p>Un couteau émoussé utilisé par l'érudit pour ouvrir les lettres et la correspondance.</p>"
+		},
+		{
+			"id": "Philter of Love",
+			"name": "Philtre d'amour",
+			"description": "<div class=\"description \">La prochaine fois que vous voyez une créature dans les 10 minutes qui suivent après avoir bu ce philtre, vous êtes charmé par cette créature pendant 1 heure. Si la créature est d'une espèce et du sexe qui vous attire normalement, vous la considérez comme votre véritable amour tant que vous êtes charmé. Cette potion aux teintes roses contient un liquide effervescent dont les bulles discrètes sont en forme de coeur.\n<br></div>"
+		},
+		{
+			"id": "War Pick",
+			"name": "Pic de guerre",
+			"description": "<p>Une pointe incurvée massive montée à l'arrière d'un solide manche - conçue pour percer les blindages avec une force mortelle.</p>"
+		},
+		{
+			"id": "War Pick +1",
+			"name": "Pic de guerre +1",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "War Pick +2",
+			"name": "Pic de guerre +2",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "War Pick +3",
+			"name": "Pic de guerre +3",
+			"description": "<div class=\"description \">Vous avez un bonus aux jets d'attaque et de dégâts effectués avec cette arme magique. Le bonus est déterminé par la rareté de l'arme.\n<br></div>"
+		},
+		{
+			"id": "Vicious War Pick",
+			"name": "pic de guerre vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Pitcher",
+			"name": "Pichet",
+			"description": "<p>Un pichet de 3,5 l de liquide.</p>"
+		},
+		{
+			"id": "Crowbar",
+			"name": "Pied-de-biche",
+			"description": "<p>Un pied de biche octroie un avantage aux jets de Force lorsque le levier du pied de biche peut être utilisé.</span></p>"
+		},
+		{
+			"id": "Hunting Trap",
+			"name": "Piège à mâchoires",
+			"description": "<p><span style=\" font-size: 13px;\"Lorsque vous utilisez votre action pour l'installer, ce piège forme un anneau d'acier en dents de scie qui se referme lorsqu'une créature marche sur la plaque de pression située au centre. Le piège est fixé par une lourde chaîne à un objet immobile, comme un arbre ou un pic enfoncé dans le sol. Une créature qui marche sur la plaque doit réussir un jet de sauvegarde de Dextérité DD 13 ou prendre 1d4 points de dégâts perforants et devoir s'arrêter de bouger. Par la suite, tant que la créature ne s'échappe pas du piège, son mouvement est limité par la longueur de la chaîne (généralement un mètre de long). Une créature peut utiliser son action pour faire un jet de Force DD 13 pour se libérer ou libérer une autre créature à sa portée en cas de succès. Chaque échec inflige 1 point de dégâts perforants à la créature piégée.</span></p>"
+		},
+		{
+			"id": "Whetstone",
+			"name": "Pierre à aiguiser",
+			"description": "<p>Utilisée pour aiguiser les bords des outils et instruments en acier par meulage et rodage.</p>"
+		},
+		{
+			"id": "Stone of Controlling Earth Elementals",
+			"name": "Pierre de contrôle des élémentaires de la terre",
+			"description": "<div class=\"description \">Si la pierre est en contact avec le sol, vous pouvez utiliser une action pour prononcer son mot de commande et invoquer un élémentaire de la Terre, comme si vous aviez lancé le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=invocation-d-elementaire\">invocation d'élémentaire</a></em>. La pierre ne peut ensuite plus être utilisée à nouveau de cette façon jusqu'à la prochaine aube. La pierre pèse 2,5 kilos.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Absorption",
+			"name": "Pierre de Ioun d'Absorption",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Agility",
+			"name": "Pierre de Ioun d'Agilité",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Greater Absorption",
+			"name": "Pierre de Ioun d'Asorption Supérieure",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Intellect",
+			"name": "Pierre de Ioun d'Intelligence",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Insight",
+			"name": "Pierre de Ioun d'Intuition",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Leadership",
+			"name": "Pierre de Ioun de Dirigeant",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Strength",
+			"name": "Pierre de Ioun de Force",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Mastery",
+			"name": "Pierre de Ioun de Maîtrise",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Sustenance",
+			"name": "Pierre de Ioun de Nourriture",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Protection",
+			"name": "Pierre de Ioun de Protection",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Regeneration",
+			"name": "Pierre de Ioun de Régénération",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Reserve",
+			"name": "Pierre de Ioun de Réserve",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Awareness",
+			"name": "Pierre de Ioun de Vigilance",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Ioun Stone of Fortitude",
+			"name": "Pierre de Ioun de Vigueur",
+			"description": "<div class=\"description \">Les pierres de Ioun doivent leur nom à Ioun, un dieu de la connaissance et des prophéties vénéré dans certains mondes. De nombreux types de pierres de Ioun existent, chaque type aillant une combinaison forme-couleur qui lui est propre.\n<br>Lorsque vous utilisez une action pour lancer l'une de ces pierres dans les airs, la pierre se met en orbite autour de votre tête à une distance de 1d3 x 30 centimètres et vous confère un avantage. Par la suite, une autre créature peut utiliser une action pour attraper ou prendre dans un filet la pierre et vous en séparer, soit en réussissant un jet d'attaque contre une CA de 24, soit en réussissant un jet de Dextérité (Acrobaties) DD 24. Vous pouvez utiliser une action pour vous saisir de la pierre et la ranger, ce qui met fin à son effet.\n<br>Une pierre possède une CA de 24, 10 points de vie, et une résistance à tous les types de dégâts. Elle est considérée comme étant un objet équipé tant qu'elle est en orbite autour de votre tête.\n<br><strong>Absorption (très rare)</strong>. Tant que cette pâle ellipsoïde couleur lavande est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 4 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 20 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Agilité (très rare)</strong>. Votre valeur de Dextérité est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un rouge profond est en orbite autour de votre tête.\n<br><strong>Vigilance (rare)</strong>. Vous ne pouvez pas être surpris tant que cette pierre rhomboïdale bleue-noire est en orbite autour de votre tête.\n<br><strong>Vigueur (très rare)</strong>. Votre valeur de Constitution est augmentée de 2, pour un maximum de 20, tant que cette pierre rhomboïdale rose est en orbite autour de votre tête.\n<br><strong>Absorption supérieure (légendaire)</strong>. Tant que cette ellipsoïde verte et lavande marbrée est en orbite autour de votre tête, vous pouvez utiliser votre réaction pour annuler un sort de niveau 8 ou inférieur lancé par une créature que vous pouvez voir et ne ciblant que vous. Une fois que la pierre a annulé un total de 50 niveaux de sort, elle s'éteint et prend une teinte gris terne, perdant alors sa magie. Si vous êtes ciblé par un sort dont le niveau est supérieur au nombre de niveaux que la pierre peut encore absorber, la pierre ne peut pas annuler ce sort.\n<br><strong>Intuition (très rare)</strong>. Votre valeur de Sagesse est augmentée de 2, pour un maximum de 20, tant que cette sphère d'un bleu incandescent est en orbite autour de votre tête.\n<br><strong>Intellect (très rare)</strong>. Votre valeur d'Intelligence est augmentée de 2, pour un maximum de 20, tant que cette sphère écarlate et bleue marbrée est en orbite autour de votre tête.\n<br><strong>Dirigeant (très rare)</strong>. Votre valeur de Charisme est augmentée de 2, pour un maximum de 20, tant que cette sphère verte et rose marbrée est en orbite autour de votre tête.\n<br><strong>Maîtrise (légendaire)</strong>. Votre bonus de maîtrise augmente de 1 tant que ce prisme vert pâle est en orbite autour de votre tête.\n<br><strong>Protection (rare)</strong>. Vous gagnez un bonus de +1 à la CA tant que ce prisme d'un rose passé est en orbite autour de votre tête.\n<br><strong>Régénération (légendaire)</strong>. Vous récupérez 15 points de vie au la fin de chaque heure pendant laquelle ce fuseau d'un blanc nacré a tourné en orbite autour de votre tête, à condition que vous ayez au moins 1 point de vie.\n<br><strong>Réserve (rare)</strong>. Ce prisme violet vif stocke les sorts qui sont lancés à l'intérieur de lui, les conservant jusqu'à ce que vous les utilisiez. La pierre peut stocker jusqu'à un total de 3 niveaux de sort à la fois. Lorsque vous la trouvez, elle contient 1d4 - 1 niveaux de sorts choisis par le MD.\n<br>N'importe quelle créature peut lancer un sort de niveau 1 à 3 dans la pierre en la touchant pendant l'incantation du sort. Le sort n'a aucun effet, si ce n'est celui d'être stocké dans la pierre. Si la pierre ne peut pas contenir le sort, le sort est dépensé sans faire effet. Le niveau de l'emplacement utilisé pour lancer le sort détermine l'espace que prend le sort dans la pierre.\n<br>Tant que cette pierre est en orbite autour de votre tête, vous pouvez lancer n'importe quel sort qu'elle contient. Le sort utilise le niveau d'emplacement, le DD au jet de sauvegarde, le bonus d'attaque avec un sort et la caractéristique d'incantation de son lanceur original, mais il est sinon considéré comme étant lancé par vous. Le sort lancé depuis la pierre n'est plus stocké dedans, libérant ainsi de l'espace.\n<br><strong>Force (très rare)</strong>. Votre valeur de Force augmente de 2, pour un total maximum de 20, tant que cette pierre rhomboïdale bleue pâle est en orbite autour de votre tête.\n<br><strong>Nourriture (rare)</strong>. Vous n'avez pas besoin de manger ni de boire tant que ce fuseau clair est en orbite autour de votre tête.\n<br></div>"
+		},
+		{
+			"id": "Stone of Good Luck (Luckstone)",
+			"name": "Pierre porte-bonheur",
+			"description": "<div class=\"description \">Si vous portez cette agate polie sur vous, vous gagnez un bonus de +1 aux jets de caractéristique et aux jets de sauvegarde.\n<br></div>"
+		},
+		{
+			"id": "Marvelous Pigments",
+			"name": "Pigments merveilleux de Nolzur",
+			"description": "<div class=\"description \">Généralement trouvés dans 1d4 pots accompagnés d'un pinceau à l'intérieur d'une fine boîte en bois (pesant 500 grammes au total), ces pigments vous permettent de créer des objets en trois dimensions en les peignant en deux dimensions. La peinture coule du pinceau pour dessiner l'image de l'objet sur lequel vous vous concentrez.\n<br>Chaque pot contient assez de peinture pour couvrir 90 mètres carrés de surface (un carré de 30x30 m) ce qui vous permet de créer des objets inanimés ou des bouts de terrain, comme une porte, un fossé, des fleurs, des arbres, des cellules, des pièces ou des armes, qui font jusqu'à 270 mètres cubes. Il faut 10 minutes pour peindre 9 mètres carrés (3x3 m) de surface.\n<br>Une fois la peinture terminée, l'objet ou le terrain dépeint devient réel et non magique. Peindre une porte sur un mur fait apparaître une vraie porte qui peut réellement être ouverte, peu importe ce qui se trouve derrière. Peindre une fosse dans un sol créé un trou dont la profondeur compte dans le total de surface/volume que vous pouvez créer.\n<br>Rien de ce qui peut être créé par les pigments ne peut valoir plus de 25 po. Si vous peignez un objet de grande valeur comme un diamant ou un tas de pièce d'or, l'objet semble authentique mais une inspection minutieuse révélera qu'il est fait de pâte, d'os ou autre matériau sans valeur.\n<br>Si vous peignez une forme d'énergie comme du feu ou de la foudre, elle apparaît puis se dissipe aussitôt une fois la peinture terminée, ne produisant aucun effet réel.\n<br></div>"
+		},
+		{
+			"id": "Miner's Pick",
+			"name": "Pioche de mineur",
+			"description": "<p>Il s'agit d'un outil à main avec une tête dure attachée perpendiculairement au manche.</p>"
+		},
+		{
+			"id": "Pike",
+			"name": "Pique",
+			"description": "<p>Une lame robuste montée au bout d'un long manche en métal. Conçue comme une arme défensive avec une portée considérable pour repousser et menacer les ennemis.</p>"
+		},
+		{
+			"id": "Pike +1",
+			"name": "Pique +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Pike +2",
+			"name": "Pique +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Pike +3",
+			"name": "Pique +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Pike",
+			"name": "Pique vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Piton",
+			"name": "Piton",
+			"description": "<p>pour faciliter l'escalade ou autre utilisation.</p>"
+		},
+		{
+			"id": "Adamantine Breastplate",
+			"name": "Plastron en Adamantium",
+			"description": "<p>Cette armure a été renforcée avec de l'Adamantium, un des métaux les plus dur existants.</p>\n<p>Quand vous la portez, un coup critique devient un coup normal.</p>"
+		},
+		{
+			"id": "Plate Armor of Etherealness",
+			"name": "Plate Armor of Etherealness",
+			"description": "Tant que vous portez cette armure, vous pouvez prononcer son mot de commande par une action pour gagner l'effet du sort forme éthérée pendant 10 minutes ou jusqu'à ce que vous retiriez l'armure ou y mettiez fin volontairement en répétant le mot de commande. Ce pouvoir ne peut alors plus être utilisé avant la prochaine aube."
+		},
+		{
+			"id": "Ink Pen",
+			"name": "Plume d’écriture",
+			"description": "<p>Utilisé en combinaison avec l'encre pour écrire ou dessiner sur une feuille de papier</p>"
+		},
+		{
+			"id": "Feather Token Anchor",
+			"name": "Plume magique de Quaal : Ancre",
+			"description": "<div class=\"description \">Ce tout petit objet ressemble à une plume. Différents types de plume magique existent, chacun possédant son propre effet. Le MD choisit le type de la plume ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Plume magique</th></tr><tr><td class=\"center\">01-20</td><td>Ancre</td></tr><tr><td class=\"center\">21-35</td><td>Oiseau</td></tr><tr><td class=\"center\">36-50</td><td>Éventail</td></tr><tr><td class=\"center\">51-65</td><td>Bateau cygne</td></tr><tr><td class=\"center\">66-90</td><td>Arbre</td></tr><tr><td class=\"center\">91-00</td><td>Fouet</td></tr></tbody></table>\n<br><strong>Ancre</strong>. Vous pouvez utiliser une action pour toucher un navire ou un bateau avec la plume. Pour les 24 prochaines heures, le vaisseau ne peut pas être déplacé par quelque moyen que ce soit. Toucher une seconde fois le vaisseau avec la plume met un terme à l'effet. Lorsque l'effet prend fin, la plume disparaît.\n<br><strong>Oiseau</strong>. Vous pouvez utiliser une action pour lancer la plume à 1,50 mètre dans les airs. La plume disparaît et un énorme oiseau multicolore prend sa place. L'oiseau possède les statistiques d'un roc, mais il obéit à vos ordres simples et ne peut pas attaquer. Il peut transporter jusqu'à 250 kilogrammes tout en volant à sa vitesse de vol maximale (24 km/heure pour un maximum de 216 km/jour, avec une heure de repos toutes les 3 heures de vol), ou 500 kilogrammes en volant à la moitié de sa vitesse de vol. L'oiseau disparaît après avoir parcouru autant que sa distance maximale de vol dans une journée, ou s'il tombe à 0 point de vie. Vous pouvez renvoyer l'oiseau en utilisant une action.\n<br><strong>Éventail</strong>. Si vous êtes sur un navire ou un bateau, vous pouvez utiliser une action pour lancer la plume de Quaal à 3 mètres en l'air. La plume disparaît, et un éventail géant en train de battre apparaît à sa place. L'éventail volette et crée un vent suffisamment puissant pour gonfler les voiles d'un navire, augmentant sa vitesse de 7,5 km/heure pendant 8 heures. Vous pouvez renvoyer l'éventail en utilisant une action.\n<br><strong>Bateau cygne</strong>. Vous pouvez utiliser une action pour toucher avec la plume une masse d'eau large d'au moins 18 mètres de diamètre. La plume disparaît, et un bateau de 15 mètres de long et 6 mètres de large ressemblant à un cygne prend sa place. Le bateau est autopropulsé et se déplace sur l'eau à la vitesse de 9 km/heure. Tant que vous êtes sur le bateau, vous pouvez utiliser une action pour lui ordonner de se déplacer ou de tourner d'un angle maximal de 90 degrés. Le bateau peut transporter jusqu'à 32 créatures de taille M ou inférieure. Une créature de taille G compte pour 4 créatures de taille M, tandis qu'une créature de taille TG compte pour 9 créatures de taille M. Le bateau reste pendant 24 puis il disparaît. Vous pouvez renvoyer le bateau en utilisant une action.\n<br><strong>Arbre</strong>. Vous devez vous trouver en extérieur pour utiliser cette plume de Quaal. Vous pouvez utiliser une action pour toucher avec la plume un espace inoccupé sur le sol. La plume disparaît et à sa place, un chêne non magique apparaît. L'arbre fait 18 mètres de haut et possède un tronc de 1,50 mètre de diamètre, et ses branches supérieures recouvrent une surface de 6 mètres de rayon.\n<br><strong>Fouet</strong>. Vous pouvez utiliser une action pour lancer la plume sur un point se trouvant à 3 mètres de vous. La plume disparaît, et un fouet en lévitation apparaît à sa place. Vous pouvez alors utiliser une action bonus pour effectuer une attaque au corps à corps avec un sort contre une créature se trouvant à 3 mètres ou moins du fouet, avec un bonus à l'attaque de +9. Si le coup touche, la cible subit 1d6 + 5 dégâts de force.\n<br>En utilisant une action bonus pendant votre tour, vous pouvez déplacer le fouet sur 6 mètres maximum et répéter l'attaque contre une créature se trouvant à 3 mètres ou moins de lui. Le fouet disparaît au bout d'une heure, lorsque vous utilisez une action pour le renvoyer, ou lorsque vous êtes incapable d'agir ou que vous mourrez.\n<br></div>"
+		},
+		{
+			"id": "Feather Token Tree",
+			"name": "Plume magique de Quaal : Arbre",
+			"description": "<div class=\"description \">Ce tout petit objet ressemble à une plume. Différents types de plume magique existent, chacun possédant son propre effet. Le MD choisit le type de la plume ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Plume magique</th></tr><tr><td class=\"center\">01-20</td><td>Ancre</td></tr><tr><td class=\"center\">21-35</td><td>Oiseau</td></tr><tr><td class=\"center\">36-50</td><td>Éventail</td></tr><tr><td class=\"center\">51-65</td><td>Bateau cygne</td></tr><tr><td class=\"center\">66-90</td><td>Arbre</td></tr><tr><td class=\"center\">91-00</td><td>Fouet</td></tr></tbody></table>\n<br><strong>Ancre</strong>. Vous pouvez utiliser une action pour toucher un navire ou un bateau avec la plume. Pour les 24 prochaines heures, le vaisseau ne peut pas être déplacé par quelque moyen que ce soit. Toucher une seconde fois le vaisseau avec la plume met un terme à l'effet. Lorsque l'effet prend fin, la plume disparaît.\n<br><strong>Oiseau</strong>. Vous pouvez utiliser une action pour lancer la plume à 1,50 mètre dans les airs. La plume disparaît et un énorme oiseau multicolore prend sa place. L'oiseau possède les statistiques d'un roc, mais il obéit à vos ordres simples et ne peut pas attaquer. Il peut transporter jusqu'à 250 kilogrammes tout en volant à sa vitesse de vol maximale (24 km/heure pour un maximum de 216 km/jour, avec une heure de repos toutes les 3 heures de vol), ou 500 kilogrammes en volant à la moitié de sa vitesse de vol. L'oiseau disparaît après avoir parcouru autant que sa distance maximale de vol dans une journée, ou s'il tombe à 0 point de vie. Vous pouvez renvoyer l'oiseau en utilisant une action.\n<br><strong>Éventail</strong>. Si vous êtes sur un navire ou un bateau, vous pouvez utiliser une action pour lancer la plume de Quaal à 3 mètres en l'air. La plume disparaît, et un éventail géant en train de battre apparaît à sa place. L'éventail volette et crée un vent suffisamment puissant pour gonfler les voiles d'un navire, augmentant sa vitesse de 7,5 km/heure pendant 8 heures. Vous pouvez renvoyer l'éventail en utilisant une action.\n<br><strong>Bateau cygne</strong>. Vous pouvez utiliser une action pour toucher avec la plume une masse d'eau large d'au moins 18 mètres de diamètre. La plume disparaît, et un bateau de 15 mètres de long et 6 mètres de large ressemblant à un cygne prend sa place. Le bateau est autopropulsé et se déplace sur l'eau à la vitesse de 9 km/heure. Tant que vous êtes sur le bateau, vous pouvez utiliser une action pour lui ordonner de se déplacer ou de tourner d'un angle maximal de 90 degrés. Le bateau peut transporter jusqu'à 32 créatures de taille M ou inférieure. Une créature de taille G compte pour 4 créatures de taille M, tandis qu'une créature de taille TG compte pour 9 créatures de taille M. Le bateau reste pendant 24 puis il disparaît. Vous pouvez renvoyer le bateau en utilisant une action.\n<br><strong>Arbre</strong>. Vous devez vous trouver en extérieur pour utiliser cette plume de Quaal. Vous pouvez utiliser une action pour toucher avec la plume un espace inoccupé sur le sol. La plume disparaît et à sa place, un chêne non magique apparaît. L'arbre fait 18 mètres de haut et possède un tronc de 1,50 mètre de diamètre, et ses branches supérieures recouvrent une surface de 6 mètres de rayon.\n<br><strong>Fouet</strong>. Vous pouvez utiliser une action pour lancer la plume sur un point se trouvant à 3 mètres de vous. La plume disparaît, et un fouet en lévitation apparaît à sa place. Vous pouvez alors utiliser une action bonus pour effectuer une attaque au corps à corps avec un sort contre une créature se trouvant à 3 mètres ou moins du fouet, avec un bonus à l'attaque de +9. Si le coup touche, la cible subit 1d6 + 5 dégâts de force.\n<br>En utilisant une action bonus pendant votre tour, vous pouvez déplacer le fouet sur 6 mètres maximum et répéter l'attaque contre une créature se trouvant à 3 mètres ou moins de lui. Le fouet disparaît au bout d'une heure, lorsque vous utilisez une action pour le renvoyer, ou lorsque vous êtes incapable d'agir ou que vous mourrez.\n<br></div>"
+		},
+		{
+			"id": "Feather Token Swan Boat",
+			"name": "Plume magique de Quaal : Bateau de cygne",
+			"description": "<div class=\"description \">Ce tout petit objet ressemble à une plume. Différents types de plume magique existent, chacun possédant son propre effet. Le MD choisit le type de la plume ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Plume magique</th></tr><tr><td class=\"center\">01-20</td><td>Ancre</td></tr><tr><td class=\"center\">21-35</td><td>Oiseau</td></tr><tr><td class=\"center\">36-50</td><td>Éventail</td></tr><tr><td class=\"center\">51-65</td><td>Bateau cygne</td></tr><tr><td class=\"center\">66-90</td><td>Arbre</td></tr><tr><td class=\"center\">91-00</td><td>Fouet</td></tr></tbody></table>\n<br><strong>Ancre</strong>. Vous pouvez utiliser une action pour toucher un navire ou un bateau avec la plume. Pour les 24 prochaines heures, le vaisseau ne peut pas être déplacé par quelque moyen que ce soit. Toucher une seconde fois le vaisseau avec la plume met un terme à l'effet. Lorsque l'effet prend fin, la plume disparaît.\n<br><strong>Oiseau</strong>. Vous pouvez utiliser une action pour lancer la plume à 1,50 mètre dans les airs. La plume disparaît et un énorme oiseau multicolore prend sa place. L'oiseau possède les statistiques d'un roc, mais il obéit à vos ordres simples et ne peut pas attaquer. Il peut transporter jusqu'à 250 kilogrammes tout en volant à sa vitesse de vol maximale (24 km/heure pour un maximum de 216 km/jour, avec une heure de repos toutes les 3 heures de vol), ou 500 kilogrammes en volant à la moitié de sa vitesse de vol. L'oiseau disparaît après avoir parcouru autant que sa distance maximale de vol dans une journée, ou s'il tombe à 0 point de vie. Vous pouvez renvoyer l'oiseau en utilisant une action.\n<br><strong>Éventail</strong>. Si vous êtes sur un navire ou un bateau, vous pouvez utiliser une action pour lancer la plume de Quaal à 3 mètres en l'air. La plume disparaît, et un éventail géant en train de battre apparaît à sa place. L'éventail volette et crée un vent suffisamment puissant pour gonfler les voiles d'un navire, augmentant sa vitesse de 7,5 km/heure pendant 8 heures. Vous pouvez renvoyer l'éventail en utilisant une action.\n<br><strong>Bateau cygne</strong>. Vous pouvez utiliser une action pour toucher avec la plume une masse d'eau large d'au moins 18 mètres de diamètre. La plume disparaît, et un bateau de 15 mètres de long et 6 mètres de large ressemblant à un cygne prend sa place. Le bateau est autopropulsé et se déplace sur l'eau à la vitesse de 9 km/heure. Tant que vous êtes sur le bateau, vous pouvez utiliser une action pour lui ordonner de se déplacer ou de tourner d'un angle maximal de 90 degrés. Le bateau peut transporter jusqu'à 32 créatures de taille M ou inférieure. Une créature de taille G compte pour 4 créatures de taille M, tandis qu'une créature de taille TG compte pour 9 créatures de taille M. Le bateau reste pendant 24 puis il disparaît. Vous pouvez renvoyer le bateau en utilisant une action.\n<br><strong>Arbre</strong>. Vous devez vous trouver en extérieur pour utiliser cette plume de Quaal. Vous pouvez utiliser une action pour toucher avec la plume un espace inoccupé sur le sol. La plume disparaît et à sa place, un chêne non magique apparaît. L'arbre fait 18 mètres de haut et possède un tronc de 1,50 mètre de diamètre, et ses branches supérieures recouvrent une surface de 6 mètres de rayon.\n<br><strong>Fouet</strong>. Vous pouvez utiliser une action pour lancer la plume sur un point se trouvant à 3 mètres de vous. La plume disparaît, et un fouet en lévitation apparaît à sa place. Vous pouvez alors utiliser une action bonus pour effectuer une attaque au corps à corps avec un sort contre une créature se trouvant à 3 mètres ou moins du fouet, avec un bonus à l'attaque de +9. Si le coup touche, la cible subit 1d6 + 5 dégâts de force.\n<br>En utilisant une action bonus pendant votre tour, vous pouvez déplacer le fouet sur 6 mètres maximum et répéter l'attaque contre une créature se trouvant à 3 mètres ou moins de lui. Le fouet disparaît au bout d'une heure, lorsque vous utilisez une action pour le renvoyer, ou lorsque vous êtes incapable d'agir ou que vous mourrez.\n<br></div>"
+		},
+		{
+			"id": "Feather Token Fan",
+			"name": "Plume magique de Quaal : Éventail",
+			"description": "<div class=\"description \">Ce tout petit objet ressemble à une plume. Différents types de plume magique existent, chacun possédant son propre effet. Le MD choisit le type de la plume ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Plume magique</th></tr><tr><td class=\"center\">01-20</td><td>Ancre</td></tr><tr><td class=\"center\">21-35</td><td>Oiseau</td></tr><tr><td class=\"center\">36-50</td><td>Éventail</td></tr><tr><td class=\"center\">51-65</td><td>Bateau cygne</td></tr><tr><td class=\"center\">66-90</td><td>Arbre</td></tr><tr><td class=\"center\">91-00</td><td>Fouet</td></tr></tbody></table>\n<br><strong>Ancre</strong>. Vous pouvez utiliser une action pour toucher un navire ou un bateau avec la plume. Pour les 24 prochaines heures, le vaisseau ne peut pas être déplacé par quelque moyen que ce soit. Toucher une seconde fois le vaisseau avec la plume met un terme à l'effet. Lorsque l'effet prend fin, la plume disparaît.\n<br><strong>Oiseau</strong>. Vous pouvez utiliser une action pour lancer la plume à 1,50 mètre dans les airs. La plume disparaît et un énorme oiseau multicolore prend sa place. L'oiseau possède les statistiques d'un roc, mais il obéit à vos ordres simples et ne peut pas attaquer. Il peut transporter jusqu'à 250 kilogrammes tout en volant à sa vitesse de vol maximale (24 km/heure pour un maximum de 216 km/jour, avec une heure de repos toutes les 3 heures de vol), ou 500 kilogrammes en volant à la moitié de sa vitesse de vol. L'oiseau disparaît après avoir parcouru autant que sa distance maximale de vol dans une journée, ou s'il tombe à 0 point de vie. Vous pouvez renvoyer l'oiseau en utilisant une action.\n<br><strong>Éventail</strong>. Si vous êtes sur un navire ou un bateau, vous pouvez utiliser une action pour lancer la plume de Quaal à 3 mètres en l'air. La plume disparaît, et un éventail géant en train de battre apparaît à sa place. L'éventail volette et crée un vent suffisamment puissant pour gonfler les voiles d'un navire, augmentant sa vitesse de 7,5 km/heure pendant 8 heures. Vous pouvez renvoyer l'éventail en utilisant une action.\n<br><strong>Bateau cygne</strong>. Vous pouvez utiliser une action pour toucher avec la plume une masse d'eau large d'au moins 18 mètres de diamètre. La plume disparaît, et un bateau de 15 mètres de long et 6 mètres de large ressemblant à un cygne prend sa place. Le bateau est autopropulsé et se déplace sur l'eau à la vitesse de 9 km/heure. Tant que vous êtes sur le bateau, vous pouvez utiliser une action pour lui ordonner de se déplacer ou de tourner d'un angle maximal de 90 degrés. Le bateau peut transporter jusqu'à 32 créatures de taille M ou inférieure. Une créature de taille G compte pour 4 créatures de taille M, tandis qu'une créature de taille TG compte pour 9 créatures de taille M. Le bateau reste pendant 24 puis il disparaît. Vous pouvez renvoyer le bateau en utilisant une action.\n<br><strong>Arbre</strong>. Vous devez vous trouver en extérieur pour utiliser cette plume de Quaal. Vous pouvez utiliser une action pour toucher avec la plume un espace inoccupé sur le sol. La plume disparaît et à sa place, un chêne non magique apparaît. L'arbre fait 18 mètres de haut et possède un tronc de 1,50 mètre de diamètre, et ses branches supérieures recouvrent une surface de 6 mètres de rayon.\n<br><strong>Fouet</strong>. Vous pouvez utiliser une action pour lancer la plume sur un point se trouvant à 3 mètres de vous. La plume disparaît, et un fouet en lévitation apparaît à sa place. Vous pouvez alors utiliser une action bonus pour effectuer une attaque au corps à corps avec un sort contre une créature se trouvant à 3 mètres ou moins du fouet, avec un bonus à l'attaque de +9. Si le coup touche, la cible subit 1d6 + 5 dégâts de force.\n<br>En utilisant une action bonus pendant votre tour, vous pouvez déplacer le fouet sur 6 mètres maximum et répéter l'attaque contre une créature se trouvant à 3 mètres ou moins de lui. Le fouet disparaît au bout d'une heure, lorsque vous utilisez une action pour le renvoyer, ou lorsque vous êtes incapable d'agir ou que vous mourrez.\n<br></div>"
+		},
+		{
+			"id": "Feather Token Whip",
+			"name": "Plume magique de Quaal : Fouet",
+			"description": "<div class=\"description \">Ce tout petit objet ressemble à une plume. Différents types de plume magique existent, chacun possédant son propre effet. Le MD choisit le type de la plume ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Plume magique</th></tr><tr><td class=\"center\">01-20</td><td>Ancre</td></tr><tr><td class=\"center\">21-35</td><td>Oiseau</td></tr><tr><td class=\"center\">36-50</td><td>Éventail</td></tr><tr><td class=\"center\">51-65</td><td>Bateau cygne</td></tr><tr><td class=\"center\">66-90</td><td>Arbre</td></tr><tr><td class=\"center\">91-00</td><td>Fouet</td></tr></tbody></table>\n<br><strong>Ancre</strong>. Vous pouvez utiliser une action pour toucher un navire ou un bateau avec la plume. Pour les 24 prochaines heures, le vaisseau ne peut pas être déplacé par quelque moyen que ce soit. Toucher une seconde fois le vaisseau avec la plume met un terme à l'effet. Lorsque l'effet prend fin, la plume disparaît.\n<br><strong>Oiseau</strong>. Vous pouvez utiliser une action pour lancer la plume à 1,50 mètre dans les airs. La plume disparaît et un énorme oiseau multicolore prend sa place. L'oiseau possède les statistiques d'un roc, mais il obéit à vos ordres simples et ne peut pas attaquer. Il peut transporter jusqu'à 250 kilogrammes tout en volant à sa vitesse de vol maximale (24 km/heure pour un maximum de 216 km/jour, avec une heure de repos toutes les 3 heures de vol), ou 500 kilogrammes en volant à la moitié de sa vitesse de vol. L'oiseau disparaît après avoir parcouru autant que sa distance maximale de vol dans une journée, ou s'il tombe à 0 point de vie. Vous pouvez renvoyer l'oiseau en utilisant une action.\n<br><strong>Éventail</strong>. Si vous êtes sur un navire ou un bateau, vous pouvez utiliser une action pour lancer la plume de Quaal à 3 mètres en l'air. La plume disparaît, et un éventail géant en train de battre apparaît à sa place. L'éventail volette et crée un vent suffisamment puissant pour gonfler les voiles d'un navire, augmentant sa vitesse de 7,5 km/heure pendant 8 heures. Vous pouvez renvoyer l'éventail en utilisant une action.\n<br><strong>Bateau cygne</strong>. Vous pouvez utiliser une action pour toucher avec la plume une masse d'eau large d'au moins 18 mètres de diamètre. La plume disparaît, et un bateau de 15 mètres de long et 6 mètres de large ressemblant à un cygne prend sa place. Le bateau est autopropulsé et se déplace sur l'eau à la vitesse de 9 km/heure. Tant que vous êtes sur le bateau, vous pouvez utiliser une action pour lui ordonner de se déplacer ou de tourner d'un angle maximal de 90 degrés. Le bateau peut transporter jusqu'à 32 créatures de taille M ou inférieure. Une créature de taille G compte pour 4 créatures de taille M, tandis qu'une créature de taille TG compte pour 9 créatures de taille M. Le bateau reste pendant 24 puis il disparaît. Vous pouvez renvoyer le bateau en utilisant une action.\n<br><strong>Arbre</strong>. Vous devez vous trouver en extérieur pour utiliser cette plume de Quaal. Vous pouvez utiliser une action pour toucher avec la plume un espace inoccupé sur le sol. La plume disparaît et à sa place, un chêne non magique apparaît. L'arbre fait 18 mètres de haut et possède un tronc de 1,50 mètre de diamètre, et ses branches supérieures recouvrent une surface de 6 mètres de rayon.\n<br><strong>Fouet</strong>. Vous pouvez utiliser une action pour lancer la plume sur un point se trouvant à 3 mètres de vous. La plume disparaît, et un fouet en lévitation apparaît à sa place. Vous pouvez alors utiliser une action bonus pour effectuer une attaque au corps à corps avec un sort contre une créature se trouvant à 3 mètres ou moins du fouet, avec un bonus à l'attaque de +9. Si le coup touche, la cible subit 1d6 + 5 dégâts de force.\n<br>En utilisant une action bonus pendant votre tour, vous pouvez déplacer le fouet sur 6 mètres maximum et répéter l'attaque contre une créature se trouvant à 3 mètres ou moins de lui. Le fouet disparaît au bout d'une heure, lorsque vous utilisez une action pour le renvoyer, ou lorsque vous êtes incapable d'agir ou que vous mourrez.\n<br></div>"
+		},
+		{
+			"id": "Feather Token Bird",
+			"name": "Plume magique de Quaal : Oiseau",
+			"description": "<div class=\"description \">Ce tout petit objet ressemble à une plume. Différents types de plume magique existent, chacun possédant son propre effet. Le MD choisit le type de la plume ou le détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Plume magique</th></tr><tr><td class=\"center\">01-20</td><td>Ancre</td></tr><tr><td class=\"center\">21-35</td><td>Oiseau</td></tr><tr><td class=\"center\">36-50</td><td>Éventail</td></tr><tr><td class=\"center\">51-65</td><td>Bateau cygne</td></tr><tr><td class=\"center\">66-90</td><td>Arbre</td></tr><tr><td class=\"center\">91-00</td><td>Fouet</td></tr></tbody></table>\n<br><strong>Ancre</strong>. Vous pouvez utiliser une action pour toucher un navire ou un bateau avec la plume. Pour les 24 prochaines heures, le vaisseau ne peut pas être déplacé par quelque moyen que ce soit. Toucher une seconde fois le vaisseau avec la plume met un terme à l'effet. Lorsque l'effet prend fin, la plume disparaît.\n<br><strong>Oiseau</strong>. Vous pouvez utiliser une action pour lancer la plume à 1,50 mètre dans les airs. La plume disparaît et un énorme oiseau multicolore prend sa place. L'oiseau possède les statistiques d'un roc, mais il obéit à vos ordres simples et ne peut pas attaquer. Il peut transporter jusqu'à 250 kilogrammes tout en volant à sa vitesse de vol maximale (24 km/heure pour un maximum de 216 km/jour, avec une heure de repos toutes les 3 heures de vol), ou 500 kilogrammes en volant à la moitié de sa vitesse de vol. L'oiseau disparaît après avoir parcouru autant que sa distance maximale de vol dans une journée, ou s'il tombe à 0 point de vie. Vous pouvez renvoyer l'oiseau en utilisant une action.\n<br><strong>Éventail</strong>. Si vous êtes sur un navire ou un bateau, vous pouvez utiliser une action pour lancer la plume de Quaal à 3 mètres en l'air. La plume disparaît, et un éventail géant en train de battre apparaît à sa place. L'éventail volette et crée un vent suffisamment puissant pour gonfler les voiles d'un navire, augmentant sa vitesse de 7,5 km/heure pendant 8 heures. Vous pouvez renvoyer l'éventail en utilisant une action.\n<br><strong>Bateau cygne</strong>. Vous pouvez utiliser une action pour toucher avec la plume une masse d'eau large d'au moins 18 mètres de diamètre. La plume disparaît, et un bateau de 15 mètres de long et 6 mètres de large ressemblant à un cygne prend sa place. Le bateau est autopropulsé et se déplace sur l'eau à la vitesse de 9 km/heure. Tant que vous êtes sur le bateau, vous pouvez utiliser une action pour lui ordonner de se déplacer ou de tourner d'un angle maximal de 90 degrés. Le bateau peut transporter jusqu'à 32 créatures de taille M ou inférieure. Une créature de taille G compte pour 4 créatures de taille M, tandis qu'une créature de taille TG compte pour 9 créatures de taille M. Le bateau reste pendant 24 puis il disparaît. Vous pouvez renvoyer le bateau en utilisant une action.\n<br><strong>Arbre</strong>. Vous devez vous trouver en extérieur pour utiliser cette plume de Quaal. Vous pouvez utiliser une action pour toucher avec la plume un espace inoccupé sur le sol. La plume disparaît et à sa place, un chêne non magique apparaît. L'arbre fait 18 mètres de haut et possède un tronc de 1,50 mètre de diamètre, et ses branches supérieures recouvrent une surface de 6 mètres de rayon.\n<br><strong>Fouet</strong>. Vous pouvez utiliser une action pour lancer la plume sur un point se trouvant à 3 mètres de vous. La plume disparaît, et un fouet en lévitation apparaît à sa place. Vous pouvez alors utiliser une action bonus pour effectuer une attaque au corps à corps avec un sort contre une créature se trouvant à 3 mètres ou moins du fouet, avec un bonus à l'attaque de +9. Si le coup touche, la cible subit 1d6 + 5 dégâts de force.\n<br>En utilisant une action bonus pendant votre tour, vous pouvez déplacer le fouet sur 6 mètres maximum et répéter l'attaque contre une créature se trouvant à 3 mètres ou moins de lui. Le fouet disparaît au bout d'une heure, lorsque vous utilisez une action pour le renvoyer, ou lorsque vous êtes incapable d'agir ou que vous mourrez.\n<br></div>"
+		},
+		{
+			"id": "Iron Spike",
+			"name": "Pointes en fer",
+			"description": "<p>A pointe de 25 cm de long en fer. Peut être improvisé pour bloquer les portes. Généralement vendu en paquets de 10.</span></p>"
+		},
+		{
+			"id": "Basic Poison",
+			"name": "Poison (fiole)",
+			"description": "<p>Vous pouvez utiliser le poison de cette fiole pour couvrir une arme tranchante ou perforante, ou jusqu'à trois munitions. Appliquer le poison prend une action. Une créature touchée par une arme ou une munition empoisonnée doit réussir un jet de sauvegarde de Constitution DD 10 ou prendre 1d4 points de dégâts de poison. Une fois appliqué, le poison conserve son activité 1 minute avant de sécher.</span></p>"
+		},
+		{
+			"id": "Cubic Gate",
+			"name": "Portail cubique",
+			"description": "<div class=\"description \">Ce cube de 7,50 centimètres de côté irradie une énergie magique palpable. Les six faces du cube sont chacune reliées à un plan d'existence différent, dont l'un d'eux est le plan matériel. Les autres faces sont reliées à des plans choisis par le MD.\n<br>Vous pouvez utiliser une action pour appuyer sur une face du cube et ainsi lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=portail\">portail</a></em>. Un portail s'ouvre alors vers le plan d'existence auquel est reliée la face du cube que vous avez pressée. Sinon, si vous utilisez une action pour appuyer deux fois sur la même face, vous pouvez lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=changement-de-plan\">changement de plan</a></em> (sauvegarde DD 17) avec le cube et transporter les cibles dans le plan d'existence relié à la face concernée.\n<br>Le cube possède 3 charges. Chaque utilisation du cube dépense une charge. Le cube récupère 1d3 charges chaque jour au lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Iron Pot",
+			"name": "Pot en fer",
+			"description": "<p>Un pot de fer qui peut contenir 4 l de liquide.</span></p>"
+		},
+		{
+			"id": "Potion of Growth",
+			"name": "Potion d'agrandissement",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous bénéficiez de l'effet « agrandissement » du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=agrandissement-rapetissement\">agrandissement/rapetissement</a></em> pendant 1d4 heures (aucune concentration n'est requise). Une couleur rouge s'étend depuis une petite perle pour colorer le liquide clair de la potion, puis se contracte. Secouer la fiole n'interrompt pas ce processus.\n<br></div>"
+		},
+		{
+			"id": "Potion of Animal Friendship",
+			"name": "Potion d'amitié avec les animaux",
+			"description": "<div class=\"description \">Quand vous buvez cette potion, vous pouvez lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=amitie-avec-les-animaux\">amitié avec les animaux</a></em> (sauvegarde DD 13) pendant 1 heure à volonté. Agiter ce liquide boueux fait apparaître de petits morceaux : une écaille de poisson, une langue de colibri, une griffe de chat ou un poil d'écureuil.\n<br></div>"
+		},
+		{
+			"id": "Potion of Climbing",
+			"name": "Potion d'escalade",
+			"description": "<div class=\"description \">Quand vous buvez cette potion, vous gagnez une vitesse d'escalade égale à votre vitesse de marche pendant 1 heure. Pendant ce temps, vous avez un avantage aux jets de Force (Athlétisme) que vous effectuez pour escalader. La potion est séparée en bandes brune, argent et grise qui ressemblent à des couches de pierre. Secouer la bouteille ne mélange pas les couleurs.\n<br></div>"
+		},
+		{
+			"id": "Potion of Heroism",
+			"name": "Potion d'héroïsme",
+			"description": "<div class=\"description \">Après avoir bu cette potion, vous gagnez 10 points de vie temporaires qui durent 1 heure. Durant tout ce temps, vous êtes sous l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=benediction\">bénédiction</a></em> (pas de concentration requise). Cette potion présente des bulles bleues et des vapeurs comme si elle était bouillante.\n<br></div>"
+		},
+		{
+			"id": "Potion of Invisibility",
+			"name": "Potion d'invisibilité",
+			"description": "<div class=\"description \">Le contenant de cette potion semble vide, mais on sent toutefois qu'il contient un liquide. Lorsque vous buvez cette potion, vous devenez invisible pour une durée de 1 heure. Tout ce que vous portez ou transportez devient également invisible. L'effet se termine plus tôt si vous attaquez ou lancez un sort.\n<br></div>"
+		},
+		{
+			"id": "Potion of Clairvoyance",
+			"name": "Potion de clairvoyance",
+			"description": "<div class=\"description \">Quand vous buvez cette potion, vous bénéficiez de l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=clairvoyance\">clairvoyance</a></em>. Un globe oculaire s'agite sur le liquide jaunâtre, mais disparaît lorsque la potion est ouverte.\n<br></div>"
+		},
+		{
+			"id": "Potion of Hill Giant Strength",
+			"name": "Potion de force de géant des collines",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre valeur de Force change pour 1 heure. Le type du géant détermine la valeur (voir le tableau ci-dessous). La potion n'a aucun effet sur vous si votre Force est égale ou supérieure à celle indiquée.\n<br>Dans le liquide transparent de cette potion flotte un morceau d'ongle d'un géant du type approprié. Une <em>potion de force de géant du givre</em> et une <em>potion de géant des pierres</em> ont le même effet.\n<br><table><tbody><tr><th>Type de géant</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Peu commun</td></tr><tr><td>Géant des pierres/du givre</td><td class=\"center\">23</td><td>Rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Très rare</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Cloud Giant Strength",
+			"name": "Potion de force de géant des nuages",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre valeur de Force change pour 1 heure. Le type du géant détermine la valeur (voir le tableau ci-dessous). La potion n'a aucun effet sur vous si votre Force est égale ou supérieure à celle indiquée.\n<br>Dans le liquide transparent de cette potion flotte un morceau d'ongle d'un géant du type approprié. Une <em>potion de force de géant du givre</em> et une <em>potion de géant des pierres</em> ont le même effet.\n<br><table><tbody><tr><th>Type de géant</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Peu commun</td></tr><tr><td>Géant des pierres/du givre</td><td class=\"center\">23</td><td>Rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Très rare</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Stone Giant Strength",
+			"name": "Potion de force de géant des pierres",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre valeur de Force change pour 1 heure. Le type du géant détermine la valeur (voir le tableau ci-dessous). La potion n'a aucun effet sur vous si votre Force est égale ou supérieure à celle indiquée.\n<br>Dans le liquide transparent de cette potion flotte un morceau d'ongle d'un géant du type approprié. Une <em>potion de force de géant du givre</em> et une <em>potion de géant des pierres</em> ont le même effet.\n<br><table><tbody><tr><th>Type de géant</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Peu commun</td></tr><tr><td>Géant des pierres/du givre</td><td class=\"center\">23</td><td>Rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Très rare</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Storm Giant Strength",
+			"name": "Potion de force de géant des tempêtes",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre valeur de Force change pour 1 heure. Le type du géant détermine la valeur (voir le tableau ci-dessous). La potion n'a aucun effet sur vous si votre Force est égale ou supérieure à celle indiquée.\n<br>Dans le liquide transparent de cette potion flotte un morceau d'ongle d'un géant du type approprié. Une <em>potion de force de géant du givre</em> et une <em>potion de géant des pierres</em> ont le même effet.\n<br><table><tbody><tr><th>Type de géant</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Peu commun</td></tr><tr><td>Géant des pierres/du givre</td><td class=\"center\">23</td><td>Rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Très rare</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Fire Giant Strength",
+			"name": "Potion de force de géant du feu",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre valeur de Force change pour 1 heure. Le type du géant détermine la valeur (voir le tableau ci-dessous). La potion n'a aucun effet sur vous si votre Force est égale ou supérieure à celle indiquée.\n<br>Dans le liquide transparent de cette potion flotte un morceau d'ongle d'un géant du type approprié. Une <em>potion de force de géant du givre</em> et une <em>potion de géant des pierres</em> ont le même effet.\n<br><table><tbody><tr><th>Type de géant</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Peu commun</td></tr><tr><td>Géant des pierres/du givre</td><td class=\"center\">23</td><td>Rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Très rare</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Frost Giant Strength",
+			"name": "Potion de force de géant du givre",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre valeur de Force change pour 1 heure. Le type du géant détermine la valeur (voir le tableau ci-dessous). La potion n'a aucun effet sur vous si votre Force est égale ou supérieure à celle indiquée.\n<br>Dans le liquide transparent de cette potion flotte un morceau d'ongle d'un géant du type approprié. Une <em>potion de force de géant du givre</em> et une <em>potion de géant des pierres</em> ont le même effet.\n<br><table><tbody><tr><th>Type de géant</th><th>Force</th><th>Rareté</th></tr><tr><td>Géant des collines</td><td class=\"center\">21</td><td>Peu commun</td></tr><tr><td>Géant des pierres/du givre</td><td class=\"center\">23</td><td>Rare</td></tr><tr><td>Géant du feu</td><td class=\"center\">25</td><td>Rare</td></tr><tr><td>Géant des nuages</td><td class=\"center\">27</td><td>Très rare</td></tr><tr><td>Géant des tempêtes</td><td class=\"center\">29</td><td>Légendaire</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Gaseous Form",
+			"name": "Potion de forme gazeuse",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous bénéficiez de l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=forme-gazeuse\">forme gazeuse</a></em> pour 1 heure (pas de concentration requise) ou jusqu'à ce que vous mettiez fin à l'effet par une action bonus. Le flacon de cette potion semble contenir un brouillard qui se déplace et se déverse comme de l'eau.\n<br></div>"
+		},
+		{
+			"id": "Potion of Healing",
+			"name": "Potion de guérison",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous regagnez des points de vie. Le nombre de points de vie dépend de la rareté de la potion, comme indiqué dans la table ci-dessous. Quelle que soit sa puissance, le liquide rouge de la potion se met à luire lorsqu'il est agité.\n<br><table><tbody><tr><th>Potion de ...</th><th>Rareté</th><th>pv regagnés</th></tr><tr><td>Soins</td><td>Commun</td><td>2d4 + 2</td></tr><tr><td>Soins majeurs</td><td>Peu commun</td><td>4d4 + 4</td></tr><tr><td>Soins supérieurs</td><td>Rare</td><td>8d4 + 8</td></tr><tr><td>Soins suprêmes</td><td>Très rare</td><td>10d4 + 20</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Greater Healing",
+			"name": "Potion de guérison majeurs",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous regagnez des points de vie. Le nombre de points de vie dépend de la rareté de la potion, comme indiqué dans la table ci-dessous. Quelle que soit sa puissance, le liquide rouge de la potion se met à luire lorsqu'il est agité.\n<br><table><tbody><tr><th>Potion de ...</th><th>Rareté</th><th>pv regagnés</th></tr><tr><td>Soins</td><td>Commun</td><td>2d4 + 2</td></tr><tr><td>Soins majeurs</td><td>Peu commun</td><td>4d4 + 4</td></tr><tr><td>Soins supérieurs</td><td>Rare</td><td>8d4 + 8</td></tr><tr><td>Soins suprêmes</td><td>Très rare</td><td>10d4 + 20</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Superior Healing",
+			"name": "Potion de guérison supérieurs",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous regagnez des points de vie. Le nombre de points de vie dépend de la rareté de la potion, comme indiqué dans la table ci-dessous. Quelle que soit sa puissance, le liquide rouge de la potion se met à luire lorsqu'il est agité.\n<br><table><tbody><tr><th>Potion de ...</th><th>Rareté</th><th>pv regagnés</th></tr><tr><td>Soins</td><td>Commun</td><td>2d4 + 2</td></tr><tr><td>Soins majeurs</td><td>Peu commun</td><td>4d4 + 4</td></tr><tr><td>Soins supérieurs</td><td>Rare</td><td>8d4 + 8</td></tr><tr><td>Soins suprêmes</td><td>Très rare</td><td>10d4 + 20</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Supreme Healing",
+			"name": "Potion de guérison suprêmes",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous regagnez des points de vie. Le nombre de points de vie dépend de la rareté de la potion, comme indiqué dans la table ci-dessous. Quelle que soit sa puissance, le liquide rouge de la potion se met à luire lorsqu'il est agité.\n<br><table><tbody><tr><th>Potion de ...</th><th>Rareté</th><th>pv regagnés</th></tr><tr><td>Soins</td><td>Commun</td><td>2d4 + 2</td></tr><tr><td>Soins majeurs</td><td>Peu commun</td><td>4d4 + 4</td></tr><tr><td>Soins supérieurs</td><td>Rare</td><td>8d4 + 8</td></tr><tr><td>Soins suprêmes</td><td>Très rare</td><td>10d4 + 20</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Mind Reading",
+			"name": "Potion de lecture des pensées",
+			"description": "<div class=\"description \">Quand vous buvez cette potion, vous bénéficiez de l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-des-pensees\">détection des pensées</a></em> (sauvegarde DD 13). Dans la potion, d'un liquide pourpre dense, flotte un nuage ovoïde rose.\n<br></div>"
+		},
+		{
+			"id": "Potion of Poison",
+			"name": "Potion de poison",
+			"description": "<div class=\"description \">Cette concoction ressemble, sent et a le gout d'une potion de guérison ou de toute autre potion bénéfique. Cependant, c'est effectivement du poison masqué par une illusion magique. Un sort d'<em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=identification\">identification</a></em> révèle sa vraie nature.\n<br>Si vous buvez cette potion, vous subissez 3d6 dégâts de poison, et devez réussir un jet de sauvegarde de Constitution DD 13 pour ne pas être empoisonné. Au début de chacun de vos tours, tant que vous êtes empoisonné de cette façon, vous subissez 3d6 dégâts de poison. À la fin de chacun de vos tours, vous pouvez rejeter le jet de sauvegarde. En cas de réussite, les dégâts de poison que vous subissez aux tours suivants diminuent de 1d6. Le poison n'a plus d'effet lorsque les dégâts tombent à 0.\n<br></div>"
+		},
+		{
+			"id": "Potion of Acid Resistance",
+			"name": "Potion de résistance (acide)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Fire Resistance",
+			"name": "Potion de résistance (feu)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Force Resistance",
+			"name": "Potion de résistance (force)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Lightning Resistance",
+			"name": "Potion de résistance (foudre)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Cold Resistance",
+			"name": "Potion de résistance (froid)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Necrotic Resistance",
+			"name": "Potion de résistance (nécrotique)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Poison Resistance",
+			"name": "Potion de résistance (poison)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Psychic Resistance",
+			"name": "Potion de résistance (psychique)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Radiant Resistance",
+			"name": "Potion de résistance (radiant)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Thunder Resistance",
+			"name": "Potion de résistance (tonnerre)",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous gagnez une résistance à un type de dégâts pendant 1 heure. Le MD choisit le type ou le détermine au hasard parmi les options ci-dessous.\n<br><table><tbody><tr><th class=\"center\">d10</th><th>Type de dégâts</th></tr><tr><td class=\"center\">1</td><td>Acide</td></tr><tr><td class=\"center\">2</td><td>Froid</td></tr><tr><td class=\"center\">3</td><td>Feu</td></tr><tr><td class=\"center\">4</td><td>Force</td></tr><tr><td class=\"center\">5</td><td>Foudre</td></tr><tr><td class=\"center\">6</td><td>Nécrotique</td></tr><tr><td class=\"center\">7</td><td>Poison</td></tr><tr><td class=\"center\">8</td><td>Psychique</td></tr><tr><td class=\"center\">9</td><td>Radiant</td></tr><tr><td class=\"center\">10</td><td>Tonnerre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Potion of Water Breathing",
+			"name": "Potion de respiration aquatique",
+			"description": "<div class=\"description \">Vous pouvez respirer sous l'eau pendant 1 heure après avoir bu cette potion. Son fluide vert nuageux sent la mer et une bulle ressemblant à une méduse y flotte en suspension.\n<br></div>"
+		},
+		{
+			"id": "Potion of Diminution",
+			"name": "Potion de rétrécissement",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous bénéficiez de l'effet « rapetissement » du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=agrandissement-rapetissement\">agrandissement/rapetissement</a></em> pendant 1d4 heures (pas de concentration requise). Le rouge du liquide de cette potion se contracte en permanence en une petite perle, puis s'étend pour colorer le liquide clair autour de lui. Secouer la bouteille n'interrompt pas ce processus.\n<br></div>"
+		},
+		{
+			"id": "Potion of Speed",
+			"name": "Potion de vitesse",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, vous bénéficiez de l'effet du sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=hate\">hâte</a></em> pendant 1 minute (pas de concentration requise). Le liquide jaune de cette potion est strié de noir et tourbillonne sur lui-même.\n<br></div>"
+		},
+		{
+			"id": "Potion of Flying",
+			"name": "Potion de vol",
+			"description": "<div class=\"description \">Lorsque vous buvez cette potion, votre obtenez une vitesse de vol égale à votre vitesse de marche pour une durée de 1 heure et pouvez flotter. Si l'effet de la potion se termine alors que vous êtes dans les airs, vous tombez, à moins de posséder un autre moyen de vous retenir en l'air. Ce liquide clair flotte en haut de son contenant et des impuretés nuageuses blanches dérivent autour.\n<br></div>"
+		},
+		{
+			"id": "Dust of Sneezing and Choking",
+			"name": "Poudre à éternuer",
+			"description": "<div class=\"description \">Trouvée dans un petit contenant, cette poudre ressemble à du sable très fin. Il ressemble à de la poussière de disparition, et un sort d'<em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=identification\">identification</a></em> l'indique comme tel. Il y a suffisamment de poudre pour une seule utilisation.\n<br>Lorsque vous utilisez une action pour lancer une poignée de cette poudre dans les airs, vous, et toute créature ayant besoin de respirer et se trouvant à 9 mètres de vous, devez réussir un jet de sauvegarde de Constitution DD 15 sous peine d'être incapable de respirer à cause d'une quinte d'éternuements incontrôlables. Une créature affectée de cette manière est incapable d'agir et suffoque. Aussi longtemps qu'elle est consciente, une créature peut retenter ce jet de sauvegarde à la fin de chacun de ses tours, mettant un terme à l'effet qui l'affecte en cas de réussite. Le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=restauration-partielle\">restauration partielle</a></em> peut également mettre un terme à cet effet sur une créature.\n<br></div>"
+		},
+		{
+			"id": "Dust of Dryness",
+			"name": "Poussière d'assèchement",
+			"description": "<div class=\"description \">Ce petit paquet contient 1d6 + 4 pincées de poussière. Vous pouvez utiliser une action pour en saupoudrer une pincée sur de l'eau.\n<br>La poussière transforme un cube d'eau de 4,50 mètres d'arête en une boule de la taille d'une bille qui flotte ou reste près du lieu où la poussière a été aspergée. Le poids de la bille est négligeable.\n<br>Quelqu'un peut utiliser une action pour écraser la bille contre une surface dure, ce qui la brise et libère l'eau que la poussière a absorbée. Cela met fin à l'effet magique.\n<br>Un élémentaire composé principalement d'eau et qui est exposé à une pincée de cette poussière doit faire un jet de sauvegarde de Constitution DD 13, subissant 10d6 dégâts nécrotiques en cas d'échec, ou la moitié de ces dégâts en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Dust of Disappearance",
+			"name": "Poussière de disparition",
+			"description": "<div class=\"description \">Rangée dans un petit paquet, cette poudre ressemble à du sable très fin. Il y en a assez pour une utilisation. Lorsque vous utilisez une action pour jeter la poussière dans l'air, vous et toute créature et objet dans un rayon de 3 mètres autour de vous devenez invisibles pour 2d4 minutes. La durée est la même pour tous les sujets, et la poussière est consommée lorsque sa magie prend effet. Si une créature affectée par la poussière attaque ou lance un sort, l'invisibilité se termine pour cette créature.\n<br></div>"
+		},
+		{
+			"id": "Well of Many Worlds",
+			"name": "Puits des mondes",
+			"description": "<div class=\"description \">Cette étoffe noire et raffinée, aussi douce que la soie, est repliée aux dimensions d'un mouchoir de poche. Lorsqu'elle est dépliée, elle prend une forme circulaire de 1,80 mètre de diamètre.\n<br>Vous pouvez utiliser une action pour déplier et poser le puits des mondes sur une surface solide, après quoi il crée un portail à double sens vers un autre monde ou plan d'existence. Chaque fois que l'objet ouvre un portail, le MD décide où il mène. Vous pouvez utiliser une action pour fermer un portail ouvert en prenant les bords du tissu et en le repliant. Une fois que le puits des mondes a ouvert un portail, il ne peut recommencer pendant 1d8 heures.\n<br></div>"
+		},
+		{
+			"id": "Portable Hole",
+			"name": "Puits portatif",
+			"description": "<div class=\"description \">Ce fin tissu noir, doux comme de la soie fait la taille d'un mouchoir une fois plié. Étendu, il a la forme d'un cercle de 1,80 mètre de diamètre.\n<br>Vous pouvez utiliser une action pour déplier le <em>puits portatif</em> et le placer sur ou contre une surface solide, ce qui créé alors un trou extra dimensionnel de 3 mètres de profondeur. Le trou cylindrique existe dans un plan différent ce qui fait qu'il ne peut pas être utilisé pour créer des passages ou passer à travers un mur. Toute créature à l'intérieur du <em>puits portatif</em> peut en sortir en escaladant les parois.\n<br>Vous pouvez utiliser une action pour fermer le <em>puits portatif</em> en le repliant à partir des bords. Plier le tissus ferme le trou et toute créature ou objet qui s'y trouve reste dans l'espace extradimensionnel. Quoiqu'il s'y trouve, le <em>puits portatif</em> ne pèse rien.\n<br>Si le trou est plié, une créature qui se trouverait à l'intérieur de l'espace extradimensionnel peut utiliser une action et faire un jet de Force DD 10. En cas de réussite, la créature force le passage et apparaît à 1,50 mètre du <em>puits portatif</em> où de la créature qui le porte sur elle. Une créature qui respire à l'intérieur du trou peut respirer pendant 10 minutes, après quoi elle commence à manquer d'air et à suffoquer.\n<br>Placer un <em>puits portatif</em> dans un autre espace extradimensionnel comme un <em>sac sans fond</em>, un <em>havresac magique d'Hévard</em> ou tout autre objet similaire détruit instantanément les deux objets et ouvre un portail sur le plan Astral. Le portail ouvre vers l'endroit où était placé l'objet à l'intérieur de l'autre. Toute créature située à 3 mètres ou moins de la porte y est aspirée et laissée à une position aléatoire du plan Astral. Le portail se referme alors immédiatement. C'est un portail à sens unique qui ne peut être ré-ouvert.\n<br></div>"
+		},
+		{
+			"id": "Rapier",
+			"name": "Rapière",
+			"description": "<p>Une lame métallique mince et résistante, légère mais de longue portée, conçue pour des attaques rapides afin de cibler les points faibles des défenses ennemies avec une rapidité fulgurante.</p>"
+		},
+		{
+			"id": "Rapier +1",
+			"name": "Rapière +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Rapier +2",
+			"name": "Rapière +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Rapier +3",
+			"name": "Rapière +3",
+			"description": "<p><em>WPar le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Flame Tongue Rapier",
+			"name": "Rapière ardente",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action bonus pour prononcer le mot de commande de l'épée, ce qui fait jaillir des flammes de la lame. Ces flammes génèrent une lumière vive dans un rayon de 12 mètres et une lumière faible sur 12 mètres supplémentaires. Tant que l'épée est en feu, elle inflige 2d6 dégâts de feu supplémentaires à toute cible qu'elle touche. Les flammes perdurent jusqu'à ce que vous utilisiez une action bonus pour prononcer le mot de commande de nouveau, ou jusqu'à ce que vous lâchiez l'épée ou la rengainiez.\n<br></div>"
+		},
+		{
+			"id": "Dancing Rapier",
+			"name": "Rapière Dansante",
+			"description": "<p><em>(nécessite un lien)</em></p>\n<p>Vous pouvez utiliser une action bonus pour lancer cette épée magique en l'air et prononcer son mot de commande. Elle se met alors à flotter et s'envole à une distance maximum de 9 mètres, attaquant la créature de votre choix située dans un rayon de 1,50 mètre autour d'elle. L'épée utilise votre jet d'attaque et votre modificateur de caractéristique aux jets de dégâts.</p>\n<p>Tant que l'épée flotte dans les airs, vous pouvez utiliser une action bonus pour l'envoyer voler sur une distance maximum de 9 mètres jusqu'à un emplacement situé dans un rayon de 9 mètres autour de vous. Lors de cette action bonus, vous pouvez demander à l'épée d'attaquer une créature située dans un rayon de 1,50 mètre autour d'elle.</p>\n<p>Une fois que l'épée a attaqué pour la quatrième fois, elle vole sur un maximum de 9 mètres et tente de retourner dans votre main. Si vous avez les deux mains prises, elle tombe à vos pieds. Si l'épée ne dispose d'aucun chemin d'accès pour vous rejoindre, elle se rapproche de vous autant que possible et tombe à terre. Elle cesse également de flotter dans les airs si vous l'attrapez ou si vous vous éloignez à plus de 9 mètres d'elle.</p>"
+		},
+		{
+			"id": "Frost Brand Rapier",
+			"name": "Rapière de givre",
+			"description": "<div class=\"description \">Lorsque vous touchez avec une attaque utilisant cette épée magique, la cible subit 1d6 dégâts de froid supplémentaires. En outre, tant que vous tenez l'épée, vous avez la résistance aux dégâts de feu. Dans des températures de congélation, la lame émet en lumière vive dans un rayon de 3 mètres et une lumière faible sur 3 mètres supplémentaires.\n<br>Lorsque vous dégainez cette arme, vous pouvez éteindre toutes les flammes non magiques dans un rayon de 9 mètres autour de vous. Cette propriété ne peut pas être utilisée plus d'une fois par heure.\n<br></div>"
+		},
+		{
+			"id": "Holy Avenger Rapier",
+			"name": "Rapière de justice",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 à l'attaque et aux dégâts réalisés avec cette arme magique. Lorsque vous touchez un fiélon ou un mort-vivant avec elle, cette créature subit 2d10 dégâts radiants supplémentaires.\n<br>Tant que vous tenez l'épée dégainée, elle crée une aura dans un rayon de 3 mètres autour de vous. Vous et toutes les créatures qui vous sont amicales dans l'aura ont un avantage aux jets de sauvegarde contre les sorts et autres effets magiques. Si vous avez 17 ou plus niveaux dans la classe de paladin, le rayon de l'aura augmente de 3 mètres.\n<br></div>"
+		},
+		{
+			"id": "Defender Rapier",
+			"name": "Rapière Gardienne",
+			"description": "<div class=\"description \">Vous obtenez un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>La première fois que vous attaquez avec l'épée au cours de chacun de vos tours, vous pouvez transférer tout ou partie du bonus de l'épée vers votre Classe d'Armure, plutôt que d'utiliser ce bonus sur vos attaques de ce tour. Par exemple, vous pourriez réduire le bonus à votre jet d'attaque et de dégâts à +1 et ainsi gagner un bonus de +2 à votre CA. La modification du bonus reste effective jusqu'au début de votre prochain tour, mais vous devez bien entendu avoir l'épée en main pour bénéficier de son bonus à la CA.\n<br></div>"
+		},
+		{
+			"id": "Rapier of Wounding",
+			"name": "Rapière incisive",
+			"description": "<div class=\"description \">Les points de vie perdus à cause de dégâts infligés par cette arme ne peuvent être récupérés que par le biais d'un repos court ou long, mais pas à l'aide de capacités de régénération, de pouvoirs magiques, de sorts, ou de tout autre moyen.\n<br>Une fois par tour, lorsque vous touchez une créature avec une attaque utilisant cette arme magique, vous pouvez blesser profondément la cible. Au début de chacun des tours de la créature blessée, celle-ci subit 1d4 dégâts nécrotiques pour chaque blessure profonde que vous lui avez infligée, et elle peut ensuite effectuer un jet de sauvegarde de Constitution DD 15, mettant un terme à l'effet de toutes les blessures profondes que vous lui avez infligées en cas de réussite. Sinon, la créature blessée profondément, ou une créature se trouvant à 1,50 mètre d'elle, peut utiliser son action pour effectuer un jet de Sagesse (Médecine) DD 15, mettant un terme à l'effet des blessures profondes qui l'affectent en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Luck Blade Rapier",
+			"name": "Rapière Lame porte-bonheur",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique. Tant que vous portez l'épée sur vous, vous bénéficiez également d'un bonus de +1 aux jets de sauvegarde.\n<br><strong>Chance</strong>. Si vos portez l'épée sur vous, vous pouvez invoquer sa chance (aucune action n'est requise) pour relancer un jet d'attaque, de caractéristique ou de sauvegarde dont le résultat vous déplaît. Vous devez accepter le nouveau résultat. Cette propriété ne peut pas être utilisée de nouveau avant le prochain lever du soleil.\n<br><strong>Souhait</strong>. L'épée possède 1d4 - 1 charges. Tant que vous la tenez en main, vous pouvez utiliser une action pour dépenser une charge et lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=souhait\">souhait</a></em>. Cette propriété ne peut plus être utilisée avant la prochaine aube. L'épée perd cette propriété si elle n'a plus de charges.\n<br></div>"
+		},
+		{
+			"id": "Dragon Slayer Rapier",
+			"name": "Rapière Tueuse de dragons",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 à l'attaque et aux dégâts fait avec cette arme magique.\n<br>Si vous touchez un dragon avec cette arme, le dragon subit 3d6 dégâts supplémentaires du type de l'arme. Pour cette arme, le terme « dragon » se réfère à toute créature qui possède le type dragon, y compris les tortues dragons et les wivernes.\n<br></div>"
+		},
+		{
+			"id": "Giant Slayer Rapier",
+			"name": "Rapière Tueuse de géant",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>Lorsque vous frappez un géant avec elle, le géant subit 2d6 dégâts supplémentaires du type de l'arme et doit réussir un jet de sauvegarde de Force DD 15 sous peine d'être jeté à terre. Dans le cadre de cette propriété de l'arme, le terme « géant » se réfère à toute créature de type géant, ce qui inclut les ettins et les trolls.\n<br></div>"
+		},
+		{
+			"id": "Vicious Rapier",
+			"name": "Rapière vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Rapier of Life Stealing",
+			"name": "Rapière voleuse de vie",
+			"description": "<div class=\"description \">Lorsque vous attaquez une créature avec cette arme magique et obtenez un 20 au jet d'attaque, la cible subit 10 dégâts nécrotiques supplémentaires, à condition qu'elle ne soit pas une créature artificielle ou un mort-vivant. Vous gagnez un nombre de points de vie temporaires égal aux dégâts supplémentaires infligés.\n<br></div>"
+		},
+		{
+			"id": "Nine Lives Stealer Rapier",
+			"name": "Rapière Voleuse des neuf vies",
+			"description": "<div class=\"description \">Vous gagnez un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.\n<br>L'épée possède 1d8 + 1 charges. Quand vous obtenez un coup critique contre une créature à qui il reste moins de 100 points de vies, celle-ci doit réussir un jet de sauvegarde de Constitution DD 15 ou être tuée instantanément, sa force vitale étant arrachée de son corps (les morts-vivants et les créatures artificielles sont immunisés). L'épée perd 1 charge si la créature est tuée. Elle perd cette propriété une fois toutes les charges épuisées.\n<br></div>"
+		},
+		{
+			"id": "Rations",
+			"name": "Rations (1 jour)",
+			"description": "<p>Aliments compacts et secs appropriés pour un voyage prolongé, les rations incluent du bœuf séché, des fruits secs, des biscuits et des noix.</span></p>"
+		},
+		{
+			"id": "Reliquary",
+			"name": "Reliquaire",
+			"description": "Une petite boîte ou un autre récipient contenant un fragment d'une précieuse relique, d'un saint ou d'un autre personnage historique qui ont consacré leur vie à suivre le chemin d'un vrai croyant. Une divinité confère au porteur de cet artefact la capacité d'invoquer son pouvoir et, ce faisant, de répandre la foi une fois de plus.Un symbole sacré est une représentation d'un dieu ou d'un panthéon. Cela peut être une amulette avec un symbole représentant une divinité, ce même symbole gravé ou incrusté tel un emblème sur un bouclier, ou une toute petite boîte renfermant le fragment d'une relique sacrée. Un clerc ou paladin peut utiliser un symbole sacré comme focaliseur magique. Pour utiliser le symbole de cette manière, le lanceur doit le porter visiblement, en main ou sur un bouclier.</p>"
+		},
+		{
+			"id": "Riding Saddle",
+			"name": "Selle d'équitation",
+			"description": "<p>Type de siège fixé sur le dos d'une monture, conçu pour soutenir le cavalier et fixer une partie de l'équipement de la monture, comme les étriers. Ce type de selle est adapté aux montures.</p>"
+		},
+		{
+			"id": "Robe of Stars",
+			"name": "Robe aux étoiles",
+			"description": "<div class=\"description \">Cette robe noire ou bleue foncée est brodée de petites étoiles blanches ou argentées. Vous gagnez un bonus de +1 aux jets de sauvegarde tant que vous êtes équipé de cette robe. Six étoiles, situées sur la robe au niveau du torse, sont particulièrement larges. Tant que vous êtes équipé de cette robe, vous pouvez utiliser une action pour prélever l'une de ces étoiles et l'utiliser pour lancer un sort de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=projectile-magique\">projectile magique</a></em> (équivalent à un emplacement de sort de niveau 5). Chaque jour, au crépuscule, 1d6 étoiles prélevées réapparaissent sur la robe.\n<br>Tant que vous êtes équipé de cette robe, vous pouvez utiliser une action pour entrer dans le plan Astral avec tout ce que vous portez et transportez. Vous y restez jusqu'à ce que vous utilisiez une action pour retourner dans votre plan de départ. Vous réapparaissez dans le dernier endroit que vous avez quitté, ou si cet espace est occupé, dans l'espace inoccupé le plus proche.\n<br></div>"
+		},
+		{
+			"id": "Robe of Eyes",
+			"name": "Robe aux yeux multiples",
+			"description": "<div class=\"description \">Cette robe est ornée de motifs en forme d'yeux. Tant que vous êtes équipé de cette robe, vous gagnez les bénéfices suivants :\n<br>• La robe vous permet de voir dans toutes les directions, et vous avez un avantage à vos jets de Sagesse (Perception) basés sur la vue.\n<br>• Vous avez la vision dans le noir à 36 mètres.\n<br>• Vous pouvez voir les créatures et objets invisibles, de même que ceux se trouvant dans le plan éthéré, à 36 mètres.\n<br>Les yeux sur la robe ne peuvent être fermés ou détournés. Et même si vous fermez ou détournez vos propres yeux, vous n'êtes jamais considéré comme en train de le faire tant que vous êtes équipé de cette robe.\n<br>Un sort de <em>lumière</em> lancé sur la robe ou de <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lumiere-du-jour\">lumière du jour</a></em> lancé à 1,50 mètre de la robe vous aveugle pendant 1 minute. À la fin de chacun de vos tours, vous pouvez effectuer un jet de sauvegarde de Constitution (DD 11 pour le sort <em>lumière</em> ou DD 15 pour le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=lumiere-du-jour\">lumière du jour</a></em>), mettant à terme à l'aveuglement en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Robe of Useful Items",
+			"name": "Robe d'objets pratiques",
+			"description": "<div class=\"description \">Cette robe est recouverte de pièces de tissu de toutes tailles et de toutes formes. Tant que vous portez cette robe, vous pouvez utiliser une action pour détacher l'un des morceaux de tissu, ce qui le transforme en l'objet ou la créature qu'il représente. Une fois que la dernière pièce est enlevée, la robe devient un vêtement ordinaire.\n<br>La robe possède deux de chacun des morceaux de tissu présentés ci-dessous :\n<br>• Dague\n<br>• Lanterne sourde (éclairée avec réservoir plein)\n<br>• Miroir en acier\n<br>• Perche (3 m)\n<br>• Corde en chanvre enroulée (15 m)\n<br>• Sac\n<br>De plus, la robe possède 4d4 autres pièces de tissu. Le MD choisit les pièces ou les détermine de manière aléatoire.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Pièce de tissu</th></tr><tr><td class=\"center\">01-08</td><td>Un sac contenant 100 po</td></tr><tr><td class=\"center\">09-15</td><td>Un coffret en argent (30 cm de longueur, 15 cm de largeur et de hauteur) d'une valeur de 500 po</td></tr><tr><td class=\"center\">16-22</td><td>Une porte en fer (jusqu'à 3 m de largeur et 3 m de hauteur, barrée du côté du votre choix), que vous pouvez placer dans une ouverture à portée ; elle s'adapte à l'ouverture, se fixant et s'alignant elle-même aux parois</td></tr><tr><td class=\"center\">23-30</td><td>10 pierres précieuses d'une valeur de 100 po chacune</td></tr><tr><td class=\"center\">31-44</td><td>Une échelle en bois (7,2 m)</td></tr><tr><td class=\"center\">45-51</td><td>Un cheval de selle avec des fontes</td></tr><tr><td class=\"center\">52-59</td><td>Une fosse (un cube de 3 mètres de côté), que vous pouvez placer sur le sol dans un rayon de 3 mètres autour de vous</td></tr><tr><td class=\"center\">60-68</td><td>4 potions de soins</td></tr><tr><td class=\"center\">69-75</td><td>Une barque (3,6 m de long)</td></tr><tr><td class=\"center\">76-83</td><td>Un rouleau de parchemin contenant un sort de niveau 1 à 3</td></tr><tr><td class=\"center\">84-90</td><td>2 molosses</td></tr><tr><td class=\"center\">91-96</td><td>Une fenêtre (60 cm x 1,2 m, jusqu'à 60 cm de profondeur), que vous pouvez placer sur une surface verticale que vous pouvez atteindre</td></tr><tr><td class=\"center\">97-00</td><td>Un bélier portatif</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Robe of Scintillating Colors",
+			"name": "Robe de couleurs étincelantes",
+			"description": "<div class=\"description \">Cette robe possède 3 charges, et elle récupère 1d3 charges dépensées chaque jour au lever du soleil. Tant que vous en êtes équipé, vous pouvez utiliser une action et dépenser 1 charge pour que la robe se pare d'une myriade de motifs changeants aux couleurs éblouissantes jusqu'à la fin de votre prochain tour. Pour toute cette durée, la robe émet une lumière vive dans un rayon de 9 mètres et une lumière faible sur 9 mètres supplémentaires. Les créatures qui peuvent vous voir ont un désavantage à leur jet d'attaque effectué contre vous. De plus, toute créature présente dans la zone de lumière vive et qui peut vous voir au moment où le pouvoir de la robe est activé doit réussir un jet de sauvegarde de Sagesse DD 15 sous peine d'être étourdie jusqu'à ce que l'effet prenne fin.\n<br></div>"
+		},
+		{
+			"id": "Robe of the Archmagi",
+			"name": "Robe de l'archimage",
+			"description": "<div class=\"description \">Ce vêtement élégant est brodé dans une étoffe raffinée de couleur blanche, grise, ou noire et ornée de runes d'argent. La couleur de la robe correspond à l'alignement pour lequel cet objet a été conçu. Une robe blanche est faite pour un personnage bon, une robe grise pour un neutre, et une robe noire pour un mauvais. Vous ne pouvez pas vous lier à une <em>robe de l'archimage</em> si votre alignement ne lui correspond pas. Vous gagnez les bénéfices suivants tant que vous êtes équipé de cette robe :\n<br>• Si vous n'êtes pas équipé d'armure, votre Classe d'Armure de base est 15 + votre modificateur de Dextérité.\n<br>• Vous avez un avantage aux jets de sauvegarde effectués contre les sorts et tout autre effet magique.\n<br>• Le DD aux jets de sauvegarde de vos sorts et votre bonus d'attaque avec un sort sont chacun augmentés de 2.\n<br></div>"
+		},
+		{
+			"id": "Robes",
+			"name": "Robes",
+			"description": "<p>Simple ou cérémoniel, souvent utilisé par les prêtres et autres figures religieuses.</p>"
+		},
+		{
+			"id": "Hourglass",
+			"name": "Sablier",
+			"description": "<p>Il s'agit d'un appareil utilisé pour mesurer la psaage du temps. Il est composé de deux ampoules de verre reliées verticalement par un col étroit qui permet un écoulement régulé du sable de l'ampoule supérieure vers l'ampoule inférieure.</p>"
+		},
+		{
+			"id": "Sack",
+			"name": "Sac",
+			"description": "<p>Un sac peut contenir jusqu'à 15 kg de matériel.</span></p>"
+		},
+		{
+			"id": "Backpack",
+			"name": "Sac à dos",
+			"description": "<p>Un sac à dos peut contenir un 30 cm3 ou 15 kg de matériel. Vous pouvez également attacher des objets, tels qu'un duvet ou une corde enroulée, à l'extérieur du sac à dos.</span></p>"
+		},
+		{
+			"id": "Bag of Tricks (Grey)",
+			"name": "Sac à malices (Gris)",
+			"description": "<div class=\"description \">Ce sac ordinaire, fait d'un tissu gris, couleur rouille, ou ocre, semble vide. Cependant, mettre la main dans le sac révèle la présence d'un petit objet poilu. Le sac pèse 250 grammes.\n<br>Vous pouvez utiliser une action pour prendre l'objet poilu du sac et le lancer jusqu'à 6 mètres. Lorsque l'objet touche le sol, il se transforme en une créature déterminée aléatoirement en lançant un d8 et en consultant la table correspondant à la couleur du sac. La créature disparaît à l'aube suivante ou quand elle tombe à 0 point de vie.\n<br>La créature a une attitude amicale envers vous et vos compagnons, et agit pendant votre tour. Vous pouvez utiliser une action bonus pour décider la façon dont la créature se déplacera et quelle action elle utilisera lors de son prochain tour, ou bien pour lui donner des ordres généraux, comme celui d'attaquer vos ennemis. En l'absence de tels ordres, la créature agit d'une manière appropriée à sa nature.\n<br>Une fois que trois objets poilus ont été pris dans le sac, le sac ne peut plus être réutilisé avant le prochain lever de soleil.<br>\n<br><strong>Sac à malices (gris)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Belette</td></tr><tr><td class=\"center\">2</td><td>Rat géant</td></tr><tr><td class=\"center\">3</td><td>Blaireau</td></tr><tr><td class=\"center\">4</td><td>Sanglier</td></tr><tr><td class=\"center\">5</td><td>Panthère</td></tr><tr><td class=\"center\">6</td><td>Blaireau géant</td></tr><tr><td class=\"center\">7</td><td>Loup sanguinaire</td></tr><tr><td class=\"center\">8</td><td>Élan géant</td></tr></tbody></table>\n<br><strong>Sac à malices (rouille)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Rat</td></tr><tr><td class=\"center\">2</td><td>Hibou</td></tr><tr><td class=\"center\">3</td><td>Molosse</td></tr><tr><td class=\"center\">4</td><td>Chèvre</td></tr><tr><td class=\"center\">5</td><td>Chèvre géante</td></tr><tr><td class=\"center\">6</td><td>Sanglier géant</td></tr><tr><td class=\"center\">7</td><td>Lion</td></tr><tr><td class=\"center\">8</td><td>Ours brun</td></tr></tbody></table>\n<br><strong>Sac à malices (ocre)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Chacal</td></tr><tr><td class=\"center\">2</td><td>Singe</td></tr><tr><td class=\"center\">3</td><td>Babouin</td></tr><tr><td class=\"center\">4</td><td>Bec de hache</td></tr><tr><td class=\"center\">5</td><td>Ours noir</td></tr><tr><td class=\"center\">6</td><td>Belette géante</td></tr><tr><td class=\"center\">7</td><td>Hyène géante</td></tr><tr><td class=\"center\">8</td><td>Tigre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Bag of Tricks (Tan)",
+			"name": "Sac à malices (Ocre)",
+			"description": "<div class=\"description \">Ce sac ordinaire, fait d'un tissu gris, couleur rouille, ou ocre, semble vide. Cependant, mettre la main dans le sac révèle la présence d'un petit objet poilu. Le sac pèse 250 grammes.\n<br>Vous pouvez utiliser une action pour prendre l'objet poilu du sac et le lancer jusqu'à 6 mètres. Lorsque l'objet touche le sol, il se transforme en une créature déterminée aléatoirement en lançant un d8 et en consultant la table correspondant à la couleur du sac. La créature disparaît à l'aube suivante ou quand elle tombe à 0 point de vie.\n<br>La créature a une attitude amicale envers vous et vos compagnons, et agit pendant votre tour. Vous pouvez utiliser une action bonus pour décider la façon dont la créature se déplacera et quelle action elle utilisera lors de son prochain tour, ou bien pour lui donner des ordres généraux, comme celui d'attaquer vos ennemis. En l'absence de tels ordres, la créature agit d'une manière appropriée à sa nature.\n<br>Une fois que trois objets poilus ont été pris dans le sac, le sac ne peut plus être réutilisé avant le prochain lever de soleil.<br>\n<br><strong>Sac à malices (gris)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Belette</td></tr><tr><td class=\"center\">2</td><td>Rat géant</td></tr><tr><td class=\"center\">3</td><td>Blaireau</td></tr><tr><td class=\"center\">4</td><td>Sanglier</td></tr><tr><td class=\"center\">5</td><td>Panthère</td></tr><tr><td class=\"center\">6</td><td>Blaireau géant</td></tr><tr><td class=\"center\">7</td><td>Loup sanguinaire</td></tr><tr><td class=\"center\">8</td><td>Élan géant</td></tr></tbody></table>\n<br><strong>Sac à malices (rouille)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Rat</td></tr><tr><td class=\"center\">2</td><td>Hibou</td></tr><tr><td class=\"center\">3</td><td>Molosse</td></tr><tr><td class=\"center\">4</td><td>Chèvre</td></tr><tr><td class=\"center\">5</td><td>Chèvre géante</td></tr><tr><td class=\"center\">6</td><td>Sanglier géant</td></tr><tr><td class=\"center\">7</td><td>Lion</td></tr><tr><td class=\"center\">8</td><td>Ours brun</td></tr></tbody></table>\n<br><strong>Sac à malices (ocre)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Chacal</td></tr><tr><td class=\"center\">2</td><td>Singe</td></tr><tr><td class=\"center\">3</td><td>Babouin</td></tr><tr><td class=\"center\">4</td><td>Bec de hache</td></tr><tr><td class=\"center\">5</td><td>Ours noir</td></tr><tr><td class=\"center\">6</td><td>Belette géante</td></tr><tr><td class=\"center\">7</td><td>Hyène géante</td></tr><tr><td class=\"center\">8</td><td>Tigre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Bag of Tricks (Rust)",
+			"name": "Sac à malices (Rouille)",
+			"description": "<div class=\"description \">Ce sac ordinaire, fait d'un tissu gris, couleur rouille, ou ocre, semble vide. Cependant, mettre la main dans le sac révèle la présence d'un petit objet poilu. Le sac pèse 250 grammes.\n<br>Vous pouvez utiliser une action pour prendre l'objet poilu du sac et le lancer jusqu'à 6 mètres. Lorsque l'objet touche le sol, il se transforme en une créature déterminée aléatoirement en lançant un d8 et en consultant la table correspondant à la couleur du sac. La créature disparaît à l'aube suivante ou quand elle tombe à 0 point de vie.\n<br>La créature a une attitude amicale envers vous et vos compagnons, et agit pendant votre tour. Vous pouvez utiliser une action bonus pour décider la façon dont la créature se déplacera et quelle action elle utilisera lors de son prochain tour, ou bien pour lui donner des ordres généraux, comme celui d'attaquer vos ennemis. En l'absence de tels ordres, la créature agit d'une manière appropriée à sa nature.\n<br>Une fois que trois objets poilus ont été pris dans le sac, le sac ne peut plus être réutilisé avant le prochain lever de soleil.<br>\n<br><strong>Sac à malices (gris)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Belette</td></tr><tr><td class=\"center\">2</td><td>Rat géant</td></tr><tr><td class=\"center\">3</td><td>Blaireau</td></tr><tr><td class=\"center\">4</td><td>Sanglier</td></tr><tr><td class=\"center\">5</td><td>Panthère</td></tr><tr><td class=\"center\">6</td><td>Blaireau géant</td></tr><tr><td class=\"center\">7</td><td>Loup sanguinaire</td></tr><tr><td class=\"center\">8</td><td>Élan géant</td></tr></tbody></table>\n<br><strong>Sac à malices (rouille)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Rat</td></tr><tr><td class=\"center\">2</td><td>Hibou</td></tr><tr><td class=\"center\">3</td><td>Molosse</td></tr><tr><td class=\"center\">4</td><td>Chèvre</td></tr><tr><td class=\"center\">5</td><td>Chèvre géante</td></tr><tr><td class=\"center\">6</td><td>Sanglier géant</td></tr><tr><td class=\"center\">7</td><td>Lion</td></tr><tr><td class=\"center\">8</td><td>Ours brun</td></tr></tbody></table>\n<br><strong>Sac à malices (ocre)</strong>\n<br><table><tbody><tr><th class=\"center\">d8</th><th>Créature</th></tr><tr><td class=\"center\">1</td><td>Chacal</td></tr><tr><td class=\"center\">2</td><td>Singe</td></tr><tr><td class=\"center\">3</td><td>Babouin</td></tr><tr><td class=\"center\">4</td><td>Bec de hache</td></tr><tr><td class=\"center\">5</td><td>Ours noir</td></tr><tr><td class=\"center\">6</td><td>Belette géante</td></tr><tr><td class=\"center\">7</td><td>Hyène géante</td></tr><tr><td class=\"center\">8</td><td>Tigre</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Bedroll",
+			"name": "Sac de couchage",
+			"description": "<p>Utilisé par le voyageur pour dormir.</p>"
+		},
+		{
+			"id": "Bag of Beans",
+			"name": "Sac de haricots",
+			"description": "<div class=\"description \">À l'intérieur de sac en tissu lourd se trouvent 3d4 haricots secs. Le sac pèse 250 grammes + 125 grammes pour chaque haricot qu'il contient.\n<br>Si vous videz le contenu du sac sur le sol, les haricots explosent. Chaque créature présente dans un rayon de 3 mètres autour du point d'impact entre les haricots et le sol doit effectuer un jet de sauvegarde de Dextérité DD 15, subissant 5d4 dégâts de feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Le feu enflamme les objets inflammables qui se trouvent dans la zone et qui ne sont ni portés ni transportés.\n<br>Si vous prélevez un haricot du sac, et le plantez dans la terre ou le sable, puis l'arrosez, le haricot produit un effet une minute plus tard, à l'endroit où vous l'avez planté. Le MD peut choisir l'effet en consultant la table qui suit, le déterminer aléatoirement, ou créer un nouvel effet.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Effet</th></tr><tr><td class=\"center\">01</td><td>5d4 champignons vénéneux poussent. Si une créature mange un champignon vénéneux, lancer n'importe quel dé. Sur un résultat impair, la créature doit réussir un jet de sauvegarde de Constitution DD 15 sous peine de subir 5d6 dégâts de poison et être empoisonnée pendant 1 heure. Sur un résultat pair, la créature gagne 5d6 points de vie temporaires pendant 1 heure.</td></tr><tr><td class=\"center\">02-10</td><td>Un geyser apparaît et fait jaillir de l'eau, de la bière, du jus de baies, du thé, du vinaigre, du vin, ou de l'huile (au choix du MD) jusqu'à 9 mètres dans les airs, pendant 1d12 tours.</td></tr><tr><td class=\"center\">11-20</td><td>Un sylvanien pousse. Il y a 50 % de risque que le sylvanien soit chaotique mauvais et vous attaque.</td></tr><tr><td class=\"center\">21-30</td><td>Une statue de pierre, immobile mais animée, vous ressemblant émerge du sol. Elle vous menace verbalement. Si vous la quittez et que d'autres créatures viennent près d'elle, elle vous décrit comme le plus malfaisant des criminels et envoie les nouveaux arrivants vous trouver et vous attaquer. Si vous vous trouvez sur le même plan d'existence que la statue, elle sait où vous êtes. La statue devient inanimée au bout de 24 heures.</td></tr><tr><td class=\"center\">31-40</td><td>Un feu de camp produisant des flammes bleues jaillit et brûle pendant 24 heures (ou jusqu'à ce qu'il soit éteint).</td></tr><tr><td class=\"center\">41-50</td><td>1d6 + 6 criards poussent.</td></tr><tr><td class=\"center\">51-60</td><td>1d4 + 8 crapauds rose brillant sortent de terre en rampant. Lorsqu'un crapaud est touché, il se transforme en un monstre de taille G ou P que le MD choisit. La monstre reste pendant 1 minute, puis disparaît dans un nuage de fumée rose brillant.</td></tr><tr><td class=\"center\">61-70</td><td>Une bulette affamée creuse jusqu'à la surface et vous attaque.</td></tr><tr><td class=\"center\">71-80</td><td>Un arbre fruitier pousse. Il possède 1d10 + 20 fruits, 1d8 d'entre eux fonctionnent comme des potions magiques déterminées aléatoirement, tandis qu'un autre fonctionne comme un poison à ingestion du choix du MD. L'arbre s'évapore au bout d'une heure. Les fruits cueillis restent, conservant leur magie pendant 30 jours.</td></tr><tr><td class=\"center\">81-90</td><td>Un nid contenant 1d4 + 3 œufs surgit du sol. Toute créature qui mange un œuf doit effectuer un jet de sauvegarde de Constitution DD 20. En cas de jet de sauvegarde réussi, une créature augmente de manière permanente sa valeur de caractéristique la plus faible de 1, choisie de manière aléatoire dans le cas ou plusieurs valeurs seraient égales. En cas d'échec au jet, la créature subit 10d6 dégâts de force à cause d'une explosion magique interne.</td></tr><tr><td class=\"center\">91-99</td><td>Une pyramide à base carré de 18 mètres de côté jaillit du sol. À l'intérieur se trouve un sarcophage abritant un seigneur momie. La pyramide est traitée comme le repaire du seigneur momie, et son sarcophage contient un trésor du choix du MD.</td></tr><tr><td class=\"center\">00</td><td>Une tige de haricot géant pousse jusqu'à atteindre une hauteur déterminée par le MD. Le sommet atteint ce que le MD choisit, comme un simple mais beau panorama, la forteresse d'un géant des nuages, ou un autre plan d'existence.</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Bag of Sand",
+			"name": "Sac de Sable",
+			"description": "<p>Un petit sac de sable utilisé par l'érudit pour sécher rapidement et en toute sécurité les lettres et la correspondance fraîchement encrées pour un envoi rapide.</p>"
+		},
+		{
+			"id": "Bag of Devouring",
+			"name": "Sac Dévoreur",
+			"description": "<p>Si on l'examine superficiellement, ce sac ressemble à un sac sans fond, mais c'est en réalité un orifice par lequel s'alimente une gigantesque créature extradimensionnelle. Si on retourne le fond du sac, l'orifice se ferme.La créature extradimensionnelle liée au sac peut sentir tout ce qui est placé dedans. Les matières animales et végétales qui sont déposées complètement dans le sac sont perdues à jamais. Lorsqu'une partie seulement d'une créature est mise dans le sac, comme cela arrive lorsqu'un personnage cherche à récupérer quelque chose à l'intérieur, il y a 50 % de chance que la créature soit aspirée à l'intérieur du sac. Une créature à l'intérieur du sac peut utiliser son action pour tenter de s'échapper en réussissant un jet de Force DD 15. Une autre créature peut utiliser son action pour glisser son bras dans le sac et en ressortir la créature avalée en réussissant un jet de sauvegarde de Force DD 20 (à condition qu'elle ne soit pas avalée avant). Toute créature qui débute son tour à l'intérieur du sac est dévorée, son corps est détruit.Les objets inanimés peuvent être stockés dans le sac, qui peut en contenir un volume cubique total de 30 centimètres d'arête. Toutefois, une fois par jour, le sac mâchouille tous les objets qu'il contient et les envoie dans un autre plan d'existence. Le MD détermine le moment de la journée et le plan d'existence.Si le sac est percé ou déchiré, il est détruit, et tout ce qu'il contenait est envoyé dans un lieu aléatoire du plan Astral.</p>"
+		},
+		{
+			"id": "Bag of Holding",
+			"name": "Sac sans fond",
+			"description": "<div class=\"description \">Ce sac de toile a un espace intérieur beaucoup plus grand que ses dimensions extérieures, environ 60 cm de diamètre à l'ouverture et 1,20 m de profondeur. Le sac peut contenir jusqu'à 250 kilos, tout en ne dépassant pas un volume de 1,20 m x 1,20 m x 1,20 m. Le sac pèse 7,5 kilos, indépendamment de son contenu. Récupérer un élément du sac demande une action.\n<br>Si le sac est surchargé, percé ou déchiré, il se rompt et est détruit, et son contenu est dispersé sur le plan Astral. Si le sac est retourné, son contenu se déverse, en bon état, mais le sac doit être remis à l'endroit pour pouvoir être utilisé à nouveau. Si des créatures qui respirent sont placées dans le sac, elles ne peuvent survivre qu'un nombre de minutes égal à 10 minutes divisé par le nombre de créatures (minimum 1 minute), après quoi elles commencent à suffoquer.\n<br>Placer un <em>sac sans fond</em> dans un espace extradimensionnel créé par un <em>havresac magique d'Hévard</em>, un <em><a href=\"https://www.aidedd.org/dnd/om.php?vf=puits-portatif\">puits portatif</a></em> ou un objet similaire, détruit instantanément les deux objets et ouvre un portail sur le plan Astral. Le portail s'ouvre là où le premier objet a été placé à l'intérieur de l'autre. Toute créature dans un rayon de 3 mètres autour du portail est aspirée par celle-ci et se retrouve à un endroit aléatoire sur le plan Astral. Puis le portail se referme. Celui-ci est à sens unique et ne peut pas être réouvert.\n<br></div>"
+		},
+		{
+			"id": "Pouch",
+			"name": "Sacoche",
+			"description": "<p>Une sacoche en tissu ou en cuir peut contenir jusqu'à 20 billes de fronde ou 50 aiguilles de sarbacane, entre autres choses. Une sacoche compartimentée pour abriter des composantes de sorts est appelée une sacoche à composantes (voir la description ci-dessous).</span></p>"
+		},
+		{
+			"id": "Component Pouch",
+			"name": "Sacoche à composantes",
+			"description": "<p>Une sacoche à composantes est une petite sacoche étanche en cuir qui possède des compartiments pour contenir toutes les composantes matérielles et autres éléments spéciaux dont vous avez besoin pour lancer vos sorts, à l'exception des composantes qui ont un coût spécifique (comme indiqué dans la description des sorts).</span></p>"
+		},
+		{
+			"id": "Saddlebags",
+			"name": "Fontes",
+			"description": "<p>Un ensemble de récipients qui se présentent généralement sous la forme d'une paire, reliés par une lanière de cuir et fixés à la selle d'une monture.</p>"
+		},	
+		{
+			"id": "Blowgun",
+			"name": "Sarbacane",
+			"description": "<p>Une arme primitive, mais mortelle, utilisée par les tribues et les guérilleros. L'aiguille tirée par cette arme peut délivrer une dose léthale de poison.</p>"
+		},
+		{
+			"id": "Blowgun +1",
+			"name": "Sarbacane +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Blowgun +2",
+			"name": "Sarbacane +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Blowgun +3",
+			"name": "Sarbacane +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Blowgun",
+			"name": "Sarbacane vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Soap",
+			"name": "Savon",
+			"description": "<p>Utilisé pour nettoyer et laver.</p>"
+		},
+		{
+			"id": "Scarab of Protection",
+			"name": "Scarabée de protection",
+			"description": "<div class=\"description \">Si vous tenez ce médaillon en forme de coléoptère dans votre main pendant 1 tour complet, une inscription apparaît à sa surface, révélant sa nature magique. Il confère deux avantages tant que vous en êtes équipé :\n<br>• Vous avez un avantage aux jets de sauvegarde effectués contre les sorts.\n<br>• Le scarabée possède 12 charges. Si vous échouez un jet de sauvegarde contre un sort de nécromancie ou un effet néfaste provenant d'une créature morte-vivante, vous pouvez utiliser votre réaction pour dépenser 1 charge et ainsi convertir cet échec en réussite. Le scarabée tombe en miettes et est détruit lorsque toutes ses charges sont dépensées.\n<br></div>"
+		},
+		{
+			"id": "Rod",
+			"name": "Sceptre",
+			"description": "<p>Une tige d'os, de pierre, de métal ou de matériaux plus exotiques, taillée ou façonnée de façon complexe. Focaliseur arcanique. Un focaliseur arcanique est un objet spécial (orbe, boule de cristal, baguette, bâton, sceptre) conçu pour canaliser la puissance de sorts de la magie des arcanes. Un ensorceleur, un sorcier ou un magicien peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Rod of Absorption",
+			"name": "Sceptre d'absorption",
+			"description": "<div class=\"description \">Lorsque vous tenez ce sceptre, vous pouvez utiliser votre réaction pour absorber un sort qui vous cible exclusivement, et sans zone d'effet. L'effet du sort absorbé est annulé, et son énergie (mais pas le sort en lui-même) est stockée dans le sceptre. L'énergie a le niveau du sort qui a été lancé. Le sceptre peut absorber jusqu'à 50 niveaux d'énergie au cours de sa vie. Lorsqu'il atteint ces 50 niveaux, il ne peut plus absorber d'énergie. Si vous êtes visé par un sort et que le sceptre ne peut plus absorber, le sceptre n'a aucun effet sur le sort.\n<br>Lorsque vous vous liez avec le sceptre, vous savez combien de niveaux il a déjà absorbé au cours de son existence, et combien de niveaux d'énergie il contient actuellement.\n<br>Si vous êtes un lanceur de sorts et que vous tenez le sceptre, vous pouvez convertir l'énergie stockée en emplacements de sorts pour lancer des sorts préparés ou connus. Vous pouvez créer des emplacements de sorts d'un niveau égal ou inférieur à vos propres emplacements, jusqu'à un niveau maximum de 5. Vous utilisez les niveaux stockés à la place de vos emplacements, mais sinon le sort est lancé normalement. Par exemple, vous pouvez utiliser 3 niveaux stockés dans le sceptre comme un emplacement de sort de niveau 3.\n<br>Un sceptre trouvé contient 1d10 niveaux d'énergie stockés. Un sceptre qui ne peut plus absorber d'énergie et qui n'a plus d'énergie stockés devient non magique.\n<br></div>"
+		},
+		{
+			"id": "Rod of Lordly Might",
+			"name": "Sceptre de puissance seigneuriale",
+			"description": "<div class=\"description \">Ce sceptre possède une bride à sa tête, et fonctionne comme une masse d'armes magique qui confère un bonus de +3 aux jets d'attaque et de dégâts effectués avec elle. Le sceptre possède des capacités associées à six boutons différents alignés le long de la hampe. Il possède également trois autres propriétés qui sont détaillées plus bas.\n<br><strong>Les six boutons</strong>. Vous pouvez appuyer sur l'un des six boutons du sceptre en utilisant une action bonus. L'effet d'un bouton dure jusqu'à ce que vous pressiez un autre bouton ou jusqu'à ce que vous appuyiez de nouveau sur le même bouton, ce qui a pour effet de rendre sa forme normale au sceptre.\n<br>Si vous pressez le <strong>bouton 1</strong>, une lame enflammée jaillit de l'extrémité opposée à la lanière, le sceptre devient une <em><a href=\"https://www.aidedd.org/dnd/om.php?vf=epee-ardente\">épée ardente</a></em> (vous choisissez le type d'épée).\n<br>Si vous pressez le <strong>bouton 2</strong>, l'extrémité du sceptre comportant une lanière se replie et deux lames en forme de croissant apparaissent, transformant le sceptre en une hache d'armes magique qui confère un bonus de +3 aux jets d'attaque et de dégâts effectués avec elle.\n<br>Si vous pressez le <strong>bouton 3</strong>, l'extrémité du sceptre comportant une lanière se replie et la pointe d'une lance en jaillit, de plus la taille du sceptre augmente jusqu'à atteindre 1,95 mètre, transformant le sceptre en une lance magique qui confère un bonus de +3 aux jets d'attaque et de dégâts effectués avec elle.\n<br>Si vous pressez le <strong>bouton 4</strong>, le sceptre se transforme en une perche de la longueur de votre choix, 15 mètres maximum. Sur des surfaces aussi dures que du granit, une pointe à l'extrémité inférieure et trois crochets à l'extrémité supérieure permettent à la perche d'être fixée. Des barreaux horizontaux espacés de 30 centimètres chacun et de 7,50 centimètres de long se déplient sur les côtés, formant une échelle. La perche peut supporter un poids total de 2 000 kilos. Un poids plus important, ou l'absence d'un ancrage solide, obligent le sceptre à retrouver sa forme normale.\n<br>Si vous pressez le <strong>bouton 5</strong>, le sceptre se transforme en un bélier de poche et confère à son utilisateur un bonus de +10 aux jets de Force effectués pour défoncer les portes, les barricades, et toute autre barrière.\n<br>Si vous pressez le <strong>bouton 6</strong>, le sceptre retrouve, ou conserve, sa forme normale et indique le nord magnétique (rien ne se produit si cette fonction est utilisée dans un lieu qui ne possède pas de nord magnétique). Le sceptre vous apprend également votre profondeur ou votre altitude par rapport à la surface du sol.\n<br><strong>Drain de vie</strong>. Lorsque vous frappez une créature avec une attaque au corps à corps en utilisant le sceptre, vous pouvez obliger la cible à effectuer un jet de sauvegarde de Constitution DD 17. En cas d'échec, la cible subit 4d6 points de dégâts nécrotiques supplémentaires, et vous récupérez un nombre de points de vie égal à la moitié de ces dégâts nécrotiques. Cette propriété ne peut être réutilisée avant le prochain lever de soleil.\n<br><strong>Paralyser</strong>. Lorsque vous touchez une créature avec une attaque au corps à corps utilisant le sceptre, vous pouvez forcer la cible à effectuer un jet de sauvegarde de Force DD 17. En cas d'échec, la cible est paralysée pendant 1 minute. La cible peut retenter son jet de sauvegarde à la fin de chacun de ses tours, mettant un terme à cet effet en cas de réussite. Cette propriété ne peut être réutilisée avant le prochain lever de soleil.\n<br><strong>Terrifier</strong>. Lorsque vous tenez le sceptre, vous pouvez utiliser une action pour forcer chaque créature que vous pouvez voir et se trouvant dans un rayon de 9 mètres autour de vous à effectuer un jet de sauvegarde de Sagesse DD 17. En cas d'échec, vous effrayez la cible pendant 1 minute. Une cible effrayée peut retenter son jet de sauvegarde à la fin de chacun de ses tours, mettant un terme à l'effet qui l'affecte en cas de réussite. Cette propriété ne peut être réutilisée avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Rod of Security",
+			"name": "Sceptre de sécurité",
+			"description": "<div class=\"description \">Tant que vous tenez ce sceptre, vous pouvez utiliser une action pour l'activer. Le sceptre vous transporte alors instantanément, vous et jusqu'à 199 autres créatures consentantes que vous pouvez voir, dans un paradis situé dans un espace extraplanaire. Vous choisissez la forme que ce paradis prend. Ce peut être un jardin tranquille, une charmante petite clairière, une joyeuse taverne, un immense palace, une île tropicale, un carnaval fantastique, ou tout autre lieu de votre imagination. Quelle que soit sa nature, le paradis contient suffisant d'eau et de nourriture pour sustenter ses visiteurs. Sinon, tout ce avec quoi les visiteurs peuvent interagir n'existe que dans cet espace extraplanaire. Par exemple, une fleur cueillie dans un jardin du paradis disparaît si elle est sortie de cet espace extraplanaire.\n<br>Pour chaque heure passée dans le paradis, un visiteur récupère autant de points de vie que s'il avait dépensé 1 dé de vie. De plus, les créatures ne vieillissent pas tant qu'elles se trouvent dans le paradis bien que le temps s'y écoule normalement. Les visiteurs peuvent rester dans le paradis pour un maximum de 200 jours divisé par le nombre de créatures présentes (arrondi à l'entier inférieur).\n<br>Lorsque toute la durée s'est écoulée, ou si vous avez utilisé une action pour mettre fin au paradis, tous les visiteurs réapparaissent dans l'endroit qu'ils ont quitté lorsque vous avez activé le sceptre, ou dans l'espace inoccupé le plus proche de cet endroit. Le sceptre ne peut être réutilisé avant que 10 jours ne se soient écoulés.\n<br></div>"
+		},
+		{
+			"id": "Rod of Rulership",
+			"name": "Sceptre de suzeraineté",
+			"description": "<div class=\"description \">Vous pouvez utiliser une action pour brandir le sceptre et imposer l'obéissance à toutes les créatures de votre choix que vous pouvez voir et se trouvant dans un rayon de 36 mètres autour de vous. Chaque créature doit réussir un jet de sauvegarde de Sagesse DD 15 sous peine d'être charmée pendant 8 heures. Tant que vous la charmez de la sorte, la créature vous considère comme son chef en qui elle peut avoir toute confiance. Si vous ou l'un de vos compagnons faites du tort à la cible, ou si vous ordonnez à la cible de faire quelque chose contre sa nature, elle cesse d'être charmée par ce sceptre. Le sceptre ne peut être réutilisé avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Rod of Alertness",
+			"name": "Sceptre de vigilance",
+			"description": "<div class=\"description \">Ce sceptre possède une lanière à l'une de ses extrémités et les propriétés suivantes.\n<br><strong>Vigilance</strong>. Tant que vous tenez le sceptre, vous avez un avantage à vos jets de Sagesse (Perception) et vos jets d'initiative.\n<br><strong>Sorts</strong>. Tant que vous tenez le sceptre, vous pouvez l'utiliser, par une action, pour lancer l'un des sorts suivants : <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-du-mal-et-du-bien\">détection du mal et du bien</a>, <a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-de-la-magie\">détection de la magie</a>, <a href=\"https://www.aidedd.org/dnd/sorts.php?vf=detection-du-poison-et-des-maladies\">détection du poison et des maladies</a></em> ou <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=voir-l-invisible\">voir l'invisible</a></em>.\n<br><strong>Aura protectrice</strong>. Par une action, vous pouvez planter le manche du sceptre dans le sol, après quoi la tête du sceptre se met à briller d'une lumière vive dans un rayon de 18 mètres et d'une lumière faible dans un rayon supplémentaire de 18 mètres. Tant que vous vous trouvez dans la zone de lumière vive, vous, et toutes les créatures qui vous sont amicales, gagnez un bonus de +1 à la CA et aux jets de sauvegarde et pouvez percevoir la localisation de toute créature hostile invisible qui se trouve dans la lumière vive et dans la lumière faible.\n<br>La tête du sceptre cesse de luire et l'effet prend fin au bout de 10 minutes, ou lorsqu'une créature utilise une action pour sortir le sceptre du sol.\n<br>Cette propriété ne peut être réutilisée avant le prochain lever de soleil.\n<br></div>"
+		},
+		{
+			"id": "Immovable Rod",
+			"name": "Sceptre inamovible",
+			"description": "<div class=\"description \">Ce sceptre plat en fer possède un bouton à une extrémité. Vous pouvez utiliser une action pour appuyer sur le bouton, ce qui fixe magiquement le sceptre sur place. Jusqu'à ce que vous ou une autre créature n'utilisiez une action pour appuyer de nouveau le bouton, le sceptre ne bouge pas, même si cela défie la gravité. Le sceptre peut retenir jusqu'à 4000 kilos. Plus de poids désactive le sceptre et le fait tomber. Une créature peut utiliser une action pour réaliser un jet de Force DD 30, lui permettant de déplacer le sceptre de 3 mètres en cas de réussite.\n<br></div>"
+		},
+		{
+			"id": "Bucket",
+			"name": "Seau",
+			"description": "<p>A bucket holds 3 gallons of liquid or ½ cubic foot of solids.</span></p>"
+		},
+		{
+			"id": "Sickle",
+			"name": "Serpe",
+			"description": "<p>Une lame en croissant montée sur un court manche, assez légère pour être maniée d'une seule main afin de trancher les cultures ... ou les ennemis.</p>"
+		},
+		{
+			"id": "Sickle +1",
+			"name": "Serpe +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Sickle +2",
+			"name": "Serpe +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Sickle +3",
+			"name": "Serpe +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Vicious Sickle",
+			"name": "Serpe vicieuse",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Signal Whistle",
+			"name": "Sifflet",
+			"description": "<p>Un sifflet peut produire un bruit spécifique. Il peut être entendu à un kilomètre et demi de distance.</p>"
+		},
+		{
+			"id": "Sling Bullet",
+			"name": "Billes de fronde",
+			"description": "<p>Caillou durci de pierre, d'os ou de métal qui peut être lancé à grande vitesse à l'aide d'une fronde.</p>\n<p><em>**Note de Foundry: Il sera généralement impossible d'acheter une balle de fronde car elles valent moins d'une pièce de cuivre (5 balles = 1 cp).</em></p>"
+		},
+		{
+			"id": "Universal Solvent",
+			"name": "Solvant universel",
+			"description": "<div class=\"description \">Ce tube contient un liquide laiteux qui dégage une forte odeur d'alcool. Vous pouvez utiliser une action pour verser le contenu du tube sur une surface à portée. Le liquide dissout instantanément les adhésifs qu'il touche, dont de la colle universelle, sur une surface carrée de 30 centimètres de côté maximum.\n<br></div>"
+		},
+		{
+			"id": "Spell Scroll Cantrip",
+			"name": "Spell Scroll Cantrip",
+			"description": "<p>A spell scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without providing any material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</p>\n<p>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make a DC 10 ability check using your spellcasting ability to determine whether you cast it successfully. On a failed check, the spell disappears from the scroll with no other effect.</p>\n<p>The level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity.</p>\n<p><strong>Save DC</strong>: 13<br><strong>Attack Bonus</strong>: +5.</p>"
+		},
+		{
+			"id": "Sphere of Annihilation",
+			"name": "Sphère d'annihilation",
+			"description": "<div class=\"description \">Cette sphère noire de 60 centimètres de diamètre est un trou dans le multivers. Elle lévite sur place et est stabilisée par un champ magique qui l'entoure. Cette sphère efface l'existence de toutes les matières qu'elle traverse et qui la traversent. Les artéfacts en sont l'exception. À moins qu'un artéfact soit susceptible d'endommager la sphère d'annihilation, il peut passer au travers sans qu'elle ne l'affecte. Si quoi que ce soit d'autre touche la sphère sans y être complètement englouti et effacé subit 4d10 dégâts de force.\n<br>La sphère reste stationnaire jusqu'à ce que quelqu'un en prenne le contrôle. Si vous vous trouvez à 18 mètres d'une sphère non contrôlée, vous pouvez utiliser une action pour effectuer un jet d'Intelligence (Arcanes) DD 25. En cas de réussite, la sphère lévite dans une direction de votre choix, sur une distance maximale en mètre de 1,50 x votre modificateur d'Intelligence (minimum 1,50 mètre). En cas d'échec, la sphère se déplace de 3 mètres dans votre direction. Une créature dont l'espace est pénétré par la sphère doit réussir un jet de sauvegarde de Dextérité DD 13 sous peine d'être touchée par la sphère et de subir 4d10 dégâts de force.\n<br>Si vous tentez de contrôler une sphère qui se trouve sous le contrôle d'une autre créature, vous devez effectuer un jet d'Intelligence (Arcanes) contre un jet d'Intelligence (Arcanes) de l'autre créature. Le vainqueur de cette opposition prend le contrôle de la sphère et peut la faire léviter normalement.\n<br>Si la sphère entre en contact avec un portail planaire, comme celui créé par le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=portail\">portail</a></em>, ou un espace extradimensionnel, comme celui d'un <em><a href=\"https://www.aidedd.org/dnd/om.php?vf=puits-portatif\">puits portatif</a></em>, le MD détermine de manière aléatoire ce qui se produit, en utilisant la table suivante.\n<br><table><tbody><tr><th>d100</th><th>Résultat</th></tr><tr><td class=\"center\">01-50</td><td>La sphère est détruite.</td></tr><tr><td class=\"center\">51-85</td><td>La sphère passe au travers du portail ou arrive dans l'espace extradimensionnel.</td></tr><tr><td class=\"center\">86-00</td><td>Une fissure spatiale envoie chaque créature et chaque objet se trouvant dans un rayon de 54 mètres autour de la sphère, y compris la sphère, dans un plan d'existence aléatoire.</td></tr></tbody></table>\n<br></div>"
+		},
+		{
+			"id": "Apparatus of the Crab",
+			"name": "Submersible de Kwalish",
+			"description": "<div class=\"description\">Cet objet apparait d'abord comme un grand baril de fer étanche pesant 250 kilos. Le baril a un loquet caché qui peut être trouvé sur un jet d'Intelligence (Investigation) DD 20 réussi. Relâcher le loquet déverrouille une trappe à une extrémité du fût, permettant à deux créatures de taille M ou inférieure de ramper à l'intérieur. Dix leviers sont alignés à l'autre extrémité, chacun dans une position neutre et pouvant être actionné vers le haut ou vers le bas. Quand certains leviers sont utilisés, l'appareil se transforme pour ressembler à un homard géant.<br>Le submersible de Kwalish est un objet de taille G avec les caractéristiques suivantes :<br><strong>Classe d'Armure</strong> : 20<br><strong>pv</strong> : 200<br><strong>Vitesse</strong> : 9 m, nage 9 m (ou 0 m si les jambes et la queue ne sont pas déployées)<br><strong>Immunité aux dégâts</strong> : poison, psychique<br>Pour être utilisé comme un véhicule, l'appareil nécessite un pilote. Lorsque la trappe est fermée, le compartiment est étanche à l'air et à l'eau. Il contient suffisamment d'air pour 10 heures de respiration, divisées entre les respirations des créatures embarquées.<br>L'appareil flotte sur l'eau, peut plonger jusqu'à une profondeur de 270 mètres. En dessous de cette profondeur, le véhicule subit 2d6 dégâts contondants par minute en raison de la pression.<br>Une créature dans le compartiment peut utiliser une action pour actionner un maximum de 2 leviers de l'appareil, vers le haut ou vers le bas. Après chaque utilisation, les leviers reviennent en position neutre. Chaque levier, de gauche à droite, fonctionne comme indiqué dans la table ci-dessous.<br><table><tbody><tr><th>Levier</th><th>Haut</th><th>Bas</th></tr><tr><td class=\"center\">1</td><td>Les jambes et la queue se déploient, permettant de marcher et de nager.</td><td>Les jambes et la queue se rétractent, réduisant la vitesse à 0 et rendant inefficace les bonus de vitesse.</td></tr><tr><td class=\"center\">2</td><td>Le volet des fenêtres avant s'ouvre.</td><td>Le volet des fenêtres avant se ferme.</td></tr><tr><td class=\"center\">3</td><td>Les volets des fenêtres latérales s'ouvrent (2 par côté).</td><td>Les volets des fenêtres latérales se ferment (2 par côté).</td></tr><tr><td class=\"center\">4</td><td>Deux pinces se déploient de chaque côté de la face de l'appareil.</td><td>Les pinces se rétractent.</td></tr><tr><td class=\"center\">5</td><td>Chaque pince déployée effectue l'attaque au corps à corps suivante : +8 à l'attaque, allonge 1,50 m, une cible. Dégâts : 7 (2d6) contondant.</td><td>Chaque pince déployée effectue l'attaque au corps à corps suivante : +8 à l'attaque, allonge 1,50 m, une cible. La cible est agrippée (DD 15 pour s'échapper).</td></tr><tr><td class=\"center\">6</td><td>L'appareil marche ou nage vers l'avant.</td><td>L'appareil marche ou nage vers l'arrière.</td></tr><tr><td class=\"center\">7</td><td>L'appareil tourne à gauche de 90 degrés.</td><td>L'appareil tourne à droite de 90 degrés.</td></tr><tr><td class=\"center\">8</td><td>Des luminaires en forme d'yeux émettent une lumière vive jusqu'à 9 mètres et une lumière faible sur 9 mètres supplémentaires.</td><td>La lumière s'éteint.</td></tr><tr><td class=\"center\">9</td><td>L'appareil plonge jusqu'à 6 mètres dans un liquide.</td><td>L'appareil remonte jusqu'à 6 mètres dans un liquide.</td></tr><tr><td class=\"center\">10</td><td>La trappe arrière se descelle et s'ouvre.</td><td>La trappe arrière se ferme et se scelle.</td></tr></tbody></table><br></div>"
+		},
+		{
+			"id": "Talisman of the Sphere",
+			"name": "Talisman de la sphère",
+			"description": "<div class=\"description \">Lorsque vous effectuez un jet d'Intelligence (Arcanes) pour contrôler une <em><a href=\"https://www.aidedd.org/dnd/om.php?vf=sphere-d-annihilation\">sphère d'annihilation</a></em> alors que vous tenez ce talisman, vous doublez votre bonus de maîtrise pour le jet. En outre, lorsque vous démarrez votre tour en contrôlant une <em>sphère d'annihilation</em>, vous pouvez utiliser une action pour la faire léviter de 3 mètres plus un nombre de mètres supplémentaires égal à 3 x votre modificateur d'Intelligence.\n<br></div>"
+		},
+		{
+			"id": "Talisman of Pure Good",
+			"name": "Talisman du bien ultime",
+			"description": "<div class=\"description \">Ce talisman est un majestueux symbole de bonté. Une créature qui n'est ni d'alignement bon ni d'alignement mauvais subit 6d6 dégâts radiants en touchant le talisman. Une créature mauvaise subit 8d6 dégâts radiants en touchant le talisman. Chacune de ces catégories de créatures subit de nouveau ces dégâts chaque fois qu'elle termine son tour en tenant ou transportant le talisman.\n<br>Si vous êtes un clerc bon ou un paladin bon, vous pouvez utiliser le talisman comme symbole sacré, et vous bénéficiez d'un bonus de +2 à vos jets d'attaque avec un sort tant que vous tenez ou êtes équipé du talisman.\n<br>Le talisman possède 7 charges. Si vous le tenez ou en êtes équipé, vous pouvez utiliser une action pour dépenser une charge du talisman et choisir l'une des créatures sur le sol, que vous pouvez voir et dans un rayon de 36 mètres autour de vous. Si la cible est d'alignement mauvais, une crevasse embrasée s'ouvre sous ses pieds. La cible doit réussir un jet de sauvegarde de Sagesse DD 20 sous peine de tomber dans la crevasse et être détruite sans rien laisser derrière elle. Après cela la fissure se referme, ne laissant aucune trace de son existence. Lorsque vous dépensez la dernière charge, le talisman se disperse en une multitude de grains de lumière dorée et est détruit.\n<br></div>"
+		},
+		{
+			"id": "Talisman of Ultimate Evil",
+			"name": "Talisman du mal ultime",
+			"description": "<div class=\"description \">Cet objet symbolise le Mal impénitent. Une créature qui n'est ni d'alignement bon ni d'alignement mauvais subit 6d6 dégâts nécrotiques en touchant le talisman. Une créature bonne subit 8d6 dégâts nécrotiques en touchant le talisman. Chacune de ces catégories de créatures subit de nouveau ces dégâts chaque fois qu'elle termine son tour en tenant ou transportant le talisman.\n<br>Si vous êtes un clerc mauvais ou un paladin mauvais, vous pouvez utiliser le talisman comme symbole sacré, et vous bénéficiez d'un bonus de +2 à vos jets d'attaque avec un sort tant que vous tenez ou êtes équipé du talisman.\n<br>Le talisman possède 6 charges. Si vous le tenez ou en êtes équipé, vous pouvez utiliser une action pour dépenser une charge du talisman et choisir l'une des créatures sur le sol, que vous pouvez voir et dans un rayon de 36 mètres autour de vous. Si la cible est d'alignement bon, une crevasse embrasée s'ouvre sous ses pieds. La cible doit réussir un jet de sauvegarde de Sagesse DD 20 sous peine de tomber dans la crevasse et être détruite sans rien laisser derrière elle. Après cela la fissure se referme, ne laissant aucune trace de son existence. Lorsque vous dépensez la dernière charge, le talisman se dissout en un limon nauséabond et est détruit.\n<br></div>"
+		},
+		{
+			"id": "Drum",
+			"name": "Tambour",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Carpet of Flying",
+			"name": "Tapis volant",
+			"description": "<div class=\"description \">Vous pouvez prononcer le mot de commande du tapis en utilisant votre action pour qu'il se mette à léviter et voler. Il se déplace dans la direction que vous lui annoncez, à condition que vous vous trouviez à 9 mètres ou moins de lui.\n<br>Quatre dimensions de tapis volant existent. Le MD choisit la taille du tapis concerné ou la détermine aléatoirement.\n<br><table><tbody><tr><th class=\"center\">d100</th><th>Dimension</th><th>Capacité</th><th>Vitesse<br>de vol</th></tr><tr><td class=\"center\">01-20</td><td>0,90 m x 1,50 m</td><td>100 kilos</td><td>24 mètres</td></tr><tr><td class=\"center\">21-55</td><td>1,20 m x 1,80 m</td><td>200 kilos</td><td>18 mètres</td></tr><tr><td class=\"center\">56-80</td><td>1,50 m x 2,10 m</td><td>300 kilos</td><td>12 mètres</td></tr><tr><td class=\"center\">81-100</td><td>1,80 m x 2,70 m</td><td>400 kilos</td><td>9 mètres</td></tr></tbody></table>\n<br>Un tapis peut porter jusqu'à deux fois le poids indiqué sur la table ci-dessus, cependant sa vitesse de vol est divisée par deux si sa charge dépasse sa capacité normale.\n<br></div>"
+		},
+		{
+			"id": "Two-Person Tent",
+			"name": "Tente 2 personnes",
+			"description": "<p>Abri de toile simple et portable, une tente peut accueillir deux personnes.</p>"
+		},
+		{
+			"id": "Barrel",
+			"name": "Tonneau",
+			"description": "<p>Un baril peut contenir 150 litres de liquide.</span></p>"
+		},
+		{
+			"id": "Torch",
+			"name": "Torche",
+			"description": "<p>Une torche brûle pendant 1 heure, projetant une lumière vive dans un rayon de 6 mètres et une lumière faible sur 6 mètres supplémentaires. Si vous effectuez une attaque au corps à corps avec une torche enflammée et touchez, vous infligez 1 point de dégât de feu.</span></p>"
+		},
+		{
+			"id": "Totem",
+			"name": "Totem",
+			"description": "<p>Un totem incorporant des plumes, de la fourrure, des os et des dents d'un animal sacré pour l'utilisateur. Ceux qui répondent à l'appel de la nature sont capables de l'exploiter pour faire appel à l'incroyable puissance de la nature. Focaliseur druidique. Un focaliseur druidique peut être un brin de gui ou de houx, une baguette ou un sceptre en bois d'if ou autre bois spécial, un bâton pris d'un arbre vivant, ou bien encore un objet totem qui intègre des plumes, de la fourrure, des os ou des dents d'animaux sacrés. Un druide peut utiliser ce type d'objet comme focaliseur pour ses sorts.</p>"
+		},
+		{
+			"id": "Tome of Leadership and Influence",
+			"name": "Traité d'autorité et d'influence",
+			"description": "<div class=\"description \">Ce livre contient des conseils pour influencer et charmer les autres, et ses mots sont chargés de magie. Si vous passez 48 heures sur une période de 6 jours ou moins à étudier le contenu du livre et pratiquez ses lignes directrices, votre Charisme augmente de 2, tout comme votre maximum pour cette caractéristique. Le manuel perd alors sa magie, mais la retrouvera dans un siècle.\n<br></div>"
+		},
+		{
+			"id": "Tome of Understanding",
+			"name": "Traité de compréhension",
+			"description": "<div class=\"description \">Ce livre contient des exercices d'intuition et de perspicacité, et ses mots sont chargés de magie. Si vous passez 48 heures sur une période de 6 jours ou moins à étudier le contenu du livre et pratiquez ses lignes directrices, votre Sagesse augmente de 2, tout comme votre maximum pour cette caractéristique. Le manuel perd alors sa magie, mais la retrouvera dans un siècle.\n<br></div>"
+		},
+		{
+			"id": "Tome of Clear Thought",
+			"name": "Traité de perspicacité",
+			"description": "<div class=\"description \">Ce livre contient des exercices de mémoire et de logique, et ses mots sont chargés de magie. Si vous passez 48 heures sur une période de 6 jours ou moins à étudier le contenu du livre et pratiquez ses lignes directrices, votre Intelligence augmente de 2, tout comme votre maximum pour cette caractéristique. Le manuel perd alors sa magie, mais la retrouvera dans un siècle.\n<br></div>"
+		},
+		{
+			"id": "Trident",
+			"name": "Trident",
+			"description": "<p>Une lance à plusieurs dents conçue pour empaler une cible à plusieurs endroits, en les immobilisant. Souvent utilisée en combinaison avec un filet pour piéger et harceler les ennemis.</p>"
+		},
+		{
+			"id": "Trident +1",
+			"name": "Trident +1",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Trident +2",
+			"name": "Trident +2",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +2 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Trident +3",
+			"name": "Trident +3",
+			"description": "<p><em>Par le biais d'un enchantement démoniaque, d'un leg céleste, d'une expérience folle, ou d'une facrication exceptionnelle, cette arme a été enchanté pour que son porteur fasse couler plus de sang.</em></p>\n<p>Vous bénéficiez d'un bonus de +3 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+		},
+		{
+			"id": "Trident of Fish Command",
+			"name": "Trident de domination des poissons",
+			"description": "<div class=\"description \">Ce trident est une arme magique. Il dispose de 3 charges. Si vous le tenez, vous pouvez utiliser une action et dépenser 1 charge pour lancer <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=domination-des-betes\">domination des bêtes</a></em> (sauvegarde DD 15) depuis le trident sur une bête qui a une vitesse de nage innée. Le trident récupère 1d3 charges dépensées tous les jours à l'aube.\n<br></div>"
+		},
+		{
+			"id": "Vicious Trident",
+			"name": "Trident vicieux",
+			"description": "<div class=\"description \">Lorsque vous obtenez un 20 naturel à votre jet d'attaque avec cette arme magique, votre coup critique inflige 7 dégâts supplémentaires du type correspondant à l'arme.\n<br></div>"
+		},
+		{
+			"id": "Healer's Kit",
+			"name": "Trousse de soins",
+			"description": "<p>Ce kit est un étui en cuir qui contient des bandages, des pommades et des attelles. Le kit permet dix utilisations. Au prix d'une action, vous pouvez dépenser une utilisation du kit pour stabiliser une créature qui a 0 pv sans avoir à réaliser un jet de Sagesse (Médecine).</span></p>"
+		},
+		{
+			"id": "Truth Serum",
+			"name": "Truth Serum",
+			"description": "<p><em>(ingested)</em></p>\n<p>A creature subjected to this poison must succeed on a <strong>DC 11 Constitution saving throw</strong> or become @Compendium[dnd5e.rules.prcOUhkWEVppFVbg]{Poisoned} for <strong>1 hour</strong>. The @Compendium[dnd5e.rules.prcOUhkWEVppFVbg]{Poisoned} creature can't knowingly speak a lie, as if under the effect of a @Compendium[dnd5e.spells.CylBa7jR8DSbo8Z3]{Zone of Truth} spell.</p>"
+		},
+		{
+			"id": "Dulcimer",
+			"name": "Tympanon",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Cook's Utensils",
+			"name": "Ustensiles de cuisinier",
+			"description": "<p>Ces outils spéciaux comprennent les éléments nécessaires à l'exercice d'un métier ou d'un commerce. La table montre des exemples des types d'outils les plus communs, chacun offrant des objets liés à un seul métier. La maîtrise d'un type d'outil d'artisan vous permet d'ajouter votre bonus de maîtrise à tous les jets de caractéristique que vous faites en utilisant les outils de votre travail. Chaque type d'outil d'artisan nécessite une maîtrise distincte.</p>"
+		},
+		{
+			"id": "Common Clothes",
+			"name": "Vêtements communs",
+			"description": "<p>Vêtements portés par la plupart des gens.</span></p>"
+		},
+		{
+			"id": "Vestments",
+			"name": "Vêtements d'apparat",
+			"description": "<p>Simple ou ostentatoire, souvent utilisé par les prêtres et autres figures religieuses pour les rituels et les cérémonies.</p>"
+		},
+		{
+			"id": "Traveler's Clothes",
+			"name": "Vêtements de voyage",
+			"description": "<p>Ensemble de vêtements portés par les voyageurs.</span></p>"
+		},
+		{
+			"id": "Fine Clothes",
+			"name": "Vêtements ostentatoires",
+			"description": "<p>Ensemble de vêtements conçus spécialement pour être chers et le montrer.</span></p>"
+		},
+		{
+			"id": "Viol",
+			"name": "Viole",
+			"description": "<p>Cet instrument peut susciter l'admiration, l'émerveillement ou la crainte de votre public. Si vous maîtrisez un instrument de musique particulier, vous ajoutez votre bonus de maîtrise à tous les jets de caractéristique pour jouer de la musique avec cet instrument. Un barde peut utiliser un instrument de musique comme focaliseur magique. Chaque instrument de musique nécessite une maîtrise distincte. Un barde peut utiliser un instrument de musique comme focaliseur pour lancer ses sorts. &nbsp;</p>"
+		},
+		{
+			"id": "Eyes of Charming",
+			"name": "Yeux de charme",
+			"description": "<div class=\"description \">Ces lentilles de cristal se placent sur les yeux. Elles possèdent 3 charges. Tant que vous en êtes équipé, vous pouvez dépenser 1 charge en utilisant une action et ainsi lancer le sort <em><a href=\"https://www.aidedd.org/dnd/sorts.php?vf=charme-personne\">charme-personne</a></em> (sauvegarde DD 13) sur un humanoïde se trouvant à 9 mètres de vous, à condition que vous et la cible puissiez vous voir mutuellement. Les lentilles récupèrent toutes les charges dépensées chaque jour au lever du soleil.\n<br></div>"
+		},
+		{
+			"id": "Eyes of the Eagle",
+			"name": "Yeux de lynx",
+			"description": "<div class=\"description \">Ces lentilles de cristal se placent sur les yeux. Tant que vous en êtes équipé, vous avez un avantage aux jets de Sagesse (Perception) basés sur la vue. Dans des conditions de bonne visibilité, vous pouvez même apercevoir les détails de créatures et d'objets extrêmement éloignés, comme s'ils étaient situés à 60 centimètres de vous.\n<br></div>"
+		},
+		{
+			"id": "Eyes of Minute Seeing",
+			"name": "Yeux grossissants",
+			"description": "<div class=\"description \">Ces lentilles de cristal se placent sur les yeux. Tant que vous en êtes équipé, vous pouvez beaucoup mieux voir tout ce qui se trouve dans un rayon de 30 centimètres. Vous avez un avantage aux jets d'Intelligence (Investigation) basés sur la vue lorsque vous cherchez dans une zone ou étudiez un objet se trouvant dans cette portée.\n<br></div>"
+		}
+	]
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,6 +106,24 @@ tests = ["pytest (>=3.2.1,!=3.3.0)"]
 typecheck = ["mypy"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.12.2"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "23.3.0"
 description = "The uncompromising code formatter."
@@ -1090,6 +1108,17 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.4.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "soupsieve-2.4.1-py3-none-any.whl", hash = "sha256:1c1bfee6819544a3447586c889157365a27e10d88cde3ad3da0cf0ddf646feb8"},
+    {file = "soupsieve-2.4.1.tar.gz", hash = "sha256:89d12b2d5dfcd2c9e8c22326da9d9aa9cb3dfab0a83a024f05704076ee8d35ea"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.17"
 description = "Database Abstraction Library"
@@ -1458,4 +1487,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "805733b2b6b720af0570da7cbeabf3b1f292eac62eb7f3e5b9fe377569dd3106"
+content-hash = "0d6144cc8dacfad8b48efd983c4d9fafe576a38685cc74a137dfbec5a074aa25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ types-python-jose = "^3.3.4.7"
 types-passlib = "^1.7.7.12"
 pytest = "^7.4.0"
 httpx = "^0.24.1"
+beautifulsoup4 = "^4.12.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/preprocess_base_item_json.py
+++ b/scripts/preprocess_base_item_json.py
@@ -144,6 +144,8 @@ def main():
     generated_items = []
     for item in base_items_data["baseitem"]:
         reformatted_item = reformat_item(item)
+        if not reformatted_item:
+            continue
         generated_items.append(reformatted_item)
 
     with open(base_items_filepath, "w") as out:

--- a/scripts/preprocess_base_item_json.py
+++ b/scripts/preprocess_base_item_json.py
@@ -147,7 +147,7 @@ def main():
         generated_items.append(reformatted_item)
 
     with open(base_items_filepath, "w") as out:
-        json.dump(generated_items, out, indent=2)
+        json.dump(generated_items, out, indent=2, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/scripts/preprocess_base_item_json.py
+++ b/scripts/preprocess_base_item_json.py
@@ -1,13 +1,15 @@
 import json
 import sys
+import glob
+
+from bs4 import BeautifulSoup
 from pathlib import Path
 
-base_items_filepath = (
-    Path(__file__).parent.parent / "dnd5esheets" / "data" / "items-base.json"
-)
+data_dir = Path(__file__).parent.parent / "dnd5esheets" / "data"
+base_items_filepath = data_dir / "items-base.json"
+items_translations_filepath = data_dir / "translations-items-*.json"
 
 item_type_fields = ["weapon", "armor", "munition"]
-
 weapon_type_fields = [
     "bow",
     "crossbow",
@@ -48,8 +50,15 @@ field_name_translations = {
     "type": "subtype",
 }
 
+translations = {}
+for translations_filepath in glob.glob(str(items_translations_filepath)):
+    language = Path(translations_filepath).stem.split("-")[-1]
+    translated_data = json.load(open(translations_filepath))
+    translated_data = {entry["id"]: entry for entry in translated_data["entries"]}
+    translations[language] = translated_data
 
-def generate_effect(item):
+
+def generate_effect(item: dict) -> str | None:
     if item.get("armor"):
         if item["type"] == "LA":
             return f'$ac := {item["ac"]} + $dex'
@@ -59,14 +68,12 @@ def generate_effect(item):
             return f'$ac := {item["ac"]}'
 
 
-base_items_data = json.load(sys.stdin)
-
-generated_items = []
-for item in base_items_data["baseitem"]:
+def reformat_item(item: dict) -> dict | None:
     if not item.get("srd"):
-        continue
+        return
+
     reformatted_item = {
-        "meta": {},
+        "meta": {"translations": {}},
         "attributes": {},
         "requirements": {},
         "damage": {},
@@ -116,8 +123,32 @@ for item in base_items_data["baseitem"]:
         else:
             reformatted_item[field] = value
 
-    reformatted_item = {k: v for k, v in reformatted_item.items() if v != {}}
-    generated_items.append(reformatted_item)
+    for language, lang_translations in translations.items():
+        if translated_item := lang_translations.get(item["name"]):
+            reformatted_item["meta"]["translations"][language] = {
+                "name": translated_item["name"],
+                "description": BeautifulSoup(
+                    translated_item["description"], features="html.parser"
+                ).text,
+            }
+        else:
+            print(f"No translation found for {item['name']}")
 
-with open(base_items_filepath, "w") as out:
-    json.dump(generated_items, out, indent=2)
+    reformatted_item = {k: v for k, v in reformatted_item.items() if v != {}}
+    return reformatted_item
+
+
+def main():
+    base_items_data = json.load(sys.stdin)
+
+    generated_items = []
+    for item in base_items_data["baseitem"]:
+        reformatted_item = reformat_item(item)
+        generated_items.append(reformatted_item)
+
+    with open(base_items_filepath, "w") as out:
+        json.dump(generated_items, out, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I tried a very naive approach: either we have an exact match, or we don't import the translation. No levenshtein.

We only have 4 non matches:

```console
~/code/5esheets main *3 !7 ?1 ❯ make data

[+] Fetching base equipment data
No translation found for Arrows (20)
No translation found for Blowgun Needles (50)
No translation found for Crossbow Bolts (20)
No translation found for Sling Bullets (20)
```

Fixes #87
