### PR TITLE
Express the spell dc effect calculation with the spell attack bonus value

### DIFF
--- a/dnd5esheets/front/src/store/index.ts
+++ b/dnd5esheets/front/src/store/index.ts
@@ -255,22 +255,22 @@ class CharacterStore {
         ),
       },
 
-      // spell DC effect
-      {
-        name: 'base',
-        priority: 10,
-        ...computeEffect(
-          `spell_dc := 8 + data.abilities[data.spellcasting_ability].modifier + data.proficiency_bonus`,
-          character
-        ),
-      },
-
       // spell attack bonus effect
       {
         name: 'base',
         priority: 10,
         ...computeEffect(
-          `spell_attack_bonus := data.abilities[data.spellcasting_ability].modifier + data.proficiency_bonus`,
+          `data.spell_attack_bonus := data.abilities[data.spellcasting_ability].modifier + data.proficiency_bonus`,
+          character
+        ),
+      },
+
+      // spell DC effect
+      {
+        name: 'base',
+        priority: 10,
+        ...computeEffect(
+          `data.spell_dc := 8 + data.spell_attack_bonus`,
           character
         ),
       },


### PR DESCRIPTION
We see the Spell DC / Spell Attack Bonus values change when Douglas' spellcasting ability (INT) changes.

| INT=18 | INT=13 |
| -- | -- |
|<img width="328" alt="Screenshot 2023-08-09 at 11 16 03" src="https://github.com/brouberol/5esheets/assets/480131/41a34176-9377-493e-a3f5-e07aa2191cd5"> |<img width="335" alt="Screenshot 2023-08-09 at 11 16 09" src="https://github.com/brouberol/5esheets/assets/480131/aaecd40c-1318-41e3-9a2c-96920783bf56"> |

