### PR TITLE
Only install production dependencies when building the JS app in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY dnd5esheets/front/package.json ./
 COPY dnd5esheets/front/package-lock.json ./
-RUN npm install
+RUN npm install --omit=dev
 COPY dnd5esheets/front/ ./
 RUN npm run build
 


### PR DESCRIPTION
~I moved `vite-plugin-solid-styled` from the `devDependencies` to the production dependencies as it seems it's required to run `solid-start build`.~ (fixed in `main`)

Fixes #143
