### PR TITLE
Replace uvicorn access logs by rich request/response metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ ruff:
 
 run: admin-statics build  ## Run the app
 	@echo  "\n[+] Running the FastApi server"
-	@cd $(app-root) && poetry run uvicorn --factory $(app-root).app:create_app --reload
+	@cd $(app-root) && poetry run uvicorn --factory $(app-root).app:create_app --reload --no-access-log
 
 test:  back-test front-test ## Run the project tests
 

--- a/dnd5esheets/logs.py
+++ b/dnd5esheets/logs.py
@@ -120,7 +120,7 @@ def generate_logging_config(app: ExtendedFastAPI) -> dict:
                 "propagate": False,
             },
             "uvicorn.access": {
-                "level": app.settings.LOG_LEVEL,
+                "level": logging.WARNING,
                 "handlers": ["console"],
                 "propagate": False,
             },

--- a/dnd5esheets/middlewares.py
+++ b/dnd5esheets/middlewares.py
@@ -1,17 +1,144 @@
+import json
+import logging
+import time
 from pathlib import Path
+from typing import Any, Callable
 
-from fastapi import Request
+from fastapi import Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pyinstrument import Profiler
 from pyinstrument.renderers.html import HTMLRenderer
 from pyinstrument.renderers.speedscope import SpeedscopeRenderer
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import Message
+
+from dnd5esheets.config import Env
 
 from . import ExtendedFastAPI
 
 current_dir = Path(__file__).parent
 
 
-def register_middlewares(app: ExtendedFastAPI):
+class RequestResponseLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware in charge of logging the HTTP request and response
+
+    Taken and adapted from https://medium.com/@dhavalsavalia/
+    fastapi-logging-middleware-logging-requests-and-responses-with-ease-and-style-201b9aa4001a
+
+    """
+
+    def __init__(self, app: ExtendedFastAPI) -> None:
+        super().__init__(app)
+        self.logger = logging.getLogger(__name__)
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        logging_dict: dict[str, Any] = {}
+
+        await self.set_body(request)
+        response, response_dict = await self._log_response(call_next, request)
+        request_dict = await self._log_request(request)
+        logging_dict["request"] = request_dict
+        logging_dict["response"] = response_dict
+
+        # self.logger.info(orjson.dumps(logging_dict).decode("utf-8"))
+        self.logger.info(json.dumps(logging_dict))
+        return response
+
+    async def set_body(self, request: Request):
+        """Avails the response body to be logged within a middleware as,
+        it is generally not a standard practice.
+
+           Arguments:
+           - request: Request
+           Returns:
+           - receive_: Receive
+        """
+        receive_ = await request._receive()
+
+        async def receive() -> Message:
+            return receive_
+
+        request._receive = receive
+
+    async def _log_request(self, request: Request) -> dict[str, Any]:
+        """Logs request part
+         Arguments:
+        - request: Request
+
+        """
+
+        path = request.url.path
+        if request.query_params:
+            path += f"?{request.query_params}"
+
+        request_logging = {
+            "method": request.method,
+            "path": path,
+            "ip": request.client.host if request.client is not None else None,
+        }
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = None
+        else:
+            request_logging["body"] = body
+
+        return request_logging
+
+    async def _log_response(
+        self, call_next: Callable, request: Request
+    ) -> tuple[Response, dict[str, Any]]:
+        """Logs response part
+
+        Arguments:
+        - call_next: Callable (To execute the actual path function and get response back)
+        - request: Request
+        - request_id: str (uuid)
+        Returns:
+        - response: Response
+        - response_logging: str
+        """
+
+        start_time = time.perf_counter()
+        response = await self._execute_request(call_next, request)
+        finish_time = time.perf_counter()
+        execution_time = finish_time - start_time
+
+        overall_status = "successful" if response.status_code < 400 else "failed"
+
+        response_logging = {
+            "status": overall_status,
+            "status_code": response.status_code,
+            "time_taken": f"{execution_time:0.4f}s",
+        }
+        return response, response_logging
+
+    async def _execute_request(self, call_next: Callable, request: Request) -> Response:
+        """Executes the actual path function using call_next.
+
+        Arguments:
+        - call_next: Callable (To execute the actual path function
+                     and get response back)
+        - request: Request
+        - request_id: str (uuid)
+        Returns:
+        - response: Response
+        """
+        try:
+            response: Response = await call_next(request)
+
+        except Exception as e:
+            self.logger.exception(
+                {"path": request.url.path, "method": request.method, "reason": e}
+            )
+            raise e
+
+        else:
+            return response
+
+
+def register_cors_middleware(app: ExtendedFastAPI):
     if app.settings.FRONTEND_CORS_ORIGIN is not None:
         app.add_middleware(
             CORSMiddleware,
@@ -20,6 +147,9 @@ def register_middlewares(app: ExtendedFastAPI):
             allow_methods=["*"],
             allow_headers=["*"],
         )
+
+
+def register_profiling_middleware(app: ExtendedFastAPI):
     if app.settings.PROFILING_ENABLED is True:
 
         @app.middleware("http")
@@ -44,3 +174,14 @@ def register_middlewares(app: ExtendedFastAPI):
                 with open(current_dir / f"../profile.{extension}", "w") as out:
                     out.write(profiler.output(renderer=renderer))
             return await call_next(request)
+
+
+def register_request_response_logging_middleware(app: ExtendedFastAPI):
+    if app.env != Env.test:
+        app.add_middleware(RequestResponseLoggingMiddleware)
+
+
+def register_middlewares(app: ExtendedFastAPI):
+    register_cors_middleware(app)
+    register_request_response_logging_middleware(app)
+    register_profiling_middleware(app)

--- a/poetry.lock
+++ b/poetry.lock
@@ -72,6 +72,23 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "asgi-correlation-id"
+version = "4.2.0"
+description = "Middleware correlating project logs to individual requests"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "asgi_correlation_id-4.2.0-py3-none-any.whl", hash = "sha256:bd3321a4022f38179db775d27c40cb45130ac9429d569cd59b5474cb2f65fb1b"},
+    {file = "asgi_correlation_id-4.2.0.tar.gz", hash = "sha256:9d7dcfc2ed016f6e594fffd553788ac70129db7f92bb4dc268ab0b1a3284de5a"},
+]
+
+[package.dependencies]
+starlette = ">=0.18"
+
+[package.extras]
+celery = ["celery"]
+
+[[package]]
 name = "bcrypt"
 version = "4.0.1"
 description = "Modern password hashing for your software and your servers"
@@ -1876,4 +1893,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "380efe2a385c82e8a0714ce7648ccdb4758ac8d0fcbe5f32d0a4c8f8757d8758"
+content-hash = "9efbf776f65df110278d8261f09b7bdb97d34f93e2f24d7f9203a11f667fe381"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pygments = "^2.15.1"
 orjson = "^3.9.3"
 pyinstrument = "^4.5.1"
 structlog = "^23.1.0"
+asgi-correlation-id = "^4.2.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ annotated-types==0.5.0 ; python_version >= "3.8" and python_version < "4.0" \
 anyio==3.7.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780 \
     --hash=sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5
+asgi-correlation-id==4.2.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:9d7dcfc2ed016f6e594fffd553788ac70129db7f92bb4dc268ab0b1a3284de5a \
+    --hash=sha256:bd3321a4022f38179db775d27c40cb45130ac9429d569cd59b5474cb2f65fb1b
 bcrypt==4.0.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535 \
     --hash=sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0 \

--- a/scripts/start-app.sh
+++ b/scripts/start-app.sh
@@ -3,4 +3,4 @@
 set -e
 
 alembic upgrade head
-exec uvicorn --factory dnd5esheets.app:create_app --host "0.0.0.0" --port 8000
+exec uvicorn --factory dnd5esheets.app:create_app --host "0.0.0.0" --port 8000 --no-access-log


### PR DESCRIPTION


This is the kind of log we see now 
```
2023-08-07 14:12:08.838167 [info     ] GET /api/character/douglas-mctrickfoot [dnd5esheets.middlewares] correlation_id=None filename=middlewares.py func_name=dispatch lineno=45 module=middlewares pathname=/Users/br/code/5esheets/dnd5esheets/middlewares.py request={'method': 'GET', 'path': '/api/character/douglas-mctrickfoot', 'ip': '127.0.0.1'} response={'status': 'successful', 'status_code': 200, 'time_taken': '0.0256s'}
```

Fixes #196