### PR TITLE
Implement a solid logging strategy

### DIFF
--- a/dnd5esheets/app.py
+++ b/dnd5esheets/app.py
@@ -6,6 +6,7 @@ from .api import register_api
 from .config import get_env, get_settings
 from .db import async_engine
 from .exceptions import register_exception_handlers
+from .logs import setup_logging
 from .middlewares import register_middlewares
 from .spa import register_spa
 
@@ -20,6 +21,7 @@ def create_app() -> ExtendedFastAPI:
         redoc_url=settings.REDOC_URL,
         openapi_url=settings.OPENAPI_URL,
     )
+    setup_logging(app)
     register_api(app)
     register_middlewares(app)
     register_exception_handlers(app)

--- a/dnd5esheets/config/base.py
+++ b/dnd5esheets/config/base.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from pathlib import Path
+from typing import Literal
 
 from pydantic_settings import BaseSettings
 
@@ -22,3 +23,6 @@ class CommonSettings(BaseSettings):
     OPENAPI_URL: str | None = "/openapi.json"
     DOCS_URL: str | None = "/docs"
     REDOC_URL: str | None = "/redoc"
+    LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    LOG_FORMAT: Literal["plain", "json"] = "plain"
+    LOG_DEBUG: bool = False

--- a/dnd5esheets/config/prod.py
+++ b/dnd5esheets/config/prod.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic_settings import SettingsConfigDict
 
 from .base import CommonSettings
@@ -13,3 +15,4 @@ class ProdSettings(CommonSettings):
     REDOC_URL: str | None = None
     OPENAPI_URL: str | None = None
     model_config = SettingsConfigDict(env_file=".env")
+    LOG_FORMAT: Literal["plain", "json"] = "json"

--- a/dnd5esheets/logs.py
+++ b/dnd5esheets/logs.py
@@ -1,0 +1,144 @@
+import logging.config
+import sys
+
+import orjson
+import structlog
+
+from . import ExtendedFastAPI
+
+
+def extract_event_dict(_, __, event_dict) -> dict:
+    """If the 'event' value is a JSON-encoded object, extract its key/values into the event itself"""
+    try:
+        event_dict = event_dict | orjson.loads(event_dict["event"])
+    except ValueError:
+        pass
+    else:
+        if "request" in event_dict:
+            event_dict[
+                "event"
+            ] = f"{event_dict['request']['method']} {event_dict['request']['path']}"
+    return event_dict
+
+
+def cleanup_event_dict(_, __, event_dict: dict) -> dict:
+    event_dict.pop("_logger", None)
+    event_dict.pop("_name", None)
+    return event_dict
+
+
+def generate_logging_config(app: ExtendedFastAPI) -> dict:
+    """Return a logging dict configuration for all application loggers"""
+    processors = [
+        # Inject a timestamp in the event
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
+        # Inject the log level in the event
+        structlog.stdlib.add_log_level,
+        # Inject the logger name in the event
+        structlog.stdlib.add_logger_name,
+        # Inject context variables in the event
+        structlog.contextvars.merge_contextvars,
+        # Include key/values added to the log record to the event
+        structlog.stdlib.ExtraAdder(),
+        # Include details about the logging call site
+        structlog.processors.CallsiteParameterAdder(
+            {
+                structlog.processors.CallsiteParameter.PATHNAME,
+                structlog.processors.CallsiteParameter.FILENAME,
+                structlog.processors.CallsiteParameter.LINENO,
+                structlog.processors.CallsiteParameter.MODULE,
+                structlog.processors.CallsiteParameter.FUNC_NAME,
+            }
+        ),
+        # Apply stdlib-like string formatting to the event key
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        # Add stack information with key 'stack' if stack_info is True
+        structlog.processors.StackInfoRenderer(),
+        # Replace an 'exc_info' field with an 'exception' string field using
+        # Python's built-in traceback formatting
+        structlog.processors.format_exc_info,
+    ]
+
+    common_formatter_processors = processors + [
+        extract_event_dict,
+        cleanup_event_dict,
+        #  Remove '_record' and '_from_structlog' from event_dict
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+    ]
+    log_level = getattr(logging, app.settings.LOG_LEVEL)
+    structlog.configure(
+        processors=processors
+        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        # This increases performance by making sure that logging with a level beneath log_level
+        # does nothing at all (return None)
+        wrapper_class=structlog.make_filtering_bound_logger(log_level),
+        cache_logger_on_first_use=True,
+    )
+
+    return {
+        "version": 1,
+        "formatters": {
+            "json": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processors": common_formatter_processors
+                + [
+                    structlog.processors.JSONRenderer(),
+                ],
+                # Processors applied to non-structlog loggers
+                "foreign_pre_chain": processors,
+            },
+            "colored": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processors": common_formatter_processors
+                + [
+                    structlog.dev.ConsoleRenderer(colors=True),
+                ],
+                "foreign_pre_chain": processors,
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": app.settings.LOG_LEVEL,
+                "class": "logging.StreamHandler",
+                "formatter": "json" if app.settings.LOG_FORMAT == "json" else "colored",
+                "stream": sys.stdout,
+            }
+        },
+        "loggers": {
+            "root": {
+                "level": app.settings.LOG_LEVEL,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "level": app.settings.LOG_LEVEL,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "level": app.settings.LOG_LEVEL,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            "uvicorn": {
+                "level": app.settings.LOG_LEVEL,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            "sqlalchemy.engine": {
+                "level": app.settings.LOG_LEVEL
+                if app.settings.SQLALCHEMY_ECHO
+                else logging.WARNING,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+        },
+    }
+
+
+def setup_logging(app: ExtendedFastAPI):
+    """Configure logging for the application"""
+    logging.config.dictConfig(generate_logging_config(app))
+    if app.settings.LOG_DEBUG:
+        __import__("logging_tree").printout()

--- a/dnd5esheets/logs.py
+++ b/dnd5esheets/logs.py
@@ -57,7 +57,6 @@ def generate_logging_config(app: ExtendedFastAPI) -> dict:
         structlog.processors.StackInfoRenderer(),
         # Replace an 'exc_info' field with an 'exception' string field using
         # Python's built-in traceback formatting
-        structlog.processors.format_exc_info,
     ]
 
     common_formatter_processors = processors + [
@@ -84,6 +83,7 @@ def generate_logging_config(app: ExtendedFastAPI) -> dict:
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processors": common_formatter_processors
                 + [
+                    structlog.processors.format_exc_info,
                     structlog.processors.JSONRenderer(),
                 ],
                 # Processors applied to non-structlog loggers
@@ -93,7 +93,9 @@ def generate_logging_config(app: ExtendedFastAPI) -> dict:
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processors": common_formatter_processors
                 + [
-                    structlog.dev.ConsoleRenderer(colors=True),
+                    structlog.dev.ConsoleRenderer(
+                        colors=True, exception_formatter=structlog.dev.rich_traceback
+                    ),
                 ],
                 "foreign_pre_chain": processors,
             },

--- a/dnd5esheets/logs.py
+++ b/dnd5esheets/logs.py
@@ -1,5 +1,6 @@
 import logging.config
 import sys
+from collections.abc import MutableMapping
 
 import orjson
 import structlog
@@ -7,7 +8,7 @@ import structlog
 from . import ExtendedFastAPI
 
 
-def extract_event_dict(_, __, event_dict) -> dict:
+def extract_event_dict(_, __, event_dict: MutableMapping) -> MutableMapping:
     """If the 'event' value is a JSON-encoded object, extract its key/values into the event itself"""
     try:
         event_dict = event_dict | orjson.loads(event_dict["event"])
@@ -21,7 +22,7 @@ def extract_event_dict(_, __, event_dict) -> dict:
     return event_dict
 
 
-def cleanup_event_dict(_, __, event_dict: dict) -> dict:
+def cleanup_event_dict(_, __, event_dict: MutableMapping) -> MutableMapping:
     event_dict.pop("_logger", None)
     event_dict.pop("_name", None)
     return event_dict
@@ -68,7 +69,7 @@ def generate_logging_config(app: ExtendedFastAPI) -> dict:
     log_level = getattr(logging, app.settings.LOG_LEVEL)
     structlog.configure(
         processors=processors
-        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],  # type: ignore
         logger_factory=structlog.stdlib.LoggerFactory(),
         # This increases performance by making sure that logging with a level beneath log_level
         # does nothing at all (return None)

--- a/poetry.lock
+++ b/poetry.lock
@@ -688,6 +688,30 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -744,6 +768,17 @@ files = [
     {file = "MarkupSafe-2.1.3-cp39-cp39-win32.whl", hash = "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"},
     {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
     {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -1332,6 +1367,25 @@ files = [
 ]
 
 [[package]]
+name = "rich"
+version = "13.5.2"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.5.2-py3-none-any.whl", hash = "sha256:146a90b3b6b47cac4a73c12866a499e9817426423f57c5a66949c086191a8808"},
+    {file = "rich-13.5.2.tar.gz", hash = "sha256:fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rsa"
 version = "4.9"
 description = "Pure-Python RSA implementation"
@@ -1812,4 +1866,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "dda711320142053ae37f38cfdcd9ca712a69983241cd9fe7a1107d6d292f5696"
+content-hash = "8745aeb44246aaf58117d19b295a80dd563866d20f6d52745a158f0bbeb9d769"

--- a/poetry.lock
+++ b/poetry.lock
@@ -658,6 +658,17 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "logging-tree"
+version = "1.9"
+description = "Introspect and display the logger tree inside \"logging\""
+optional = false
+python-versions = "*"
+files = [
+    {file = "logging_tree-1.9-py2.py3-none-any.whl", hash = "sha256:1aa4c74f9ae0a86d14bb1d36b2e3066324e22132e6e55200d4ecf009dba4c536"},
+    {file = "logging_tree-1.9.tar.gz", hash = "sha256:fe78b28788c249b515d12a50417e4a96ba095582927b3601a0573886bffc1ff0"},
+]
+
+[[package]]
 name = "mako"
 version = "1.2.4"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -1512,6 +1523,23 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
+name = "structlog"
+version = "23.1.0"
+description = "Structured Logging for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "structlog-23.1.0-py3-none-any.whl", hash = "sha256:79b9e68e48b54e373441e130fa447944e6f87a05b35de23138e475c05d0f7e0e"},
+    {file = "structlog-23.1.0.tar.gz", hash = "sha256:270d681dd7d163c11ba500bc914b2472d2b50a8ef00faa999ded5ff83a2f906b"},
+]
+
+[package.extras]
+dev = ["structlog[docs,tests,typing]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
+tests = ["coverage[toml]", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
+typing = ["mypy", "rich", "twisted"]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
@@ -1784,4 +1812,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3ef8a2f2c6d44f748c0675f060496352616a8d2d5658900ab7df7a2b85f49dff"
+content-hash = "dda711320142053ae37f38cfdcd9ca712a69983241cd9fe7a1107d6d292f5696"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ beautifulsoup4 = "^4.12.2"
 types-python-slugify = "^8.0.0.2"
 pytest-asyncio = "^0.21.1"
 logging-tree = "^1.9"
+rich = "^13.5.2"
 
 [tool.poetry.scripts]
 dnd5esheets-cli = 'dnd5esheets.cli:cli'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ itsdangerous = "^2.1.2"
 pygments = "^2.15.1"
 orjson = "^3.9.2"
 pyinstrument = "^4.5.1"
+structlog = "^23.1.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -35,6 +36,7 @@ httpx = "^0.24.1"
 beautifulsoup4 = "^4.12.2"
 types-python-slugify = "^8.0.0.2"
 pytest-asyncio = "^0.21.1"
+logging-tree = "^1.9"
 
 [tool.poetry.scripts]
 dnd5esheets-cli = 'dnd5esheets.cli:cli'


### PR DESCRIPTION
We allow two main logging strategies:
- logging to the console in a human-readable format
- logging to the console in a machine-readable format (JSON)

We accomplish this using `structlog` and a bit of `logging` elbow grease.

Several development-focused features can be leveraged:
- the `LOG_DEBUG` environment variable can be passed with a value of `true` or `1` to print the configuration of all loggers (app and libraries)
- the `SQLALCHEMY_ECHO` environment variable can be passed with a value of  `true` or `1` to print all SQL requests being sent out to the DB (this pre-existed this PR)
- the `LOG_FORMAT` environment variable can be passed with a value of `json` to have the logs be printed as JSON

To prettify the logs via `jq`, we can use
```
LOG_FORMAT=json make run 2>&1 | grep '{' --line-buffered | jq --unbuffered .
```

### Default logs in dev
<img width="895" alt="Screenshot 2023-08-07 at 14 04 42" src="https://github.com/brouberol/5esheets/assets/480131/0720271b-fe8a-4679-b021-07b1a17adda0">

### JSON logs (default in prod)
<img width="899" alt="Screenshot 2023-08-07 at 14 05 04" src="https://github.com/brouberol/5esheets/assets/480131/01f9904f-16fb-4140-907d-3919b0451016">

### JSON logs prettified by `jq`
<img width="900" alt="Screenshot 2023-08-07 at 14 06 48" src="https://github.com/brouberol/5esheets/assets/480131/ffe4edc2-61c7-42f2-8055-250242450fe3">

### Exceptions are logged
<img width="900" alt="Screenshot 2023-08-07 at 14 07 46" src="https://github.com/brouberol/5esheets/assets/480131/9294974e-f2ef-4bf5-8889-9811d33d6516">

### SQL statements can be logged
<img width="892" alt="Screenshot 2023-08-07 at 14 51 20" src="https://github.com/brouberol/5esheets/assets/480131/2857f992-2315-41e0-b359-9a70342bc9fb">

### Debugging of the logging setup (levels, handlers, formatters, propagation, etc)
<img width="895" alt="Screenshot 2023-08-07 at 15 06 50" src="https://github.com/brouberol/5esheets/assets/480131/c59e6530-21ed-44ed-be15-84c49784f2f2">


Fixes #183 
