### PR TITLE
By default, a model's etag is the sha1 of its last update datetime

### DIFF
--- a/dnd5esheets/models.py
+++ b/dnd5esheets/models.py
@@ -102,14 +102,9 @@ class BaseModel(DeclarativeBase):
         return self
 
     def compute_etag(self):
-        """Compute the model instance etag as the sha1 of its json-encoded dict representation"""
+        """Compute the model instance etag as the sha1 of its last update ISO datetime"""
         digest = hashlib.sha1()
-        model_dict = self.as_dict()
-        # default=str allows the encoding of datetimes by first casting them to strings
-        model_json = orjson.dumps(
-            model_dict, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS
-        )
-        digest.update(model_json)
+        digest.update(self.updated_at.isoformat().encode("utf-8"))
         return digest.hexdigest()
 
 


### PR DESCRIPTION
It's much lighter to compute than the hash of the whole model dict to JSON representation.

Calling `GET /api/spell/30` 300 times leads to the following profile.

<img width="1515" alt="Screenshot 2023-08-05 at 17 04 55" src="https://github.com/brouberol/5esheets/assets/480131/7f3126c8-318d-4c64-9bd9-9974cbd7554c">

The new etag computation makes the `handle_model_etag` span completely disappear from the profile.  