### PR TITLE
Replace the stdlib json module by orjson

### DIFF
--- a/dnd5esheets/admin/admin.py
+++ b/dnd5esheets/admin/admin.py
@@ -1,9 +1,9 @@
 """Definition of admin model views"""
 
-import json
 from pathlib import Path
 from typing import Type
 
+import orjson
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from markupsafe import Markup
@@ -30,7 +30,7 @@ statics_dir = Path(__file__).parent / "statics"
 
 
 def json_formatter(value: dict) -> Markup:
-    json_value = json.dumps(value, indent=2, ensure_ascii=False)
+    json_value = orjson.dumps(value, option=orjson.OPT_INDENT_2)
     html_json_value = highlight(
         json_value,
         lexer=get_lexer_by_name("json"),

--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -1,3 +1,5 @@
+from fastapi.responses import ORJSONResponse
+
 from . import ExtendedFastAPI
 from .admin import register_admin
 from .api import register_api
@@ -9,7 +11,9 @@ from .spa import register_spa
 
 
 def create_app() -> ExtendedFastAPI:
-    app = ExtendedFastAPI(settings=get_settings(), env=get_env())
+    app = ExtendedFastAPI(
+        default_response_class=ORJSONResponse, settings=get_settings(), env=get_env()
+    )
     register_api(app)
     register_middlewares(app)
     register_exception_handlers(app)

--- a/dnd5esheets/cli.py
+++ b/dnd5esheets/cli.py
@@ -1,7 +1,7 @@
-import json
 from pathlib import Path
 
 import click
+import orjson
 from sqlalchemy import select
 
 from dnd5esheets.config.base import db_dir
@@ -36,7 +36,8 @@ def populate():
 
 def _populate_base_items(silent: bool = False):
     with open(data_dir / "items-base.json") as base_items_fd:
-        base_items = json.load(base_items_fd)
+        base_items_str = base_items_fd.read()
+        base_items = orjson.loads(base_items_str)
 
     with create_session(commit_at_end=True) as session:
         for i, base_item in enumerate(base_items, 1):
@@ -48,11 +49,12 @@ def _populate_base_items(silent: bool = False):
 
 
 def _populate_spells(silent: bool = False):
-    with open(data_dir / "spells.json") as base_items_fd:
-        base_items = json.load(base_items_fd)
+    with open(data_dir / "spells.json") as spells_fd:
+        spells_str = spells_fd.read()
+        spells = orjson.loads(spells_str)
 
     with create_session(commit_at_end=True) as session:
-        for i, spell in enumerate(base_items, 1):
+        for i, spell in enumerate(spells, 1):
             spell_name = spell.pop("name")
             spell_school = spell.pop("school")
             spell_level = spell.pop("level")
@@ -70,7 +72,8 @@ def _populate_spells(silent: bool = False):
 
 def _populate_db_with_dev_data(silent: bool = False):
     with open(db_dir / "fixtures" / "dev.json") as dev_fixtures_fd:
-        dev_fixtures = json.load(dev_fixtures_fd)
+        dev_fixtures_str = dev_fixtures_fd.read()
+        dev_fixtures = orjson.loads(dev_fixtures_str)
 
     with create_session(commit_at_end=True) as session:
         longsword = session.execute(

--- a/dnd5esheets/exceptions.py
+++ b/dnd5esheets/exceptions.py
@@ -3,7 +3,7 @@ from typing import Self
 from fastapi import HTTPException, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import ResponseValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import ORJSONResponse as JSONResponse
 from starlette import status
 
 from . import ExtendedFastAPI

--- a/poetry.lock
+++ b/poetry.lock
@@ -807,6 +807,61 @@ files = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.9.2"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "orjson-3.9.2-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:7323e4ca8322b1ecb87562f1ec2491831c086d9faa9a6c6503f489dadbed37d7"},
+    {file = "orjson-3.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1272688ea1865f711b01ba479dea2d53e037ea00892fd04196b5875f7021d9d3"},
+    {file = "orjson-3.9.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0b9a26f1d1427a9101a1e8910f2e2df1f44d3d18ad5480ba031b15d5c1cb282e"},
+    {file = "orjson-3.9.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6a5ca55b0d8f25f18b471e34abaee4b175924b6cd62f59992945b25963443141"},
+    {file = "orjson-3.9.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:877872db2c0f41fbe21f852ff642ca842a43bc34895b70f71c9d575df31fffb4"},
+    {file = "orjson-3.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a39c2529d75373b7167bf84c814ef9b8f3737a339c225ed6c0df40736df8748"},
+    {file = "orjson-3.9.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:84ebd6fdf138eb0eb4280045442331ee71c0aab5e16397ba6645f32f911bfb37"},
+    {file = "orjson-3.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5a60a1cfcfe310547a1946506dd4f1ed0a7d5bd5b02c8697d9d5dcd8d2e9245e"},
+    {file = "orjson-3.9.2-cp310-none-win_amd64.whl", hash = "sha256:c290c4f81e8fd0c1683638802c11610b2f722b540f8e5e858b6914b495cf90c8"},
+    {file = "orjson-3.9.2-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:02ef014f9a605e84b675060785e37ec9c0d2347a04f1307a9d6840ab8ecd6f55"},
+    {file = "orjson-3.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:992af54265ada1c1579500d6594ed73fe333e726de70d64919cf37f93defdd06"},
+    {file = "orjson-3.9.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a40958f7af7c6d992ee67b2da4098dca8b770fc3b4b3834d540477788bfa76d3"},
+    {file = "orjson-3.9.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:93864dec3e3dd058a2dbe488d11ac0345214a6a12697f53a63e34de7d28d4257"},
+    {file = "orjson-3.9.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:16fdf5a82df80c544c3c91516ab3882cd1ac4f1f84eefeafa642e05cef5f6699"},
+    {file = "orjson-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:275b5a18fd9ed60b2720543d3ddac170051c43d680e47d04ff5203d2c6d8ebf1"},
+    {file = "orjson-3.9.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b9aea6dcb99fcbc9f6d1dd84fca92322fda261da7fb014514bb4689c7c2097a8"},
+    {file = "orjson-3.9.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7d74ae0e101d17c22ef67b741ba356ab896fc0fa64b301c2bf2bb0a4d874b190"},
+    {file = "orjson-3.9.2-cp311-none-win_amd64.whl", hash = "sha256:6320b28e7bdb58c3a3a5efffe04b9edad3318d82409e84670a9b24e8035a249d"},
+    {file = "orjson-3.9.2-cp37-cp37m-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:368e9cc91ecb7ac21f2aa475e1901204110cf3e714e98649c2502227d248f947"},
+    {file = "orjson-3.9.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58e9e70f0dcd6a802c35887f306b555ff7a214840aad7de24901fc8bd9cf5dde"},
+    {file = "orjson-3.9.2-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:00c983896c2e01c94c0ef72fd7373b2aa06d0c0eed0342c4884559f812a6835b"},
+    {file = "orjson-3.9.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ee743e8890b16c87a2f89733f983370672272b61ee77429c0a5899b2c98c1a7"},
+    {file = "orjson-3.9.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7b065942d362aad4818ff599d2f104c35a565c2cbcbab8c09ec49edba91da75"},
+    {file = "orjson-3.9.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e46e9c5b404bb9e41d5555762fd410d5466b7eb1ec170ad1b1609cbebe71df21"},
+    {file = "orjson-3.9.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8170157288714678ffd64f5de33039e1164a73fd8b6be40a8a273f80093f5c4f"},
+    {file = "orjson-3.9.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e3e2f087161947dafe8319ea2cfcb9cea4bb9d2172ecc60ac3c9738f72ef2909"},
+    {file = "orjson-3.9.2-cp37-none-win_amd64.whl", hash = "sha256:d7de3dbbe74109ae598692113cec327fd30c5a30ebca819b21dfa4052f7b08ef"},
+    {file = "orjson-3.9.2-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:8cd4385c59bbc1433cad4a80aca65d2d9039646a9c57f8084897549b55913b17"},
+    {file = "orjson-3.9.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a74036aab1a80c361039290cdbc51aa7adc7ea13f56e5ef94e9be536abd227bd"},
+    {file = "orjson-3.9.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1aaa46d7d4ae55335f635eadc9be0bd9bcf742e6757209fc6dc697e390010adc"},
+    {file = "orjson-3.9.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e52c67ed6bb368083aa2078ea3ccbd9721920b93d4b06c43eb4e20c4c860046"},
+    {file = "orjson-3.9.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a6cdfcf9c7dd4026b2b01fdff56986251dc0cc1e980c690c79eec3ae07b36e7"},
+    {file = "orjson-3.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1882a70bb69595b9ec5aac0040a819e94d2833fe54901e2b32f5e734bc259a8b"},
+    {file = "orjson-3.9.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:fc05e060d452145ab3c0b5420769e7356050ea311fc03cb9d79c481982917cca"},
+    {file = "orjson-3.9.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f8bc2c40d9bb26efefb10949d261a47ca196772c308babc538dd9f4b73e8d386"},
+    {file = "orjson-3.9.2-cp38-none-win_amd64.whl", hash = "sha256:3164fc20a585ec30a9aff33ad5de3b20ce85702b2b2a456852c413e3f0d7ab09"},
+    {file = "orjson-3.9.2-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:7a6ccadf788531595ed4728aa746bc271955448d2460ff0ef8e21eb3f2a281ba"},
+    {file = "orjson-3.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3245d230370f571c945f69aab823c279a868dc877352817e22e551de155cb06c"},
+    {file = "orjson-3.9.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:205925b179550a4ee39b8418dd4c94ad6b777d165d7d22614771c771d44f57bd"},
+    {file = "orjson-3.9.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0325fe2d69512187761f7368c8cda1959bcb75fc56b8e7a884e9569112320e57"},
+    {file = "orjson-3.9.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:806704cd58708acc66a064a9a58e3be25cf1c3f9f159e8757bd3f515bfabdfa1"},
+    {file = "orjson-3.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03fb36f187a0c19ff38f6289418863df8b9b7880cdbe279e920bef3a09d8dab1"},
+    {file = "orjson-3.9.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:20925d07a97c49c6305bff1635318d9fc1804aa4ccacb5fb0deb8a910e57d97a"},
+    {file = "orjson-3.9.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:eebfed53bec5674e981ebe8ed2cf00b3f7bcda62d634733ff779c264307ea505"},
+    {file = "orjson-3.9.2-cp39-none-win_amd64.whl", hash = "sha256:869b961df5fcedf6c79f4096119b35679b63272362e9b745e668f0391a892d39"},
+    {file = "orjson-3.9.2.tar.gz", hash = "sha256:24257c8f641979bf25ecd3e27251b5cc194cdd3a6e96004aac8446f5e63d9664"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -1743,4 +1798,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ff1d14c8d44876d71512c49bacf894c53a6ff9427dc0efedba93ab8c95d5c341"
+content-hash = "6633b75167c600fc814835c249ebc0d0f982c981719f370e6ddbec94c101902e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pydantic-settings = "^2.0.2"
 sqladmin = "^0.13.0"
 itsdangerous = "^2.1.2"
 pygments = "^2.15.1"
+orjson = "^3.9.2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
We launch 300 consecutive `get_character` request, and we observe that ~6% of the whole runtime is spent by deserializing JSON payloads from database (in `models.Json.process_result_value`).

<img width="1541" alt="Screenshot 2023-08-05 at 11 15 32" src="https://github.com/brouberol/5esheets/assets/480131/e1cf83f4-55cf-46d0-b440-f32d401e5f38">

By replacing the stdblib `json` module by [`orjson`](https://github.com/ijl/orjson) (written in rust), we speed up this deserialization step by a 2x factor.

<img width="1536" alt="Screenshot 2023-08-05 at 11 15 10" src="https://github.com/brouberol/5esheets/assets/480131/307920a6-a323-450e-bbce-43f360a55b6c">

I thus replaced all uses of `json` by `orjson` and made `ORJSONReponse` the default `FastAPI` response class.