### PR TITLE
Validate the schema of each spell in DB in unit tests

### DIFF
--- a/dnd5esheets/data/spells.json
+++ b/dnd5esheets/data/spells.json
@@ -317,15 +317,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "lightning damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "lightning damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "lightning"
     ],
@@ -376,15 +378,17 @@
         "amount": 1
       }
     ],
-    "scaling_level_dice": {
-      "label": "psychic damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "psychic damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "psychic"
     ],
@@ -891,15 +895,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "force damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "force damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "force"
     ],
@@ -1796,15 +1802,17 @@
         "amount": 1
       }
     ],
-    "scaling_level_dice": {
-      "label": "fire damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "fire damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "fire"
     ],
@@ -2658,15 +2666,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "cold damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "cold damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "cold"
     ],
@@ -3151,15 +3161,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "poison damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "poison damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "poison"
     ],
@@ -4142,15 +4154,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "acid damage",
-      "scaling": {
-        "1": "1d10",
-        "5": "2d10",
-        "11": "3d10",
-        "17": "4d10"
+    "scaling_level_dice": [
+      {
+        "label": "acid damage",
+        "scaling": {
+          "1": "1d10",
+          "5": "2d10",
+          "11": "3d10",
+          "17": "4d10"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "acid"
     ],
@@ -5248,15 +5262,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "thunder damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "thunder damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "thunder"
     ],
@@ -5942,15 +5958,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "radiant damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "radiant damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "radiant"
     ],
@@ -6117,15 +6135,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "acid damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "acid damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "acid"
     ],
@@ -8490,15 +8510,17 @@
         "amount": 1
       }
     ],
-    "scaling_level_dice": {
-      "label": "necrotic damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "necrotic damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "necrotic"
     ],
@@ -13178,15 +13200,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "fire damage",
-      "scaling": {
-        "1": "1d10",
-        "5": "2d10",
-        "11": "3d10",
-        "17": "4d10"
+    "scaling_level_dice": [
+      {
+        "label": "fire damage",
+        "scaling": {
+          "1": "1d10",
+          "5": "2d10",
+          "11": "3d10",
+          "17": "4d10"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "fire"
     ],
@@ -19425,15 +19449,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "poison damage",
-      "scaling": {
-        "1": "1d12",
-        "5": "2d12",
-        "11": "3d12",
-        "17": "4d12"
+    "scaling_level_dice": [
+      {
+        "label": "poison damage",
+        "scaling": {
+          "1": "1d12",
+          "5": "2d12",
+          "11": "3d12",
+          "17": "4d12"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "poison"
     ],
@@ -19942,15 +19968,17 @@
         "amount": 10
       }
     ],
-    "scaling_level_dice": {
-      "label": "fire damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "fire damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "fire"
     ],
@@ -20480,15 +20508,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "cold damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "cold damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "cold"
     ],
@@ -20998,15 +21028,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "radiant damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "radiant damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "radiant"
     ],
@@ -21726,15 +21758,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "lightning damage",
-      "scaling": {
-        "1": "1d8",
-        "5": "2d8",
-        "11": "3d8",
-        "17": "4d8"
+    "scaling_level_dice": [
+      {
+        "label": "lightning damage",
+        "scaling": {
+          "1": "1d8",
+          "5": "2d8",
+          "11": "3d8",
+          "17": "4d8"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "lightning"
     ],
@@ -23477,15 +23511,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "piercing damage",
-      "scaling": {
-        "1": "1d6",
-        "5": "2d6",
-        "11": "3d6",
-        "17": "4d6"
+    "scaling_level_dice": [
+      {
+        "label": "piercing damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "piercing"
     ],
@@ -24187,15 +24223,17 @@
         "type": "instant"
       }
     ],
-    "scaling_level_dice": {
-      "label": "psychic damage",
-      "scaling": {
-        "1": "1d4",
-        "5": "2d4",
-        "11": "3d4",
-        "17": "4d4"
+    "scaling_level_dice": [
+      {
+        "label": "psychic damage",
+        "scaling": {
+          "1": "1d4",
+          "5": "2d4",
+          "11": "3d4",
+          "17": "4d4"
+        }
       }
-    },
+    ],
     "damage_inflict": [
       "psychic"
     ],

--- a/dnd5esheets/front/openapi.json
+++ b/dnd5esheets/front/openapi.json
@@ -2684,9 +2684,15 @@
             "default": 0
           },
           "consume": {
-            "type": "boolean",
-            "title": "Consume",
-            "default": false
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Consume"
           }
         },
         "type": "object",
@@ -2740,11 +2746,11 @@
             "default": []
           },
           "scaling_level_dice": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SpellScalingLevel"
-              }
-            ]
+            "items": {
+              "$ref": "#/components/schemas/SpellScalingLevel"
+            },
+            "type": "array",
+            "title": "Scaling Level Dice"
           },
           "damage_inflict": {
             "items": {
@@ -2914,13 +2920,19 @@
             "title": "Type"
           },
           "distance": {
-            "$ref": "#/components/schemas/SpellRangeDistance"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpellRangeDistance"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
         "required": [
-          "type",
-          "distance"
+          "type"
         ],
         "title": "SpellRange"
       },

--- a/dnd5esheets/front/src/5esheets-client/models/SpellCastingMaterial.ts
+++ b/dnd5esheets/front/src/5esheets-client/models/SpellCastingMaterial.ts
@@ -6,6 +6,6 @@
 export type SpellCastingMaterial = {
     text: string;
     cost?: number;
-    consume?: boolean;
+    consume?: (boolean | string);
 };
 

--- a/dnd5esheets/front/src/5esheets-client/models/SpellData.ts
+++ b/dnd5esheets/front/src/5esheets-client/models/SpellData.ts
@@ -21,7 +21,7 @@ export type SpellData = {
     duration: Array<SpellDuration>;
     misc_tags?: Array<string>;
     area_tags?: Array<string>;
-    scaling_level_dice?: SpellScalingLevel;
+    scaling_level_dice?: Array<SpellScalingLevel>;
     damage_inflict?: Array<string>;
     saving_throw?: Array<string>;
     condition_inflict?: Array<string>;

--- a/dnd5esheets/front/src/5esheets-client/models/SpellRange.ts
+++ b/dnd5esheets/front/src/5esheets-client/models/SpellRange.ts
@@ -7,6 +7,6 @@ import type { SpellRangeDistance } from './SpellRangeDistance';
 
 export type SpellRange = {
     type: string;
-    distance: SpellRangeDistance;
+    distance?: (SpellRangeDistance | null);
 };
 

--- a/dnd5esheets/schemas.py
+++ b/dnd5esheets/schemas.py
@@ -171,7 +171,7 @@ class SpellCastingMaterial(BaseSchema):
         title="A description of the material components required to cast a spell"
     )
     cost: int = Field(title="The minimum cost of the materials", default=0)
-    consume: bool = Field(default=False)
+    consume: bool | str = Field(default=None)
 
 
 class SpellCasting(BaseSchema):
@@ -218,7 +218,7 @@ class SpellRangeDistance(BaseSchema):
 
 class SpellRange(BaseSchema):
     type: str
-    distance: SpellRangeDistance
+    distance: Optional[SpellRangeDistance] = Field(default=None)
 
 
 class SpellDuration(BaseSchema):
@@ -249,7 +249,7 @@ class SpellData(BaseSchema):
     duration: list[SpellDuration]
     misc_tags: list[str] = Field(default=[])
     area_tags: list[str] = Field(default=[])
-    scaling_level_dice: SpellScalingLevel = Field(default=None)
+    scaling_level_dice: list[SpellScalingLevel] = Field(default_factory=list)
     damage_inflict: list[str] = Field(default=[])
     saving_throw: list[str] = Field(default=[])
     condition_inflict: list[str] = Field(default=[])

--- a/dnd5esheets/tests/test_api_spell.py
+++ b/dnd5esheets/tests/test_api_spell.py
@@ -1,3 +1,7 @@
+from sqlalchemy import select
+
+from dnd5esheets.models import Spell
+
 from .utils import assert_status_and_return_data
 
 
@@ -10,3 +14,14 @@ def test_get_spell(client):
 def test_get_spell_etag(client):
     response = client.get("/api/spell/1")
     assert "etag" in response.headers
+    etag = response.headers["etag"]
+
+    response2 = client.get("/api/spell/1")
+    assert etag == response2.headers["etag"]
+
+
+def test_spell_schema(client, session):
+    spell_ids = session.execute(select(Spell.id)).scalars().all()
+    for spell_id in spell_ids:
+        resp = client.get(f"/api/spell/{spell_id}")
+        assert resp.status_code == 200, (spell_id, resp.status_code)

--- a/scripts/preprocess_spells_json.py
+++ b/scripts/preprocess_spells_json.py
@@ -110,6 +110,10 @@ def reformat_spell(spell: dict) -> dict | None:
             reformatted_spell["duration"] = durations
         elif field == "school":
             reformatted_spell["school"] = school_translations[value]
+        elif field == "scaling_level_dice":
+            if isinstance(value, dict):
+                value = [value]
+            reformatted_spell[field] = value
         else:
             reformatted_spell[field] = value
 


### PR DESCRIPTION
This allowed me to unearth discrepancies between specific spells and our `SpellData` schema, and will make sure that each new spell we add to DB conforms with it.
