### PR TITLE
Fix: if the whole ability score is deleted, don't insert NaN in the label

### DIFF
--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -215,12 +215,9 @@ export default function CharacterSheet(props: {
                         props.character.data.abilities[ability].modifier
                       }
                       onChange={(score: number) => {
-                        if (Number.isNaN(score)) {
-                          score = 0
-                        }
                         props.updateCharacter(
                           (character) =>
-                            (character.data.abilities[ability].score = score)
+                            (character.data.abilities[ability].score = Number.isNaN(score) ? 0 : score)
                         )
                       }}
                     />

--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -217,7 +217,8 @@ export default function CharacterSheet(props: {
                       onChange={(score: number) => {
                         props.updateCharacter(
                           (character) =>
-                            (character.data.abilities[ability].score = Number.isNaN(score) ? 0 : score)
+                            (character.data.abilities[ability].score =
+                              Number.isNaN(score) ? 0 : score)
                         )
                       }}
                     />

--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -214,12 +214,15 @@ export default function CharacterSheet(props: {
                       modifier={
                         props.character.data.abilities[ability].modifier
                       }
-                      onChange={(score: number) =>
+                      onChange={(score: number) => {
+                        if (Number.isNaN(score)) {
+                          score = 0
+                        }
                         props.updateCharacter(
                           (character) =>
                             (character.data.abilities[ability].score = score)
                         )
-                      }
+                      }}
                     />
                   )}
                 </For>


### PR DESCRIPTION
Once the `NaN` appears in the label, we can't delete it and can't overwrite it.

https://github.com/brouberol/5esheets/assets/480131/61777629-217c-4e44-81e7-a39c7d442dad 

https://github.com/brouberol/5esheets/assets/480131/29fb2b6c-7622-44e5-a448-a5b464855b4d






