### PR TITLE
Inject a unique correlation ID in each log emitted during a request's lifespan

### DIFF
--- a/dnd5esheets/middlewares.py
+++ b/dnd5esheets/middlewares.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pyinstrument import Profiler
@@ -39,6 +40,7 @@ class RequestResponseLoggingMiddleware(BaseHTTPMiddleware):
         request_dict = await self._log_request(request)
         logging_dict["request"] = request_dict
         logging_dict["response"] = response_dict
+        logging_dict["correlation_id"] = request.headers["X-Request-ID"]
 
         # self.logger.info(orjson.dumps(logging_dict).decode("utf-8"))
         self.logger.info(json.dumps(logging_dict))
@@ -181,7 +183,12 @@ def register_request_response_logging_middleware(app: ExtendedFastAPI):
         app.add_middleware(RequestResponseLoggingMiddleware)
 
 
+def register_correlation_id_middleware(app: ExtendedFastAPI):
+    app.add_middleware(CorrelationIdMiddleware)
+
+
 def register_middlewares(app: ExtendedFastAPI):
     register_cors_middleware(app)
+    register_correlation_id_middleware(app)
     register_request_response_logging_middleware(app)
     register_profiling_middleware(app)


### PR DESCRIPTION
This works due to the fact that `CorrelationIdMiddleware` sets a context variable (unique per asynchronous task, cf https://peps.python.org/pep-0567/). We can then fetch its value from the logging processors, and inject it into the event dict.

Example of 2 logs emitted during the same request:

```
2023-08-07 14:54:16.015774 [info     ] Computing etag                         [dnd5esheets.api.character] correlation_id=fb24d107db474ab0ae2be8eb6ad68231 filename=character.py func_name=handle_character_etag lineno=30 module=character pathname=/Users/br/code/5esheets/dnd5esheets/api/character.py
2023-08-07 14:54:16.035390 [info     ] GET /api/character/douglas-mctrickfoot [dnd5esheets.middlewares] correlation_id=fb24d107db474ab0ae2be8eb6ad68231 filename=middlewares.py func_name=dispatch lineno=49 module=middlewares pathname=/Users/br/code/5esheets/dnd5esheets/middlewares.py request={'method': 'GET', 'path': '/api/character/douglas-mctrickfoot', 'ip': '127.0.0.1'} response={'status': 'successful', 'status_code': 200, 'time_taken': '0.0792s'}
```

We see `correlation_id=fb24d107db474ab0ae2be8eb6ad68231` in both, as well as in the HTTP response headers:
```console
~/c/5esheets correlation-id *1 !2 ?1 ❯ curl -v localhost:8000/api/character/douglas-mctrickfoot -v
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api/character/douglas-mctrickfoot HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< date: Mon, 07 Aug 2023 15:08:56 GMT
< server: uvicorn
< content-length: 5489
< content-type: application/json
< etag: ec942323b56a86722183d8cb9300c5517a926990
< x-request-id: fb24d107db474ab0ae2be8eb6ad68231
...
```

Fixes #195