### PR TITLE
Trigger a workflow to update requirements.txt when dependabot creates a PR

### DIFF
--- a/.github/workflows/update-requirements-after-dependabot.yml
+++ b/.github/workflows/update-requirements-after-dependabot.yml
@@ -1,0 +1,28 @@
+name: Dependabot update requirements.txt
+on: pull_request
+permissions:
+  contents: write
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - uses: actions/checkout@master
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+    - name: Install poetry
+      run: python3 -m pip install poetry
+
+    - name: Create local changes
+      run: poetry export -o requirements.txt
+
+    - name: Commit & Push changes
+      uses: actions-js/push@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        author_name: "dependabot[bot]"
+        author_email: "support@github.com"
+        message: "Update requirements.txt"
+        branch: "${{ github.head_ref }}"


### PR DESCRIPTION
When Dependabot updates the python dependencies, this workflow will make sure to also update `requirements.txt` with it. This will save me about 5 minutes a week. Yay! 