### PR TITLE
Create the app via the app factory pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ ruff:
 
 run: admin-statics build  ## Run the app
 	@echo  "\n[+] Running the FastApi server"
-	@cd $(app-root) && poetry run uvicorn $(app-root).app:app --reload
+	@cd $(app-root) && poetry run uvicorn --factory $(app-root).app:create_app --reload
 
 test:  back-test front-test ## Run the project tests
 

--- a/dnd5esheets/__init__.py
+++ b/dnd5esheets/__init__.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+from .config import Env
+from .config.base import CommonSettings
+
+
+class ExtendedFastAPI(FastAPI):
+    settings: CommonSettings
+    env: Env

--- a/dnd5esheets/__init__.py
+++ b/dnd5esheets/__init__.py
@@ -5,5 +5,7 @@ from .config.base import CommonSettings
 
 
 class ExtendedFastAPI(FastAPI):
-    settings: CommonSettings
-    env: Env
+    def __init__(self, settings: CommonSettings, env: Env, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.settings = settings
+        self.env = env

--- a/dnd5esheets/api/__init__.py
+++ b/dnd5esheets/api/__init__.py
@@ -1,1 +1,1 @@
-from .root import api  # noqa
+from .root import register_api  # noqa

--- a/dnd5esheets/api/root.py
+++ b/dnd5esheets/api/root.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter
 from fastapi.routing import APIRoute
 
+from dnd5esheets import ExtendedFastAPI
 from dnd5esheets.api.character import character_api
 from dnd5esheets.api.item import item_api
 from dnd5esheets.api.login import login_api
@@ -14,7 +15,7 @@ def custom_generate_unique_id(route: APIRoute):
     return f"{route.tags[0]}-{route.name}"
 
 
-def register_api(app: FastAPI):
+def register_api(app: ExtendedFastAPI):
     api = APIRouter(
         prefix="/api", generate_unique_id_function=custom_generate_unique_id
     )

--- a/dnd5esheets/api/root.py
+++ b/dnd5esheets/api/root.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 
 from dnd5esheets.api.character import character_api
@@ -14,10 +14,14 @@ def custom_generate_unique_id(route: APIRoute):
     return f"{route.tags[0]}-{route.name}"
 
 
-api = APIRouter(prefix="/api", generate_unique_id_function=custom_generate_unique_id)
-api.include_router(character_api)
-api.include_router(party_api)
-api.include_router(player_api)
-api.include_router(login_api)
-api.include_router(spell_api)
-api.include_router(item_api)
+def register_api(app: FastAPI):
+    api = APIRouter(
+        prefix="/api", generate_unique_id_function=custom_generate_unique_id
+    )
+    api.include_router(character_api)
+    api.include_router(party_api)
+    api.include_router(player_api)
+    api.include_router(login_api)
+    api.include_router(spell_api)
+    api.include_router(item_api)
+    app.include_router(api)

--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -1,5 +1,4 @@
-from fastapi import FastAPI
-
+from . import ExtendedFastAPI
 from .admin import register_admin
 from .api import register_api
 from .config import get_env, get_settings
@@ -9,8 +8,8 @@ from .middleware import register_middlewares
 from .spa import register_spa
 
 
-def create_app() -> FastAPI:
-    app = FastAPI()
+def create_app() -> ExtendedFastAPI:
+    app = ExtendedFastAPI()
     app.settings = get_settings()
     app.env = get_env()
 

--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -1,71 +1,22 @@
-from pathlib import Path
-
 from fastapi import FastAPI
-from fastapi.encoders import jsonable_encoder
-from fastapi.exceptions import ResponseValidationError
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.requests import Request
-from fastapi.responses import JSONResponse, Response
-from starlette import status
 
 from .admin import register_admin
-from .api import api
-from .config import Env, get_env, get_settings
+from .api import register_api
+from .config import get_env, get_settings
 from .db import async_engine
-from .exceptions import CacheHit, DuplicateModel, ModelNotFound
-from .spa import SPAStaticFiles
-
-app = FastAPI()
-settings = get_settings()
-app.include_router(api)
+from .exceptions import register_exception_handlers
+from .middleware import register_middlewares
+from .spa import register_spa
 
 
-if settings.FRONTEND_CORS_ORIGIN is not None:
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=[settings.FRONTEND_CORS_ORIGIN],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.settings = get_settings()
+    app.env = get_env()
 
-
-register_admin(app, async_engine)
-
-dist_dir = Path(__file__).parent / "front" / "dist"
-
-
-@app.exception_handler(ModelNotFound)
-def raise_404_exception_on_model_not_found(_: Request, exc: Exception):
-    """Return a 404 response when handling a ModelNotFound exception"""
-    return JSONResponse(
-        content={"detail": str(exc)}, status_code=status.HTTP_404_NOT_FOUND
-    )
-
-
-@app.exception_handler(DuplicateModel)
-def raise_400_exception_on_duplicate_model(_: Request, exc: Exception):
-    """Return a 400 response when handling a DuplicateModel exception"""
-    return JSONResponse(
-        content={"detail": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
-    )
-
-
-@app.exception_handler(CacheHit)
-def cachehit_exception_handler(_: Request, exc: CacheHit):
-    """Generate a correct 304 response when handling a CacheHit exception"""
-    return Response("", status_code=exc.status_code, headers=exc.headers)
-
-
-if get_env() != Env.prod:
-
-    @app.exception_handler(ResponseValidationError)
-    async def validation_exception_handler(_: Request, exc: ResponseValidationError):
-        return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content=jsonable_encoder({"detail": exc.errors()}),
-        )
-
-
-if dist_dir.exists():
-    app.mount("", SPAStaticFiles(directory=dist_dir, html=True), name="static")
+    register_api(app)
+    register_middlewares(app)
+    register_exception_handlers(app)
+    register_admin(app, async_engine)
+    register_spa(app)
+    return app

--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -9,10 +9,7 @@ from .spa import register_spa
 
 
 def create_app() -> ExtendedFastAPI:
-    app = ExtendedFastAPI()
-    app.settings = get_settings()
-    app.env = get_env()
-
+    app = ExtendedFastAPI(settings=get_settings(), env=get_env())
     register_api(app)
     register_middlewares(app)
     register_exception_handlers(app)

--- a/dnd5esheets/exceptions.py
+++ b/dnd5esheets/exceptions.py
@@ -1,6 +1,13 @@
 from typing import Self
 
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import ResponseValidationError
+from fastapi.requests import Request
+from fastapi.responses import JSONResponse, Response
+from starlette import status
+
+from .config import Env
 
 
 class CacheHit(HTTPException):
@@ -19,3 +26,35 @@ class ModelNotFound(RepositoryException):
 
 class DuplicateModel(RepositoryException):
     ...
+
+
+def register_exception_handlers(app: FastAPI):
+    @app.exception_handler(ModelNotFound)
+    def raise_404_exception_on_model_not_found(_: Request, exc: Exception):
+        """Return a 404 response when handling a ModelNotFound exception"""
+        return JSONResponse(
+            content={"detail": str(exc)}, status_code=status.HTTP_404_NOT_FOUND
+        )
+
+    @app.exception_handler(DuplicateModel)
+    def raise_400_exception_on_duplicate_model(_: Request, exc: Exception):
+        """Return a 400 response when handling a DuplicateModel exception"""
+        return JSONResponse(
+            content={"detail": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
+        )
+
+    @app.exception_handler(CacheHit)
+    def cachehit_exception_handler(_: Request, exc: CacheHit):
+        """Generate a correct 304 response when handling a CacheHit exception"""
+        return Response("", status_code=exc.status_code, headers=exc.headers)
+
+    if app.env != Env.prod:
+
+        @app.exception_handler(ResponseValidationError)
+        async def validation_exception_handler(
+            _: Request, exc: ResponseValidationError
+        ):
+            return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                content=jsonable_encoder({"detail": exc.errors()}),
+            )

--- a/dnd5esheets/exceptions.py
+++ b/dnd5esheets/exceptions.py
@@ -1,12 +1,12 @@
 from typing import Self
 
-from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi import HTTPException, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import ResponseValidationError
-from fastapi.requests import Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 from starlette import status
 
+from . import ExtendedFastAPI
 from .config import Env
 
 
@@ -28,7 +28,7 @@ class DuplicateModel(RepositoryException):
     ...
 
 
-def register_exception_handlers(app: FastAPI):
+def register_exception_handlers(app: ExtendedFastAPI):
     @app.exception_handler(ModelNotFound)
     def raise_404_exception_on_model_not_found(_: Request, exc: Exception):
         """Return a 404 response when handling a ModelNotFound exception"""

--- a/dnd5esheets/middleware.py
+++ b/dnd5esheets/middleware.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from . import ExtendedFastAPI
 
-def register_middlewares(app: FastAPI):
+
+def register_middlewares(app: ExtendedFastAPI):
     if app.settings.FRONTEND_CORS_ORIGIN is not None:
         app.add_middleware(
             CORSMiddleware,

--- a/dnd5esheets/middleware.py
+++ b/dnd5esheets/middleware.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+
+def register_middlewares(app: FastAPI):
+    if app.settings.FRONTEND_CORS_ORIGIN is not None:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=[app.settings.FRONTEND_CORS_ORIGIN],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )

--- a/dnd5esheets/spa.py
+++ b/dnd5esheets/spa.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from typing import cast
 
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 from fastapi.staticfiles import StaticFiles
+
+from . import ExtendedFastAPI
 
 dist_dir = Path(__file__).parent / "front" / "dist"
 
@@ -25,6 +27,6 @@ class SPAStaticFiles(StaticFiles):
                 return await super().get_response(".", scope)
 
 
-def register_spa(app: FastAPI):
+def register_spa(app: ExtendedFastAPI):
     if dist_dir.exists():
         app.mount("", SPAStaticFiles(directory=dist_dir, html=True), name="static")

--- a/dnd5esheets/spa.py
+++ b/dnd5esheets/spa.py
@@ -1,7 +1,10 @@
+from pathlib import Path
 from typing import cast
 
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
+
+dist_dir = Path(__file__).parent / "front" / "dist"
 
 
 class SPAStaticFiles(StaticFiles):
@@ -20,3 +23,8 @@ class SPAStaticFiles(StaticFiles):
             else:
                 # We serve the SPA root page
                 return await super().get_response(".", scope)
+
+
+def register_spa(app: FastAPI):
+    if dist_dir.exists():
+        app.mount("", SPAStaticFiles(directory=dist_dir, html=True), name="static")

--- a/scripts/start-app.sh
+++ b/scripts/start-app.sh
@@ -3,4 +3,4 @@
 set -e
 
 alembic upgrade head
-exec uvicorn dnd5esheets.app:app --host "0.0.0.0" --port 8000
+exec uvicorn --factory dnd5esheets.app:create_app --host "0.0.0.0" --port 8000


### PR DESCRIPTION
This removes any import-time side effects, and gets us closer from the Flask good practices that I'm trying to follow even with FastAPI.