### PR TITLE
Hide openapi/docs/redoc pages in production

### DIFF
--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -11,8 +11,14 @@ from .spa import register_spa
 
 
 def create_app() -> ExtendedFastAPI:
+    settings = get_settings()
     app = ExtendedFastAPI(
-        default_response_class=ORJSONResponse, settings=get_settings(), env=get_env()
+        default_response_class=ORJSONResponse,
+        settings=settings,
+        env=get_env(),
+        docs_url=settings.DOCS_URL,
+        redoc_url=settings.REDOC_URL,
+        openapi_url=settings.OPENAPI_URL,
     )
     register_api(app)
     register_middlewares(app)

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -19,3 +19,6 @@ class CommonSettings(BaseSettings):
     FRONTEND_CORS_ORIGIN: str | None = "http://localhost:3000"
 
     PROFILING_ENABLED: bool = False
+    OPENAPI_URL: str | None = "/openapi.json"
+    DOCS_URL: str | None = "/docs"
+    REDOC_URL: str | None = "/redoc"

--- a/dnd5esheets/config/prod.py
+++ b/dnd5esheets/config/prod.py
@@ -1,5 +1,6 @@
-from .base import CommonSettings
 from pydantic_settings import SettingsConfigDict
+
+from .base import CommonSettings
 
 
 class ProdSettings(CommonSettings):
@@ -8,4 +9,7 @@ class ProdSettings(CommonSettings):
     DB_ASYNC_URI: str
     MULTITENANT_ENABLED: bool = True
     FRONTEND_CORS_ORIGIN: str | None = None
+    DOCS_URL: str | None = None
+    REDOC_URL: str | None = None
+    OPENAPI_URL: str | None = None
     model_config = SettingsConfigDict(env_file=".env")


### PR DESCRIPTION
This implements best practice 9 from https://github.com/zhanymkanov/fastapi-best-practices#9-docs