### PR TITLE
Setup CORS to allow API calls to come from the dev frontend server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = help
-.PHONY: api-doc api-explorer black check clean dev docker-build docker-run front-check help init mypy ruff run test trash-env $(front-root)/src/5esheets-client/core/OpenAPI.ts
+.PHONY: api-doc api-explorer black check clean dev docker-build docker-run front-check help init mypy ruff run test trash-env $(api-client-root)/core/OpenAPI.ts
 
 UNAME_S := $(shell uname -s)
 
@@ -7,6 +7,7 @@ app-root = dnd5esheets
 app-port = 8000
 app-cli = poetry run dnd5esheets-cli
 front-root = $(app-root)/front
+api-client-root = $(front-root)/src/5esheets-client
 npm = cd $(front-root) && npm
 npm-run = $(npm) run
 
@@ -42,10 +43,10 @@ $(front-root)/openapi.json: $(wildcard $(app-root)/api/*.py) $(app-root)/schemas
 	@kill $$(lsof -i tcp:$(app-port) | grep -v PID | head -n 1 | awk '{ print $$2 }')
 	@python3 scripts/preprocess_openapi_json.py
 
-$(front-root)/src/5esheets-client/core/OpenAPI.ts: $(front-root)/src/5esheets-client
-	@$(sed_i) "s@BASE: ''@BASE: process.env.NODE_ENV === 'production' ? '/api' : 'http://127.0.0.1:$(app-port)'@" $(front-root)/src/5esheets-client/core/OpenAPI.ts
+$(api-client-root)/core/OpenAPI.ts: $(api-client-root)
+	@$(sed_i) "s@BASE: ''@BASE: process.env.NODE_ENV === 'production' ? '/api' : 'http://127.0.0.1:$(app-port)'@" $(api-client-root)/core/OpenAPI.ts
 
-$(front-root)/src/5esheets-client: $(front-root)/openapi.json
+$(api-client-root): $(front-root)/openapi.json
 	@echo "\n[+] Generating the typescript API client for the 5esheets API"
 	@$(npm-run) generate-client
 
@@ -129,7 +130,7 @@ front-run-dev: front-build  ## Run the development frontend server
 	@echo "\n[+] Running the dev frontend server"
 	@$(npm-run) dev -- --open
 
-front-generate-api-client: $(front-root)/src/5esheets-client/core/OpenAPI.ts ## Generate the API openapi.json file
+front-generate-api-client: $(api-client-root)/core/OpenAPI.ts ## Generate the API openapi.json file
 
 front-prettier:
 	@echo "\n[+] Running prettier on the codebase"

--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -1,17 +1,26 @@
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi_jwt_auth.exceptions import AuthJWTException
 
 from .api import api
+from .config import get_settings
 from .repositories import ModelNotFound
 
 app = FastAPI()
+settings = get_settings()
 app.include_router(api)
-
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[settings.FRONTEND_CORS_ORIGIN],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 dist_dir = Path(__file__).parent / "front" / "dist"
 
 

--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -14,13 +14,14 @@ from .repositories import ModelNotFound
 app = FastAPI()
 settings = get_settings()
 app.include_router(api)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[settings.FRONTEND_CORS_ORIGIN],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+if settings.FRONTEND_CORS_ORIGIN is not None:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[settings.FRONTEND_CORS_ORIGIN],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 dist_dir = Path(__file__).parent / "front" / "dist"
 
 

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -18,4 +18,4 @@ class CommonSettings(BaseSettings):
     DB_URI: str = f"sqlite:///{db_file}"
     DB_ASYNC_URI: str = f"sqlite+aiosqlite:///{db_file}"
     SQLALCHEMY_ECHO: bool = False
-    FRONTEND_CORS_ORIGIN = "http://localhost:3000"
+    FRONTEND_CORS_ORIGIN: str | None = "http://localhost:3000"

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -18,3 +18,4 @@ class CommonSettings(BaseSettings):
     DB_URI: str = f"sqlite:///{db_file}"
     DB_ASYNC_URI: str = f"sqlite+aiosqlite:///{db_file}"
     SQLALCHEMY_ECHO: bool = False
+    FRONTEND_CORS_ORIGIN = "http://localhost:3000"

--- a/dnd5esheets/config/prod.py
+++ b/dnd5esheets/config/prod.py
@@ -7,6 +7,7 @@ class ProdSettings(CommonSettings):
     DB_URI: str
     DB_ASYNC_URI: str
     MULTITENANT_ENABLED: bool = True
+    FRONTEND_CORS_ORIGIN: str | None = None
 
     class Config:
         env_file = ".env"

--- a/dnd5esheets/front/src/5esheets-client/core/OpenAPI.ts
+++ b/dnd5esheets/front/src/5esheets-client/core/OpenAPI.ts
@@ -19,7 +19,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: '',
+    BASE: process.env.NODE_ENV === 'production' ? '/api' : 'http://127.0.0.1:8000',
     VERSION: '0.1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',


### PR DESCRIPTION
Setup CORS in development mode only, as we have both a backend and frontend servers, running on different "domains":
- the backend runs on `localhost:8000`
- the frontend runs on `localhost:3000`

However, in prod, the frontend will only be static compiled files served by a CDN, and they will only hit the local domain.

To that end, we configure the `BASE` API host in the `OpenAPI.ts` configuration file according to the `NODE_ENV` we're running in. We do this via some make/sed magic, but it might be easier to simply keep a modified copy of `OpenAPI.ts` and simply `cp` it after a new client generation.