### PR TITLE
Allow the server to run with a profiling middleware, to measure spent time in request handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ node_modules
 *.njsproj
 *.sln
 *.sw?
+
+# profiling files
+*.pstats
+profile.png

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ api-client-root = $(front-root)/src/5esheets-client
 npm = cd $(front-root) && npm
 npm-run = $(npm) run
 python = poetry run python3
+pstats-file = 5esheets.pstats
 
 sed_i = sed -i
 ifeq ($(UNAME_S),Darwin)
@@ -142,6 +143,10 @@ front-prettier:
 	@echo "\n[+] Running prettier on the front codebase"
 	@$(npm-run) prettier-check
 
+profile:  ## Convert a profile to a png file
+	@poetry run gprof2dot -f pstats $(pstats-file) | dot -Tpng -o profile.png
+	@open profile.png
+
 ruff:
 	@echo "\n[+] Running linter"
 	@poetry run ruff $(app-root)/
@@ -149,6 +154,9 @@ ruff:
 run: admin-statics build  ## Run the app
 	@echo  "\n[+] Running the FastApi server"
 	@cd $(app-root) && poetry run uvicorn --factory $(app-root).app:create_app --reload
+
+run-with-profiling:  ## Run the server with the profiling middleware enabled
+	@PROFILING_ENABLED=true make run
 
 test:  back-test front-test ## Run the project tests
 

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 from datetime import timedelta
+from pathlib import Path
+
 from pydantic_settings import BaseSettings
 
 db_dir = Path(__file__).parent.parent / "db"
@@ -16,3 +17,5 @@ class CommonSettings(BaseSettings):
     DB_ASYNC_URI: str = f"sqlite+aiosqlite:///{db_file}"
     SQLALCHEMY_ECHO: bool = False
     FRONTEND_CORS_ORIGIN: str | None = "http://localhost:3000"
+
+    PROFILING_ENABLED: bool = False

--- a/dnd5esheets/middlewares.py
+++ b/dnd5esheets/middlewares.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi_cprofile.profiler import CProfileMiddleware
 
 from . import ExtendedFastAPI
+
+current_dir = Path(__file__).parent
 
 
 def register_middlewares(app: ExtendedFastAPI):
@@ -11,4 +16,14 @@ def register_middlewares(app: ExtendedFastAPI):
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
+        )
+    if app.settings.PROFILING_ENABLED is True:
+        app.add_middleware(
+            CProfileMiddleware,
+            server_app=app,
+            enable=True,
+            print_each_request=True,
+            strip_dirs=False,
+            sort_by="cumulative",
+            filename=current_dir / ".." / "5esheets.pstats",
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -378,6 +378,20 @@ typing-extensions = ">=4.5.0"
 all = ["email-validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "fastapi-cprofile"
+version = "0.0.2"
+description = "A FastAPI Middleware with cProfile to stats your service performance."
+optional = false
+python-versions = "*"
+files = [
+    {file = "fastapi_cprofile-0.0.2-py3-none-any.whl", hash = "sha256:dc2709c54a9503915d7f1fa9a81c38c9405762440421a22d131d78c3461cdb08"},
+    {file = "fastapi_cprofile-0.0.2.tar.gz", hash = "sha256:af929b6c48add45b36c68a22efc1b699f86317e7d3d52623d52589228a764d5e"},
+]
+
+[package.dependencies]
+fastapi = "*"
+
+[[package]]
 name = "fastapi-jwt"
 version = "0.1.12"
 description = "`FastAPI` extension for JTW Auth"
@@ -394,6 +408,17 @@ python-jose = {version = ">=3.3.0", extras = ["cryptography"]}
 [package.extras]
 docs = ["MkAutoDoc (>=0.2.0,<1.0.0)", "lazydocs (>=0.4.5,<1.0.0)", "mike (>=1.1.0,<2.0.0)", "mkdocs (>=1.4.0,<2.0.0)", "mkdocs-awesome-pages-plugin (>=2.8.0,<3.0.0)", "mkdocs-include-markdown-plugin (>=4.0.0,<5.0.0)", "mkdocs-material (>=9.0.0,<10.0.0)"]
 test = ["black (==23.1.0)", "flake8 (>=6.0.0,<7.0.0)", "httpx (>=0.23.0,<1.0.0)", "isort (>=5.11.0,<6.0.0)", "mypy (>=1.0.0,<2.0.0)", "pytest (>=7.0.0,<8.0.0)", "pytest-cov (>=4.0.0,<5.0.0)", "pytest-mock (>=3.0.0,<4.0.0)", "requests (>=2.28.0,<3.0.0)", "types-python-jose (==3.3.4.5)"]
+
+[[package]]
+name = "gprof2dot"
+version = "2022.7.29"
+description = "Generate a dot graph from the output of several profilers."
+optional = false
+python-versions = ">=2.7"
+files = [
+    {file = "gprof2dot-2022.7.29-py2.py3-none-any.whl", hash = "sha256:f165b3851d3c52ee4915eb1bd6cca571e5759823c2cd0f71a79bda93c2dc85d6"},
+    {file = "gprof2dot-2022.7.29.tar.gz", hash = "sha256:45b4d298bd36608fccf9511c3fd88a773f7a1abc04d6cd39445b11ba43133ec5"},
+]
 
 [[package]]
 name = "greenlet"
@@ -1667,4 +1692,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "13e96f09b6223242567040ae6696ec8c7edae793722f6cfd1305ef3406e69288"
+content-hash = "9c36052843e97933123ae02271ba22eb1bd99a6a8b92aeda51d6b66edbf46f07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ httpx = "^0.24.1"
 beautifulsoup4 = "^4.12.2"
 types-python-slugify = "^8.0.0.2"
 pytest-asyncio = "^0.21.1"
+gprof2dot = "^2022.7.29"
+fastapi-cprofile = "^0.0.2"
 
 [tool.poetry.scripts]
 dnd5esheets-cli = 'dnd5esheets.cli:cli'


### PR DESCRIPTION
To profile a given route, we run the server with profiling enabled (`make run-with-profiling`), and hit the same endpoint multiple times 

```python
>>> import timeit
>>> import httpx 
>>> timeit.timeit('httpx.get("http://localhost:8000/api/character/douglas-mctrickfoot")', globals={'httpx': httpx}, number=300)
```

We then shutdown the app, and run `make profile`, which generates this kind of profiling output

![profile](https://github.com/brouberol/5esheets/assets/480131/c3fc4124-4822-49b2-8ce7-1cb79c501227)

