### PR TITLE
Implement a full text search service for Items using SQLite fts5

### DIFF
--- a/dnd5esheets/api/item.py
+++ b/dnd5esheets/api/item.py
@@ -4,9 +4,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dnd5esheets.db import create_scoped_session
 from dnd5esheets.etag import handle_model_etag
 from dnd5esheets.repositories.item import ItemRepository
-from dnd5esheets.schemas import ItemSchema
+from dnd5esheets.schemas import ItemSchema, SearchResult
 
 item_api = APIRouter(prefix="/item", tags=["item"])
+
+
+@item_api.get("/search", response_model=list[SearchResult])
+async def search_items(
+    search_term: str,
+    favored_language: str | None = None,
+    limit: int = 10,
+    session: AsyncSession = Depends(create_scoped_session),
+):
+    return await ItemRepository.search(
+        session, search_term=search_term, favored_language=favored_language, limit=limit
+    )
 
 
 @item_api.get("/{id}", response_model=ItemSchema)

--- a/dnd5esheets/front/openapi.json
+++ b/dnd5esheets/front/openapi.json
@@ -1073,6 +1073,78 @@
         }
       }
     },
+    "/api/item/search": {
+      "get": {
+        "tags": [
+          "item"
+        ],
+        "summary": "Search Items",
+        "operationId": "search_items",
+        "parameters": [
+          {
+            "name": "search_term",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Search Term"
+            }
+          },
+          {
+            "name": "favored_language",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Favored Language"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResult"
+                  },
+                  "title": "Response Item-Search Items"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/item/{id}": {
       "get": {
         "tags": [
@@ -2508,6 +2580,34 @@
           "data"
         ],
         "title": "RestrictedSpellSchema"
+      },
+      "SearchResult": {
+        "properties": {
+          "rank": {
+            "type": "number",
+            "title": "Rank"
+          },
+          "resource_id": {
+            "type": "integer",
+            "title": "Resource Id"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rank",
+          "resource_id",
+          "language",
+          "name"
+        ],
+        "title": "SearchResult"
       },
       "Skill": {
         "properties": {

--- a/dnd5esheets/front/src/5esheets-client/index.ts
+++ b/dnd5esheets/front/src/5esheets-client/index.ts
@@ -42,6 +42,7 @@ export type { ResourceTranslation } from './models/ResourceTranslation';
 export type { RestrictedKnownSpellSchema } from './models/RestrictedKnownSpellSchema';
 export type { RestrictedSpellData } from './models/RestrictedSpellData';
 export type { RestrictedSpellSchema } from './models/RestrictedSpellSchema';
+export type { SearchResult } from './models/SearchResult';
 export type { Skill } from './models/Skill';
 export type { Skills } from './models/Skills';
 export type { SpellCasting } from './models/SpellCasting';

--- a/dnd5esheets/front/src/5esheets-client/models/SearchResult.ts
+++ b/dnd5esheets/front/src/5esheets-client/models/SearchResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type SearchResult = {
+    rank: number;
+    resource_id: number;
+    language: string;
+    name: string;
+};
+

--- a/dnd5esheets/front/src/5esheets-client/services/ItemService.ts
+++ b/dnd5esheets/front/src/5esheets-client/services/ItemService.ts
@@ -3,12 +3,40 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ItemSchema } from '../models/ItemSchema';
+import type { SearchResult } from '../models/SearchResult';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 
 export class ItemService {
+
+    /**
+     * Search Items
+     * @param searchTerm
+     * @param favoredLanguage
+     * @param limit
+     * @returns SearchResult Successful Response
+     * @throws ApiError
+     */
+    public static searchItems(
+        searchTerm: string,
+        favoredLanguage?: (string | null),
+        limit: number = 10,
+    ): CancelablePromise<Array<SearchResult>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/item/search',
+            query: {
+                'search_term': searchTerm,
+                'favored_language': favoredLanguage,
+                'limit': limit,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
 
     /**
      * Get Item

--- a/dnd5esheets/migrations/versions/623e8558c9ba_add_item_full_text_search_table.py
+++ b/dnd5esheets/migrations/versions/623e8558c9ba_add_item_full_text_search_table.py
@@ -37,15 +37,15 @@ def upgrade() -> None:
                 new.id,
                 'en',
                 new.name,
-                new.json_data ->> '$.meta.description'
+                json_extract(new.json_data, '$.meta.description')
             );
             INSERT INTO item_search_index (rowid, item_id, language, name, description)
                 SELECT
                     cast(hex(json_each.key) as integer) + new.id,
                     new.id,
                     json_each.key,
-                    json_each.value ->> '$.name',
-                    json_each.value ->> '$.description'
+                    json_extract(json_each.value, '$.name'),
+                    json_extract(json_each.value, '$.description')
                 FROM json_each(json_extract(new.json_data, '$.meta.translations'));
         END;
         """,
@@ -57,7 +57,7 @@ def upgrade() -> None:
                 id,
                 'en',
                 name,
-                json_data ->> '$.meta.description'
+                json_extract(json_data, '$.meta.description')
             FROM item;
         """,
         """
@@ -66,8 +66,8 @@ def upgrade() -> None:
                 cast(hex(json_each.key) as integer) + item.id,
                 item.id,
                 json_each.key,
-                json_each.value ->> '$.name',
-                json_each.value ->> '$.description'
+                json_extract(json_each.value, '$.name'),
+                json_extract(json_each.value, '$.description')
             FROM item, json_each(json_extract(item.json_data, '$.meta.translations'));
         """,
         # Every time an item is deleted from DB, delete it from the search index
@@ -90,15 +90,15 @@ def upgrade() -> None:
                 new.id,
                 'en',
                 new.name,
-                new.json_data ->> '$.meta.description'
+                json_extract(new.json_data, '$.meta.description')
             );
             REPLACE INTO item_search_index (rowid, item_id, language, name, description)
                 SELECT
                     cast(hex(json_each.key) as integer) + new.id,
                     new.id,
                     json_each.key,
-                    json_each.value ->> '$.name',
-                    json_each.value ->> '$.description'
+                    json_extract(json_each.value, '$.name'),
+                    json_extract(json_each.value, '$.description')
                 FROM json_each(json_extract(new.json_data, '$.meta.translations'));
         END
         """,

--- a/dnd5esheets/migrations/versions/623e8558c9ba_add_item_full_text_search_table.py
+++ b/dnd5esheets/migrations/versions/623e8558c9ba_add_item_full_text_search_table.py
@@ -1,0 +1,118 @@
+"""add_item_full_text_search_table
+
+Revision ID: 623e8558c9ba
+Revises: a4d56d02c64b
+Create Date: 2023-08-09 15:45:46.542535
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "623e8558c9ba"
+down_revision = "a4d56d02c64b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    ddls = [
+        # Create a full text search index for items
+        """
+        CREATE VIRTUAL TABLE item_search_index USING fts5(
+            item_id UNINDEXED,
+            language UNINDEXED,
+            name,
+            description,
+            tokenize=porter
+        )
+        """,
+        # Every time a new item is created, insert a new row into the item_search_index FTS table,
+        # one for the default english name/description, and one per translated name/description
+        """
+        CREATE TRIGGER item_after_insert
+            AFTER INSERT ON item
+        BEGIN
+            INSERT INTO item_search_index (rowid, item_id, language, name, description) VALUES (
+                cast(hex('en') as integer) + new.id,
+                new.id,
+                'en',
+                new.name,
+                new.json_data ->> '$.meta.description'
+            );
+            INSERT INTO item_search_index (rowid, item_id, language, name, description)
+                SELECT
+                    cast(hex(json_each.key) as integer) + new.id,
+                    new.id,
+                    json_each.key,
+                    json_each.value ->> '$.name',
+                    json_each.value ->> '$.description'
+                FROM json_each(json_extract(new.json_data, '$.meta.translations'));
+        END;
+        """,
+        # Populate the search index with the existing items
+        """
+        INSERT INTO item_search_index (rowid, item_id, language, name, description)
+            SELECT
+                cast(hex('en') as integer) + id,
+                id,
+                'en',
+                name,
+                json_data ->> '$.meta.description'
+            FROM item;
+        """,
+        """
+        INSERT INTO item_search_index (rowid, item_id, language, name, description)
+            SELECT
+                cast(hex(json_each.key) as integer) + item.id,
+                item.id,
+                json_each.key,
+                json_each.value ->> '$.name',
+                json_each.value ->> '$.description'
+            FROM item, json_each(json_extract(item.json_data, '$.meta.translations'));
+        """,
+        # Every time an item is deleted from DB, delete it from the search index
+        """
+        CREATE TRIGGER item_after_delete
+            AFTER DELETE ON item
+        BEGIN
+            DELETE FROM item_search_index WHERE item_id=old.id;
+        END;
+        """,
+        # Every time an item is update in DB, update it in the search index as well
+        """
+        CREATE TRIGGER item_after_update
+            AFTER UPDATE ON item
+            WHEN old.name <> new.name
+                OR old.json_data <> new.json_data
+        BEGIN
+            REPLACE INTO item_search_index (rowid, item_id, language, name, description) VALUES (
+                cast(hex('en') as integer) + new.id,
+                new.id,
+                'en',
+                new.name,
+                new.json_data ->> '$.meta.description'
+            );
+            REPLACE INTO item_search_index (rowid, item_id, language, name, description)
+                SELECT
+                    cast(hex(json_each.key) as integer) + new.id,
+                    new.id,
+                    json_each.key,
+                    json_each.value ->> '$.name',
+                    json_each.value ->> '$.description'
+                FROM json_each(json_extract(new.json_data, '$.meta.translations'));
+        END
+        """,
+    ]
+    for stmt in ddls:
+        op.execute(stmt)
+
+
+def downgrade() -> None:
+    ddls = [
+        "DROP TRIGGER item_after_update",
+        "DROP TRIGGER item_after_delete",
+        "DROP TRIGGER item_after_insert",
+        "DROP TABLE item_search_index",
+    ]
+    for stmt in ddls:
+        op.execute(stmt)

--- a/dnd5esheets/repositories/base.py
+++ b/dnd5esheets/repositories/base.py
@@ -58,16 +58,20 @@ class BaseRepository:
 
     @classmethod
     async def _search(
-        cls, session: AsyncSession, search_term: str, sort_by_rank: bool = True
+        cls,
+        session: AsyncSession,
+        search_term: str,
+        limit: int,
+        sort_by_rank: bool = True,
     ) -> Sequence[Row[Any]]:
         fields = ["rank"] + cls.search_fields
         query = (
             f"SELECT {', '.join(fields)} FROM {cls.search_index_table_name()} "
             f"WHERE {cls.search_index_table_name()} MATCH :search_term "
-            f"{'ORDER BY rank' if sort_by_rank else ''};"
+            f"{'ORDER BY rank' if sort_by_rank else ''} LIMIT :limit;"
         )
         results = await session.execute(
             text(query),
-            {"search_term": search_term},
+            {"search_term": search_term, "limit": limit},
         )
         return results.all()

--- a/dnd5esheets/repositories/item.py
+++ b/dnd5esheets/repositories/item.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-
+from pydantic.dataclasses import dataclass
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.models import Item
@@ -9,10 +8,10 @@ from dnd5esheets.repositories import BaseRepository
 @dataclass
 class ItemSearchResult:
     rank: float
-    item_id: int
+    resource_id: int
     language: str
     name: str
-    description: str
+    description: str | None
 
 
 class ItemRepository(BaseRepository):

--- a/dnd5esheets/repositories/item.py
+++ b/dnd5esheets/repositories/item.py
@@ -1,6 +1,43 @@
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from dnd5esheets.models import Item
 from dnd5esheets.repositories import BaseRepository
 
 
+@dataclass
+class ItemSearchResult:
+    rank: float
+    item_id: int
+    language: str
+    name: str
+    description: str
+
+
 class ItemRepository(BaseRepository):
     model = Item
+    search_fields = ["item_id", "language", "name", "description"]
+
+    @classmethod
+    async def search(
+        cls,
+        session: AsyncSession,
+        search_term: str,
+        favored_language: str | None = None,
+    ) -> list[ItemSearchResult]:
+        results = [
+            ItemSearchResult(*result)
+            for result in await cls._search(session, search_term=search_term)
+        ]
+        if favored_language:
+            results = sorted(
+                results,
+                # The lower the rank, the better the match, so we need to assign a lower weight
+                # to the favored language
+                key=lambda result: (
+                    0 if result.language == favored_language else 1,
+                    result.rank,
+                ),
+            )
+        return results

--- a/dnd5esheets/repositories/item.py
+++ b/dnd5esheets/repositories/item.py
@@ -24,11 +24,14 @@ class ItemRepository(BaseRepository):
         cls,
         session: AsyncSession,
         search_term: str,
+        limit: int = 10,
         favored_language: str | None = None,
     ) -> list[ItemSearchResult]:
         results = [
             ItemSearchResult(*result)
-            for result in await cls._search(session, search_term=search_term)
+            for result in await cls._search(
+                session, search_term=search_term, limit=limit
+            )
         ]
         if favored_language:
             results = sorted(

--- a/dnd5esheets/schemas.py
+++ b/dnd5esheets/schemas.py
@@ -512,5 +512,12 @@ class UpdateCharacterSchema(BaseUpdateSchema):
     )
 
 
+class SearchResult(BaseSchema):
+    rank: float
+    resource_id: int
+    language: str
+    name: str
+
+
 DisplayPlayerSchema.model_rebuild()
 DisplayPartySchema.model_rebuild()

--- a/dnd5esheets/tests/test_api_item.py
+++ b/dnd5esheets/tests/test_api_item.py
@@ -24,3 +24,58 @@ def test_item_schema(client, session):
     for item_id in item_ids:
         resp = client.get(f"/api/item/{item_id}")
         assert resp.status_code == 200, (item_id, resp.status_code)
+
+
+def test_search_item(client):
+    search_results = assert_status_and_return_data(
+        client.get,
+        "/api/item/search",
+        params={"search_term": "name:fleche"},
+        status_code=200,
+    )
+    assert len(search_results) == 1
+    assert sorted(search_results[0].keys()) == [
+        "language",
+        "name",
+        "rank",
+        "resource_id",
+    ]
+    assert search_results[0]["language"] == "fr"
+    assert search_results[0]["name"] == "Flèche"
+    assert search_results[0]["resource_id"] == 1
+
+
+def test_search_item_with_limit(client):
+    search_results = assert_status_and_return_data(
+        client.get,
+        "/api/item/search",
+        params={"search_term": "arm"},
+        status_code=200,
+    )
+    assert len(search_results) == 10
+
+    search_results = assert_status_and_return_data(
+        client.get,
+        "/api/item/search",
+        params={"search_term": "arm", "limit": 5},
+        status_code=200,
+    )
+    assert len(search_results) == 5
+
+
+def test_search_item_with_favored_language(client):
+    search_results = assert_status_and_return_data(
+        client.get,
+        "/api/item/search",
+        params={"search_term": "mail"},
+        status_code=200,
+    )
+    assert search_results[0]["language"] == "en"
+
+    search_results = assert_status_and_return_data(
+        client.get,
+        "/api/item/search",
+        params={"search_term": "mail", "favored_language": "fr"},
+        status_code=200,
+    )
+    assert search_results[0]["language"] == "fr"

--- a/dnd5esheets/tests/test_repository_item.py
+++ b/dnd5esheets/tests/test_repository_item.py
@@ -60,10 +60,20 @@ async def test_trigger_iter_after_update(async_session):
 
 @pytest.mark.asyncio
 async def test_search_item_with_favored_language(async_session):
-    search_results = await ItemRepository.search(async_session, search_term="arm")
-    assert search_results[0].language == "fr"
+    search_results = await ItemRepository.search(async_session, search_term="chain")
+    assert search_results[0].language == "en"
 
-    search_results_favoring_en = await ItemRepository.search(
-        async_session, search_term="arm", favored_language="en"
+    search_results_favoring_fr = await ItemRepository.search(
+        async_session, search_term="arm", favored_language="fr"
     )
-    assert search_results_favoring_en[0].language == "en"
+    assert search_results_favoring_fr[0].language == "fr"
+
+
+@pytest.mark.asyncio
+async def test_search_item_with_limit(async_session):
+    search_results = await ItemRepository.search(async_session, search_term="arrow")
+    assert len(search_results) == 2
+    search_results = await ItemRepository.search(
+        async_session, search_term="arm", limit=1
+    )
+    assert len(search_results) == 1

--- a/dnd5esheets/tests/test_repository_item.py
+++ b/dnd5esheets/tests/test_repository_item.py
@@ -17,8 +17,8 @@ async def test_get_item_by_id(async_session):
 async def test_search_item(async_session):
     search_results = await ItemRepository.search(async_session, search_term="arrow")
     assert len(search_results) == 2
-    result_item_ids = sorted([result.item_id for result in search_results])
-    assert result_item_ids == [1, 2]
+    result_resource_ids = sorted([result.resource_id for result in search_results])
+    assert result_resource_ids == [1, 2]
 
 
 @pytest.mark.asyncio
@@ -28,20 +28,20 @@ async def test_trigger_item_after_delete_and_insert(async_session):
     await async_session.commit()
     search_results = await ItemRepository.search(async_session, search_term="arrow")
     assert len(search_results) == 1
-    result_item_ids = sorted([result.item_id for result in search_results])
-    assert result_item_ids == [2]
+    result_resource_ids = sorted([result.resource_id for result in search_results])
+    assert result_resource_ids == [2]
 
     _populate_base_items(silent=True)  # reinsert all items
     search_results = await ItemRepository.search(async_session, search_term="arrow")
     assert len(search_results) == 2
-    result_item_ids = sorted([result.item_id for result in search_results])
-    assert result_item_ids == [1, 2]
+    result_resource_ids = sorted([result.resource_id for result in search_results])
+    assert result_resource_ids == [1, 2]
 
 
 @pytest.mark.asyncio
 async def test_trigger_iter_after_update(async_session):
     search_results = await ItemRepository.search(async_session, search_term="arrow")
-    arrow_search_result = [res for res in search_results if res.item_id == 1][0]
+    arrow_search_result = [res for res in search_results if res.resource_id == 1][0]
     assert arrow_search_result.description is None
 
     # Add a description to the item
@@ -54,7 +54,7 @@ async def test_trigger_iter_after_update(async_session):
 
     # Make sure the new description was propagated to the search index
     search_results = await ItemRepository.search(async_session, search_term="arrow")
-    arrow_search_result = [res for res in search_results if res.item_id == 1][0]
+    arrow_search_result = [res for res in search_results if res.resource_id == 1][0]
     assert arrow_search_result.description == "A very useful set of arrows"
 
 

--- a/dnd5esheets/tests/test_repository_item.py
+++ b/dnd5esheets/tests/test_repository_item.py
@@ -77,3 +77,19 @@ async def test_search_item_with_limit(async_session):
         async_session, search_term="arm", limit=1
     )
     assert len(search_results) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_item_via_specific_field(async_session):
+    search_results = await ItemRepository.search(
+        async_session, search_term="name:fleche"
+    )
+    assert len(search_results) == 1
+    assert search_results[0].name == "Flèche"
+
+    search_results = await ItemRepository.search(async_session, search_term="fleche")
+    assert len(search_results) == 2
+    assert sorted([r.name for r in search_results]) == [
+        "Arc long",
+        "Flèche",
+    ]

--- a/dnd5esheets/tests/test_repository_item.py
+++ b/dnd5esheets/tests/test_repository_item.py
@@ -1,5 +1,9 @@
+from copy import deepcopy
+
 import pytest
 
+from dnd5esheets.cli import _populate_base_items
+from dnd5esheets.models import Item
 from dnd5esheets.repositories.item import ItemRepository
 
 
@@ -7,3 +11,59 @@ from dnd5esheets.repositories.item import ItemRepository
 async def test_get_item_by_id(async_session):
     spell = await ItemRepository.get_by_id(async_session, id=1)
     assert spell.name == "Arrow"
+
+
+@pytest.mark.asyncio
+async def test_search_item(async_session):
+    search_results = await ItemRepository.search(async_session, search_term="arrow")
+    assert len(search_results) == 2
+    result_item_ids = sorted([result.item_id for result in search_results])
+    assert result_item_ids == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_trigger_item_after_delete_and_insert(async_session):
+    arrow = await async_session.get(Item, 1)
+    await async_session.delete(arrow)
+    await async_session.commit()
+    search_results = await ItemRepository.search(async_session, search_term="arrow")
+    assert len(search_results) == 1
+    result_item_ids = sorted([result.item_id for result in search_results])
+    assert result_item_ids == [2]
+
+    _populate_base_items(silent=True)  # reinsert all items
+    search_results = await ItemRepository.search(async_session, search_term="arrow")
+    assert len(search_results) == 2
+    result_item_ids = sorted([result.item_id for result in search_results])
+    assert result_item_ids == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_trigger_iter_after_update(async_session):
+    search_results = await ItemRepository.search(async_session, search_term="arrow")
+    arrow_search_result = [res for res in search_results if res.item_id == 1][0]
+    assert arrow_search_result.description is None
+
+    # Add a description to the item
+    arrow = await async_session.get(Item, 1)
+    data = deepcopy(arrow.data)
+    data["meta"]["description"] = "A very useful set of arrows"
+    arrow.data = data
+    async_session.add(arrow)
+    await async_session.commit()
+
+    # Make sure the new description was propagated to the search index
+    search_results = await ItemRepository.search(async_session, search_term="arrow")
+    arrow_search_result = [res for res in search_results if res.item_id == 1][0]
+    assert arrow_search_result.description == "A very useful set of arrows"
+
+
+@pytest.mark.asyncio
+async def test_search_item_with_favored_language(async_session):
+    search_results = await ItemRepository.search(async_session, search_term="arm")
+    assert search_results[0].language == "fr"
+
+    search_results_favoring_en = await ItemRepository.search(
+        async_session, search_term="arm", favored_language="en"
+    )
+    assert search_results_favoring_en[0].language == "en"


### PR DESCRIPTION
The way this works is by defining an SQLite search index table and relying on triggers to keep the search index in sync with the actual `item` table.

Every time an `Item` is inserted to, deleted from, or updated in the `item` table, a trigger is executed to mirror the changes into the `item_search_index` virtual table.
This way, the search index is always up-to-date.

We also introduce a way to favor result of a given language, to make sure to surface the results in the player's locale/language first.
