### PR TITLE
Protect API resources with security policies when multitenancy is enabled

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,7 +24,7 @@ i18n:
   - dnd5esheets/front/src/i18n/**
 
 security:
-  - dnd5esheets/security/*.py
+  - dnd5esheets/security/**.py
 
 ci:
   - .github/**

--- a/dnd5esheets/admin/admin.py
+++ b/dnd5esheets/admin/admin.py
@@ -73,7 +73,7 @@ class CustomModelView(ModelView):
             col
             for col in dir(self.model)
             if not col.startswith("_")
-            if not col in self.details_property_exclude_list
+            if col not in self.details_property_exclude_list
             if hasattr(getattr(self.model, col), "fset")
         ]
         self._prop_names += property_details_list

--- a/dnd5esheets/api/character.py
+++ b/dnd5esheets/api/character.py
@@ -11,7 +11,7 @@ from dnd5esheets.schemas import (
     ListCharacterSchema,
     UpdateCharacterSchema,
 )
-from dnd5esheets.security.policies import in_same_party, party_gm_or_owner
+from dnd5esheets.security.policies.character import in_same_party, party_gm_or_owner
 from dnd5esheets.security.user import get_current_user_id
 
 character_api = APIRouter(prefix="/character", tags=["character"])

--- a/dnd5esheets/api/character.py
+++ b/dnd5esheets/api/character.py
@@ -11,6 +11,7 @@ from dnd5esheets.schemas import (
     ListCharacterSchema,
     UpdateCharacterSchema,
 )
+from dnd5esheets.security.policies import in_same_party, party_gm_or_owner
 from dnd5esheets.security.user import get_current_user_id
 
 character_api = APIRouter(prefix="/character", tags=["character"])
@@ -47,6 +48,7 @@ async def list_characters(
 
 @character_api.get(
     "/{slug}",
+    dependencies=[Depends(in_same_party)],
     response_model=CharacterSchema,
 )
 async def get_character(
@@ -58,17 +60,14 @@ async def get_character(
 ):
     """Returns all details of a given character."""
     await handle_character_etag(session, slug, current_player_id, request, response)
-    return await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
+    return await CharacterRepository.get_by_slug(session, slug=slug)
 
 
-@character_api.put("/{slug}")
+@character_api.put("/{slug}", dependencies=[Depends(party_gm_or_owner)])
 async def update_character(
     slug: str,
     character_data: UpdateCharacterSchema,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Update a character details.
 
@@ -82,9 +81,6 @@ async def update_character(
     as well as an attribute nested in the character JSON data.
 
     """
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.update(session, slug, character_data)
     return {"status": "ok"}
 
@@ -101,178 +97,154 @@ async def create_character(
     )
 
 
-@character_api.delete("/{slug}")
+@character_api.delete("/{slug}", dependencies=[Depends(party_gm_or_owner)])
 async def delete_character(
     slug: str,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ):
     """Delete the character associated with the slug and the currently logged in player id"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
-    await CharacterRepository.delete(session, slug=slug, owner_id=current_player_id)
+    await CharacterRepository.delete(session, slug=slug)
     return Response(status_code=HTTP_204_NO_CONTENT)
 
 
-@character_api.put("/{slug}/equipment/{item_id}")
+@character_api.put(
+    "/{slug}/equipment/{item_id}", dependencies=[Depends(party_gm_or_owner)]
+)
 async def add_item_to_equipment(
     slug: str,
     item_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Ensure the argument item is present in the character's equipment"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.add_item_to_equipment(
         session,
         slug=slug,
-        owner_id=current_player_id,
         item_id=item_id,
     )
     return {"status": "ok"}
 
 
-@character_api.delete("/{slug}/equipment/{equipped_item_id}")
+@character_api.delete(
+    "/{slug}/equipment/{equipped_item_id}", dependencies=[Depends(party_gm_or_owner)]
+)
 async def remove_item_from_equipment(
     slug: str,
     equipped_item_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Ensure the argument item is absent from the character's equipment"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.remove_item_from_equipment(
         session,
         slug=slug,
-        owner_id=current_player_id,
         equipped_item_id=equipped_item_id,
     )
     return {"status": "ok"}
 
 
-@character_api.put("/{slug}/equipment/{equipped_item_id}/equip")
+@character_api.put(
+    "/{slug}/equipment/{equipped_item_id}/equip",
+    dependencies=[Depends(party_gm_or_owner)],
+)
 async def equip_item(
     slug: str,
     equipped_item_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Set the argument equipped item as equipped"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.change_equipment_item_equipped_status(
         session,
         slug=slug,
-        owner_id=current_player_id,
         equipped_item_id=equipped_item_id,
         equipped=True,
     )
     return {"status": "ok"}
 
 
-@character_api.put("/{slug}/equipment/{equipped_item_id}/unequip")
+@character_api.put(
+    "/{slug}/equipment/{equipped_item_id}/unequip",
+    dependencies=[Depends(party_gm_or_owner)],
+)
 async def unequip_item(
     slug: str,
     equipped_item_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Set the argument equipped item as unequipped"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.change_equipment_item_equipped_status(
         session,
         slug=slug,
-        owner_id=current_player_id,
         equipped_item_id=equipped_item_id,
         equipped=False,
     )
     return {"status": "ok"}
 
 
-@character_api.put("/{slug}/spellbook/{spell_id}")
+@character_api.put(
+    "/{slug}/spellbook/{spell_id}", dependencies=[Depends(party_gm_or_owner)]
+)
 async def learn_spell(
     slug: str,
     spell_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Ensure the argument spell is added to the character's spellbook"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.learn_spell(
         session,
         slug=slug,
-        owner_id=current_player_id,
         spell_id=spell_id,
     )
     return {"status": "ok"}
 
 
-@character_api.delete("/{slug}/spellbook/{known_spell_id}")
+@character_api.delete(
+    "/{slug}/spellbook/{known_spell_id}", dependencies=[Depends(party_gm_or_owner)]
+)
 async def forget_spell(
     slug: str,
     known_spell_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Ensure the argument known spell is absent from the character's spellbook"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.forget_spell(
         session,
         slug=slug,
-        owner_id=current_player_id,
         known_spell_id=known_spell_id,
     )
     return {"status": "ok"}
 
 
-@character_api.put("/{slug}/spellbook/{known_spell_id}/prepare")
+@character_api.put(
+    "/{slug}/spellbook/{known_spell_id}/prepare",
+    dependencies=[Depends(party_gm_or_owner)],
+)
 async def prepare_spell(
     slug: str,
     known_spell_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Set the argument known spell as prepared"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.change_known_spell_prepared_status(
         session,
         slug=slug,
-        owner_id=current_player_id,
         known_spell_id=known_spell_id,
         prepared=True,
     )
     return {"status": "ok"}
 
 
-@character_api.put("/{slug}/spellbook/{known_spell_id}/unprepare")
+@character_api.put(
+    "/{slug}/spellbook/{known_spell_id}/unprepare",
+    dependencies=[Depends(party_gm_or_owner)],
+)
 async def unprepare_spell(
     slug: str,
     known_spell_id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Set the argument known spell as unprepared"""
-    await CharacterRepository.get_by_slug_if_owned(
-        session, slug=slug, owner_id=current_player_id
-    )
     await CharacterRepository.change_known_spell_prepared_status(
         session,
         slug=slug,
-        owner_id=current_player_id,
         known_spell_id=known_spell_id,
         prepared=False,
     )

--- a/dnd5esheets/api/player.py
+++ b/dnd5esheets/api/player.py
@@ -1,32 +1,30 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.db import create_scoped_session
 from dnd5esheets.repositories.player import PlayerRepository
 from dnd5esheets.schemas import DisplayPlayerSchema, UpdatePlayerSchema
-from dnd5esheets.security.user import get_current_user_id
+from dnd5esheets.security.policies.player import is_owner
 
 player_api = APIRouter(prefix="/player", tags=["player"])
 
 
-@player_api.get("/{id}", response_model=DisplayPlayerSchema)
+@player_api.get(
+    "/{id}", dependencies=[Depends(is_owner)], response_model=DisplayPlayerSchema
+)
 async def display_player(
     id: int,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ):
     """Display all details of a given player."""
-    if current_player_id and id != current_player_id:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     return await PlayerRepository.get_by_id(session, id=id)
 
 
-@player_api.put("/{id}")
+@player_api.put("/{id}", dependencies=[Depends(is_owner)])
 async def update_player(
     id: int,
     player_data: UpdatePlayerSchema,
     session: AsyncSession = Depends(create_scoped_session),
-    current_player_id: int | None = Depends(get_current_user_id),
 ) -> dict:
     """Update a player details.
 
@@ -34,7 +32,5 @@ async def update_player(
 
 
     """
-    if current_player_id and id != current_player_id:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     await PlayerRepository.update(session, id, player_data)
     return {"status": "ok"}

--- a/dnd5esheets/cli.py
+++ b/dnd5esheets/cli.py
@@ -80,21 +80,25 @@ def _populate_db_with_dev_data(silent: bool = False):
         longsword = session.execute(
             select(Item).filter(Item.name == "Longsword")
         ).scalar()
-        spells = session.execute(
-            select(Spell).filter(
-                Spell.name.in_(
-                    (
-                        "Mending",
-                        "Fire Bolt",
-                        "Thunderwave",
-                        "Shield",
-                        "Detect Magic",
-                        "Catapult",
-                        "Absorb Elements",
+        spells = (
+            session.execute(
+                select(Spell).filter(
+                    Spell.name.in_(
+                        (
+                            "Mending",
+                            "Fire Bolt",
+                            "Thunderwave",
+                            "Shield",
+                            "Detect Magic",
+                            "Catapult",
+                            "Absorb Elements",
+                        )
                     )
                 )
             )
-        ).scalars()
+            .scalars()
+            .all()
+        )
 
         for player_attrs in dev_fixtures["players"]:
             player = Player(**player_attrs)
@@ -121,7 +125,13 @@ def _populate_db_with_dev_data(silent: bool = False):
                     EquippedItem(item_id=longsword.id, id=character_attrs["id"])
                 ],
                 spellbook=[
-                    KnownSpell(spell_id=spell.id, prepared=True) for spell in spells
+                    KnownSpell(
+                        id=i + len(spells) * character_attrs["id"],
+                        spell_id=spell.id,
+                        character_id=character_attrs["id"],
+                        prepared=True,
+                    )
+                    for i, spell in enumerate(spells, 1)
                 ],
             )
             session.merge(character)

--- a/dnd5esheets/db/fixtures/dev.json
+++ b/dnd5esheets/db/fixtures/dev.json
@@ -24,6 +24,12 @@
       "name": "Marine",
       "email": "ml@test.com",
       "hashed_password": "$2b$12$JoYFBGO5rjhS5YS2sWF0eOYfWN1b1rHT/x0Yy1ukTaYHVOQHC2bUq"
+    },
+    {
+      "id": "5",
+      "name": "Nicolas",
+      "email": "ne@test.com",
+      "hashed_password": "$2b$12$M4blXQox9LreJsunS2MrWOVyT9O0F4r7oQzwg2JiIcxfdY/MtCOV."
     }
   ],
   "player_roles": [
@@ -50,6 +56,18 @@
       "player_id": 4,
       "party_id": 1,
       "role": "player"
+    },
+    {
+      "id": 5,
+      "player_id": 5,
+      "party_id": 2,
+      "role": "player"
+    },
+    {
+      "id": 6,
+      "player_id": 2,
+      "party_id": 2,
+      "role": "gm"
     }
   ],
   "parties": [
@@ -257,7 +275,183 @@
       "slug": "trevor-mctrickfoot",
       "class_": "Soulknife",
       "level": 4,
-      "data": {}
+      "data": {
+        "abilities": {
+          "strength": {
+            "score": 8,
+            "proficiency": 0,
+            "save": 0,
+            "modifier": 0
+          },
+          "dexterity": {
+            "score": 14,
+            "proficiency": 0,
+            "save": 0,
+            "modifier": 0
+          },
+          "constitution": {
+            "score": 12,
+            "proficiency": 0,
+            "save": 0,
+            "modifier": 0
+          },
+          "intelligence": {
+            "score": 18,
+            "proficiency": 0,
+            "save": 0,
+            "modifier": 0
+          },
+          "wisdom": {
+            "score": 12,
+            "proficiency": 0,
+            "save": 0,
+            "modifier": 0
+          },
+          "charisma": {
+            "score": 14,
+            "proficiency": 0,
+            "save": 0,
+            "modifier": 0
+          }
+        },
+        "skills": {
+          "acrobatics": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "arcana": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "athletics": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "stealth": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "animal_handling": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "sleight_of_hand": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "history": {
+            "proficiency": 1,
+            "modifier": 0
+          },
+          "intimidation": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "investigation": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "medicine": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "nature": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "perception": {
+            "proficiency": 1,
+            "modifier": 0
+          },
+          "insight": {
+            "proficiency": 1,
+            "modifier": 0
+          },
+          "persuasion": {
+            "proficiency": 1,
+            "modifier": 0
+          },
+          "religion": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "performance": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "survival": {
+            "proficiency": 0,
+            "modifier": 0
+          },
+          "deception": {
+            "proficiency": 0,
+            "modifier": 0
+          }
+        },
+        "xp": 0,
+        "background": "Artistan",
+        "race": "Gnome",
+        "alignment": "Chaotique Bon",
+        "darkvision": true,
+        "inspiration": true,
+        "languages_and_proficiencies": "**Outils**\r\n- menuisier\r\n- souffleur de verre\r\n- bricolage\r\n- voleur\r\n- forgeron\r\n\r\n**Langues**\r\n- Nain\r\n- Gnome\r\n- Commun\r\n\r\n**Armes**\r\n- légères",
+        "speed": 25,
+        "hp": {
+          "max": 33,
+          "temp": 0,
+          "current": 33
+        },
+        "hit_dice": {
+          "type": "1d8",
+          "total": 4,
+          "remaining": 4
+        },
+        "custom_resources": [
+          {
+            "header": "Infusions",
+            "remaining": 3,
+            "available": 3
+          },
+          {
+            "header": "Canon",
+            "remaining": 3,
+            "available": 3
+          },
+          {
+            "header": "Baguette des secrets",
+            "remaining": 3,
+            "available": 3
+          }
+        ],
+        "attacks": [
+          {
+            "name": "Arbalète légère",
+            "damage": "1d8+2",
+            "bonus": 4,
+            "damage_type": "piercing"
+          },
+          {
+            "name": "Hache à une main",
+            "damage": "1d6+2",
+            "bonus": 4,
+            "damage_type": "slashing"
+          }
+        ],
+        "money": {
+          "copper": 0,
+          "silver": 0,
+          "electrum": 0,
+          "gold": 1,
+          "platinum": 0
+        },
+        "personality": "Douglas est astucieux et fait preuve d'une répartie rapide. Il est fidèle envers ses amis et curieux d'apprendre des nouveaux sujets.",
+        "ideals": "Douglas rêve de maîtriser la magie à la seule force de son intellect.",
+        "bonds": "Douglas est particulièrement fidèle envers les membres de sa famille, et se sent responsable de Crounch.",
+        "flaws": "Douglas est impulsif. Son besoin de paraître intelligent cache un manque de confiance en soi. ",
+        "features": "**Bricolage**\r\n- 1h pour bricoler 1 objet\r\n- jusqu'à 3 objets \r\n  * boîte à musique\r\n  * jouet mécanique en bois\r\n  * allume feu\r\n\r\n**Bricolage magique**\r\n- sur objet minuscule\r\n- jusqu'à 3\r\n  * peut jouer un message enregistré\r\n  * peut jouer un son continu\r\n\r\n**Infusions**\r\n- 4 connues\r\n- jusqu'à 3 objets en même temps\r\n- dure 3 jours\r\n\r\n**Right tool**\r\n1h pour crafter des objets d'artisan\r\n\r\n**Canon occulte**\r\n- 1 action pour invoquer/faire disparaître\r\n- 1 action bonus pour utiliser\r\n * lance-flamme: 🔺 DEX save ? 2d8 🔥 : 1/2\r\n * baliste: 🏹 40m. 2d8 💪 + 1.5m recul\r\n * protecteur: 3m ⭕, 1d8@int_mod temp HP",
+        "daily_prepared_spells": 6,
+        "spellcasting_ability": "intelligence"
+      }
     },
     {
       "id": 3,
@@ -276,6 +470,26 @@
       "name": "Crounch McTrickfoot",
       "slug": "crounch-mctrickfoot",
       "class_": "Barbare - Voie du Zélote",
+      "level": 4,
+      "data": {}
+    },
+    {
+      "id": 5,
+      "player_id": 5,
+      "party_id": 2,
+      "name": "Groumph",
+      "slug": "groumph",
+      "class_": "Clerc de la Paix",
+      "level": 4,
+      "data": {}
+    },
+    {
+      "id": 6,
+      "player_id": 2,
+      "party_id": 2,
+      "name": "Thirai",
+      "slug": "thirai",
+      "class_": "Mage du Savoir",
       "level": 4,
       "data": {}
     }

--- a/dnd5esheets/front/openapi.json
+++ b/dnd5esheets/front/openapi.json
@@ -775,7 +775,7 @@
           "party"
         ],
         "summary": "Display Party",
-        "description": "Display all details of a given party.",
+        "description": "Display details of a given party",
         "operationId": "display_party",
         "security": [
           {

--- a/dnd5esheets/front/src/5esheets-client/services/PartyService.ts
+++ b/dnd5esheets/front/src/5esheets-client/services/PartyService.ts
@@ -27,7 +27,7 @@ export class PartyService {
 
     /**
      * Display Party
-     * Display all details of a given party.
+     * Display details of a given party
      * @param id
      * @returns DisplayPartySchema Successful Response
      * @throws ApiError

--- a/dnd5esheets/repositories/character.py
+++ b/dnd5esheets/repositories/character.py
@@ -167,9 +167,9 @@ class CharacterRepository(BaseRepository):
         return digest.hexdigest()
 
     @classmethod
-    async def delete(cls, session: AsyncSession, slug: str, owner_id: int | None):
+    async def delete(cls, session: AsyncSession, slug: str):
         """Delete the character identified by the argument slug"""
-        character = await cls.get_by_slug(session, slug=slug, owner_id=owner_id)
+        character = await cls.get_by_slug(session, slug=slug)
         await session.delete(character)
         await session.commit()
 
@@ -178,16 +178,13 @@ class CharacterRepository(BaseRepository):
         cls,
         session: AsyncSession,
         slug: str,
-        owner_id: int | None,
         equipped_item_id: int,
         equipped: bool,
     ):
         """Change the equipped status of the argument equipped item in the character's equipment"""
-        character = await cls.get_by_slug_if_owned(
-            session, slug=slug, owner_id=owner_id
-        )
+        character = await cls.get_by_slug(session, slug=slug)
         await EquippedItemRepository.change_equipped_status(
-            session, id=equipped_item_id, owner_id=character.id, equipped=equipped
+            session, id=equipped_item_id, equipped=equipped
         )
         await session.refresh(character)
         return character
@@ -197,16 +194,13 @@ class CharacterRepository(BaseRepository):
         cls,
         session: AsyncSession,
         slug: str,
-        owner_id: int | None,
         known_spell_id: int,
         prepared: bool,
     ):
         """Change the prepared status of the argument known spell in the character's spellbook"""
-        character = await cls.get_by_slug_if_owned(
-            session, slug=slug, owner_id=owner_id
-        )
+        character = await cls.get_by_slug(session, slug=slug)
         await KnownSpellRepository.change_prepared_status(
-            session, id=known_spell_id, owner_id=character.id, prepared=prepared
+            session, id=known_spell_id, prepared=prepared
         )
         await session.refresh(character)
         return character
@@ -216,14 +210,11 @@ class CharacterRepository(BaseRepository):
         cls,
         session: AsyncSession,
         slug: str,
-        owner_id: int | None,
         spell_id: int,
         prepared: bool = False,
     ):
         """Ensure a given spell is present in the character's spellbook"""
-        character = await cls.get_by_slug_if_owned(
-            session, slug=slug, owner_id=owner_id
-        )
+        character = await cls.get_by_slug(session, slug=slug)
         for known_spell in character.spellbook:
             if known_spell.spell_id == spell_id:
                 return character
@@ -244,13 +235,10 @@ class CharacterRepository(BaseRepository):
         cls,
         session: AsyncSession,
         slug: str,
-        owner_id: int | None,
         known_spell_id: int,
     ):
         """Ensure a given spell is absent from the character's spellbook"""
-        character = await cls.get_by_slug_if_owned(
-            session, slug=slug, owner_id=owner_id
-        )
+        character = await cls.get_by_slug(session, slug=slug)
         await KnownSpellRepository.delete_by_id(session, id=known_spell_id)
         await session.refresh(character)
         return character
@@ -260,14 +248,11 @@ class CharacterRepository(BaseRepository):
         cls,
         session: AsyncSession,
         slug: str,
-        owner_id: int | None,
         item_id: int,
         amount: int = 1,
     ):
         """Ensure a given item is present in the character's equipment"""
-        character = await cls.get_by_slug_if_owned(
-            session, slug=slug, owner_id=owner_id
-        )
+        character = await cls.get_by_slug(session, slug=slug)
         for equipped_item in character.equipment:
             if equipped_item.item_id == item_id:
                 return character
@@ -288,13 +273,10 @@ class CharacterRepository(BaseRepository):
         cls,
         session: AsyncSession,
         slug: str,
-        owner_id: int | None,
         equipped_item_id: int,
     ):
         """Ensure a given item is absent from the character's equipment"""
-        character = await cls.get_by_slug_if_owned(
-            session, slug=slug, owner_id=owner_id
-        )
+        character = await cls.get_by_slug(session, slug=slug)
         await EquippedItemRepository.delete_by_id(session, id=equipped_item_id)
         await session.refresh(character)
         return character

--- a/dnd5esheets/repositories/equipped_item.py
+++ b/dnd5esheets/repositories/equipped_item.py
@@ -24,7 +24,7 @@ class EquippedItemRepository(BaseRepository):
     async def change_equipped_status(
         cls, session: AsyncSession, id: int, equipped: bool
     ):
-        equipped_item = await cls.get_by_id(session, id=id)
+        equipped_item = cast(EquippedItem, await cls.get_by_id(session, id=id))
         equipped_item.equipped = equipped
         session.add(equipped_item)
         await session.commit()

--- a/dnd5esheets/repositories/equipped_item.py
+++ b/dnd5esheets/repositories/equipped_item.py
@@ -22,9 +22,9 @@ class EquippedItemRepository(BaseRepository):
 
     @classmethod
     async def change_equipped_status(
-        cls, session: AsyncSession, id: int, owner_id: int, equipped: bool
+        cls, session: AsyncSession, id: int, equipped: bool
     ):
-        equipped_item = await cls.get_by_id_if_owned(session, id=id, owner_id=owner_id)
+        equipped_item = await cls.get_by_id(session, id=id)
         equipped_item.equipped = equipped
         session.add(equipped_item)
         await session.commit()

--- a/dnd5esheets/repositories/known_spell.py
+++ b/dnd5esheets/repositories/known_spell.py
@@ -22,9 +22,9 @@ class KnownSpellRepository(BaseRepository):
 
     @classmethod
     async def change_prepared_status(
-        cls, session: AsyncSession, id: int, owner_id: int, prepared: bool
+        cls, session: AsyncSession, id: int, prepared: bool
     ):
-        known_spell = await cls.get_by_id_if_owned(session, id=id, owner_id=owner_id)
+        known_spell = await cls.get_by_id(session, id=id)
         known_spell.prepared = prepared
         session.add(known_spell)
         await session.commit()

--- a/dnd5esheets/repositories/known_spell.py
+++ b/dnd5esheets/repositories/known_spell.py
@@ -24,7 +24,7 @@ class KnownSpellRepository(BaseRepository):
     async def change_prepared_status(
         cls, session: AsyncSession, id: int, prepared: bool
     ):
-        known_spell = await cls.get_by_id(session, id=id)
+        known_spell = cast(KnownSpell, await cls.get_by_id(session, id=id))
         known_spell.prepared = prepared
         session.add(known_spell)
         await session.commit()

--- a/dnd5esheets/repositories/party.py
+++ b/dnd5esheets/repositories/party.py
@@ -26,25 +26,6 @@ class PartyRepository(BaseRepository):
         return result.scalars().all()
 
     @classmethod
-    async def get_by_id_if_member_of(
-        cls, session: AsyncSession, id: int, member_id: int | None
-    ) -> Party:
-        """Return a Party given an argument id if it is owned by the argument player id"""
-        query = (
-            select(Party)
-            .join(
-                Character, Party.members, isouter=True
-            )  # we use outer joins because we want to be able to display a group with no members
-            .join(Player, Character.player, isouter=True)
-            .filter(Party.id == id)
-            .group_by(Party.id)
-        )
-        if member_id is not None:
-            query = query.filter(Player.id == member_id)
-        result = await session.execute(query)
-        return cast(Party, cls.one_or_raise_model_not_found(result))
-
-    @classmethod
     async def update(
         cls,
         session: AsyncSession,

--- a/dnd5esheets/repositories/party.py
+++ b/dnd5esheets/repositories/party.py
@@ -45,16 +45,13 @@ class PartyRepository(BaseRepository):
         return cast(Party, cls.one_or_raise_model_not_found(result))
 
     @classmethod
-    async def update_if_member_of(
+    async def update(
         cls,
         session: AsyncSession,
         id: int,
         body: UpdatePartySchema,
-        member_id: int | None,
     ) -> Party:
-        party = await cls.get_by_id_if_member_of(
-            session=session, id=id, member_id=member_id
-        )
+        party = await cls.get_by_id(session=session, id=id)
 
         # Any non-nil field should be taken as the new value
         fields_to_update = {

--- a/dnd5esheets/repositories/party.py
+++ b/dnd5esheets/repositories/party.py
@@ -46,4 +46,4 @@ class PartyRepository(BaseRepository):
         await session.commit()
         await session.refresh(party)
 
-        return party
+        return cast(Party, party)

--- a/dnd5esheets/repositories/player.py
+++ b/dnd5esheets/repositories/player.py
@@ -56,3 +56,22 @@ class PlayerRepository(BaseRepository):
                 .filter(Player.id == player_id, Party.id == party_id)
             )
         )
+
+    @classmethod
+    async def get_all_players_with_characters_in_same_party_than_character(
+        cls, session: AsyncSession, character_slug: str
+    ) -> list[Player]:
+        party_subquery = (
+            select(Party.id)
+            .join(Character)
+            .join(Player)
+            .filter(Character.slug == character_slug)
+        )
+        query = (
+            select(Player)
+            .join(Character)
+            .join(Party)
+            .filter(Party.id.in_(party_subquery))
+        )
+        result = await session.execute(query)
+        return result.scalars().all()

--- a/dnd5esheets/repositories/player.py
+++ b/dnd5esheets/repositories/player.py
@@ -61,6 +61,7 @@ class PlayerRepository(BaseRepository):
     async def get_all_players_with_characters_in_same_party_than_character(
         cls, session: AsyncSession, character_slug: str
     ) -> list[Player]:
+        """Return all players belonging to the same party than the argument character"""
         party_subquery = (
             select(Party.id)
             .join(Character)
@@ -73,5 +74,16 @@ class PlayerRepository(BaseRepository):
             .join(Party)
             .filter(Party.id.in_(party_subquery))
         )
+        result = await session.execute(query)
+        return result.scalars().all()
+
+    @classmethod
+    async def get_all_players_with_characters_in_party(
+        cls, session: AsyncSession, party_id: int, player_id: int | None = None
+    ) -> list[Player]:
+        """Return all players belonging to the argument party"""
+        query = select(Player).join(Character).join(Party).filter(Party.id == party_id)
+        if player_id:
+            query = query.filter(Player.id == player_id)
         result = await session.execute(query)
         return result.scalars().all()

--- a/dnd5esheets/repositories/player.py
+++ b/dnd5esheets/repositories/player.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Sequence, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -60,7 +60,7 @@ class PlayerRepository(BaseRepository):
     @classmethod
     async def get_all_players_with_characters_in_same_party_than_character(
         cls, session: AsyncSession, character_slug: str
-    ) -> list[Player]:
+    ) -> Sequence[Player]:
         """Return all players belonging to the same party than the argument character"""
         party_subquery = (
             select(Party.id)
@@ -80,7 +80,7 @@ class PlayerRepository(BaseRepository):
     @classmethod
     async def get_all_players_with_characters_in_party(
         cls, session: AsyncSession, party_id: int, player_id: int | None = None
-    ) -> list[Player]:
+    ) -> Sequence[Player]:
         """Return all players belonging to the argument party"""
         query = select(Player).join(Character).join(Party).filter(Party.id == party_id)
         if player_id:

--- a/dnd5esheets/security/policies.py
+++ b/dnd5esheets/security/policies.py
@@ -1,0 +1,49 @@
+from fastapi import Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dnd5esheets.db import create_scoped_session
+from dnd5esheets.exceptions import Forbidden
+from dnd5esheets.models import Role
+from dnd5esheets.repositories.character import CharacterRepository
+from dnd5esheets.repositories.player import PlayerRepository
+from dnd5esheets.security.user import get_current_user_id
+
+
+async def party_gm_or_owner(
+    request: Request,
+    current_user_id=Depends(get_current_user_id),
+    session: AsyncSession = Depends(create_scoped_session),
+):
+    """Security policy allowing access to a route only by the resource owner or the associated party GM"""
+    character_slug = request.scope["path_params"]["slug"]
+    character = await CharacterRepository.get_by_slug(session, slug=character_slug)
+    current_player = await PlayerRepository.get_by_id(session, current_user_id)
+    if current_player == character.player:
+        return
+    character_party = character.party
+    for player_role in current_player.player_roles:
+        if player_role.party_id == character_party.id and player_role.role == Role.gm:
+            return
+    raise Forbidden(
+        detail="Only the resource owner or the party GM can access this resource"
+    )
+
+
+async def in_same_party(
+    request: Request,
+    current_user_id: int | None = Depends(get_current_user_id),
+    session: AsyncSession = Depends(create_scoped_session),
+):
+    """Security policy allowing access to a route only to players belonging to the same party"""
+    character_slug = request.scope["path_params"]["slug"]
+    character = await CharacterRepository.get_by_slug(session, slug=character_slug)
+    if character is None:
+        return
+    current_player = await PlayerRepository.get_by_id(session, current_user_id)
+    players_in_party = await PlayerRepository.get_all_players_with_characters_in_same_party_than_character(
+        session, character_slug=character_slug
+    )
+    if current_player not in players_in_party:
+        raise Forbidden(
+            detail="Only a member of the same party can access this resource"
+        )

--- a/dnd5esheets/security/policies/base.py
+++ b/dnd5esheets/security/policies/base.py
@@ -1,0 +1,19 @@
+from dnd5esheets.exceptions import Forbidden
+from dnd5esheets.models import Party, Player, Role
+
+
+def _in_same_party(current_player: Player, players_in_party: list[Player]):
+    if current_player not in players_in_party:
+        raise Forbidden(
+            detail="Only a member of the same party can access this resource"
+        )
+
+
+def _is_party_gm(players: list[Player], party: Party):
+    for player in players:
+        for player_role in player.player_roles:
+            if player_role.party_id == party.id and player_role.role == Role.gm:
+                return
+    raise Forbidden(
+        detail="Only the resource owner or the party GM can access this resource"
+    )

--- a/dnd5esheets/security/policies/base.py
+++ b/dnd5esheets/security/policies/base.py
@@ -1,15 +1,17 @@
+from typing import Sequence
+
 from dnd5esheets.exceptions import Forbidden
 from dnd5esheets.models import Party, Player, Role
 
 
-def _in_same_party(current_player: Player, players_in_party: list[Player]):
+def _in_same_party(current_player: Player, players_in_party: Sequence[Player]):
     if current_player not in players_in_party:
         raise Forbidden(
             detail="Only a member of the same party can access this resource"
         )
 
 
-def _is_party_gm(players: list[Player], party: Party):
+def _is_party_gm(players: Sequence[Player], party: Party):
     for player in players:
         for player_role in player.player_roles:
             if player_role.party_id == party.id and player_role.role == Role.gm:

--- a/dnd5esheets/security/policies/character.py
+++ b/dnd5esheets/security/policies/character.py
@@ -1,3 +1,5 @@
+"""Security policies related to Character resources"""
+
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/dnd5esheets/security/policies/party.py
+++ b/dnd5esheets/security/policies/party.py
@@ -1,29 +1,28 @@
-"""Security policies related to Character resources"""
+"""Security policies related to Party resources"""
 
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dnd5esheets.db import create_scoped_session
-from dnd5esheets.exceptions import Forbidden
-from dnd5esheets.models import Role
-from dnd5esheets.repositories.character import CharacterRepository
+from dnd5esheets.repositories.party import PartyRepository
 from dnd5esheets.repositories.player import PlayerRepository
 from dnd5esheets.security.policies.base import _in_same_party, _is_party_gm
 from dnd5esheets.security.user import get_current_user_id
 
 
-async def party_gm_or_owner(
+async def is_party_gm(
     request: Request,
     current_user_id=Depends(get_current_user_id),
     session: AsyncSession = Depends(create_scoped_session),
 ):
     """Security policy allowing access to a route only by the resource owner or the associated party GM"""
-    character_slug = request.scope["path_params"]["slug"]
-    character = await CharacterRepository.get_by_slug(session, slug=character_slug)
+    party_id = request.scope["path_params"]["id"]
+    party = await PartyRepository.get_by_id(session, id=party_id)
     current_player = await PlayerRepository.get_by_id(session, current_user_id)
-    if current_player == character.player:
-        return
-    return _is_party_gm(players=[current_player], party=character.party)
+    players_in_party = await PlayerRepository.get_all_players_with_characters_in_party(
+        session, party_id=party_id, player_id=current_player.id
+    )
+    return _is_party_gm(players=players_in_party, party=party)
 
 
 async def in_same_party(
@@ -32,13 +31,13 @@ async def in_same_party(
     session: AsyncSession = Depends(create_scoped_session),
 ):
     """Security policy allowing access to a route only to players belonging to the same party"""
-    character_slug = request.scope["path_params"]["slug"]
-    character = await CharacterRepository.get_by_slug(session, slug=character_slug)
-    if character is None:
+    party_id = request.scope["path_params"]["id"]
+    party = await PartyRepository.get_by_id(session, id=party_id)
+    if party is None:
         return
     current_player = await PlayerRepository.get_by_id(session, current_user_id)
-    players_in_party = await PlayerRepository.get_all_players_with_characters_in_same_party_than_character(
-        session, character_slug=character_slug
+    players_in_party = await PlayerRepository.get_all_players_with_characters_in_party(
+        session, party_id=party_id
     )
     return _in_same_party(
         current_player=current_player, players_in_party=players_in_party

--- a/dnd5esheets/security/policies/player.py
+++ b/dnd5esheets/security/policies/player.py
@@ -1,0 +1,22 @@
+"""Security policies related to Party resources"""
+
+from fastapi import Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dnd5esheets.db import create_scoped_session
+from dnd5esheets.exceptions import Forbidden
+from dnd5esheets.repositories.player import PlayerRepository
+from dnd5esheets.security.user import get_current_user_id
+
+
+async def is_owner(
+    request: Request,
+    current_user_id=Depends(get_current_user_id),
+    session: AsyncSession = Depends(create_scoped_session),
+):
+    """Security policy allowing access to a route only by the resource owner"""
+    player_id = request.scope["path_params"]["id"]
+    player = await PlayerRepository.get_by_id(session, id=player_id)
+    current_player = await PlayerRepository.get_by_id(session, current_user_id)
+    if player != current_player:
+        raise Forbidden(detail="This resource can only be accessed by its owner")

--- a/dnd5esheets/security/policies/player.py
+++ b/dnd5esheets/security/policies/player.py
@@ -3,6 +3,8 @@
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from dnd5esheets.config import get_settings
+from dnd5esheets.config.base import CommonSettings
 from dnd5esheets.db import create_scoped_session
 from dnd5esheets.exceptions import Forbidden
 from dnd5esheets.repositories.player import PlayerRepository
@@ -13,8 +15,12 @@ async def is_owner(
     request: Request,
     current_user_id=Depends(get_current_user_id),
     session: AsyncSession = Depends(create_scoped_session),
+    settings: CommonSettings = Depends(get_settings),
 ):
     """Security policy allowing access to a route only by the resource owner"""
+    if not settings.MULTITENANT_ENABLED:
+        return
+
     player_id = request.scope["path_params"]["id"]
     player = await PlayerRepository.get_by_id(session, id=player_id)
     current_player = await PlayerRepository.get_by_id(session, current_user_id)

--- a/dnd5esheets/tests/conftest.py
+++ b/dnd5esheets/tests/conftest.py
@@ -18,6 +18,8 @@ from dnd5esheets.cli import (
 from dnd5esheets.db import create_session
 from dnd5esheets.models import Character, Player
 
+from .utils import log_as
+
 current_dir = Path(__file__).parent
 
 
@@ -33,11 +35,27 @@ def unauthed_client(app):
 
 @fixture(scope="session")
 def client(app):
-    _client = TestClient(app)
-    _client.post(
-        "/api/login/token", data={"username": "br@test.com", "password": "azerty"}
-    )
-    return _client
+    return log_as("br@test.com", app)
+
+
+@fixture(scope="session")
+def client_as_mctrickfoot_family_gm(app):
+    return log_as("br@test.com", app)
+
+
+@fixture(scope="session")
+def client_as_mctrickfoot_family_player(app):
+    return log_as("eb@test.com", app)
+
+
+@fixture(scope="session")
+def client_as_compagnie_des_gourmands_gm(app):
+    return log_as("eb@test.com", app)
+
+
+@fixture(scope="session")
+def client_as_compagnie_des_gourmands_player(app):
+    return log_as("ne@test.com", app)
 
 
 @fixture(scope="session", autouse=True)

--- a/dnd5esheets/tests/test_api_character.py
+++ b/dnd5esheets/tests/test_api_character.py
@@ -1,11 +1,6 @@
 import pytest
 
-from .conftest import (
-    client_as_compagnie_des_gourmands_player,
-    client_as_mctrickfoot_family_gm,
-    client_as_mctrickfoot_family_player,
-)
-from .utils import assert_status_and_return_data, log_as
+from .utils import assert_status_and_return_data
 
 
 def test_list_characters(client):

--- a/dnd5esheets/tests/test_api_character.py
+++ b/dnd5esheets/tests/test_api_character.py
@@ -1,4 +1,11 @@
-from .utils import assert_status_and_return_data
+import pytest
+
+from .conftest import (
+    client_as_compagnie_des_gourmands_player,
+    client_as_mctrickfoot_family_gm,
+    client_as_mctrickfoot_family_player,
+)
+from .utils import assert_status_and_return_data, log_as
 
 
 def test_list_characters(client):
@@ -41,6 +48,26 @@ def test_describe_character(client):
     }
 
 
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 200),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_describe_character_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.get,
+        f"/api/character/{slug}",
+        status_code=status_code,
+    )
+
+
 def test_update_characters(client):
     initial_data = assert_status_and_return_data(
         client.get, "/api/character/douglas-mctrickfoot", status_code=200
@@ -61,6 +88,30 @@ def test_update_characters(client):
     )
     assert updated_data["name"] == "Ronald McDonald"
     assert updated_data["data"]["abilities"]["strength"]["score"] == 10
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_update_character_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put,
+        f"/api/character/{slug}",
+        status_code=status_code,
+        json={
+            "name": "Ronald McDonald",
+            "data": {"abilities": {"strength": {"score": 10}}},
+        },
+    )
 
 
 def test_update_with_invalid_payload(client):
@@ -168,10 +219,20 @@ def test_delete_character(client):
     )
 
 
-def test_delete_character_from_non_owner(client):
-    assert_status_and_return_data(
-        client.get, "/api/character/trevor-mctrickfoot", status_code=404
-    )
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 204),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 204),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_delete_character_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert client.delete(f"/api/character/{slug}").status_code == status_code
 
 
 def test_change_character_equipment_item_equipped_status(client):
@@ -200,6 +261,26 @@ def test_change_character_equipment_item_equipped_status(client):
     assert data_after_update["equipment"][0]["equipped"] is False
 
 
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_change_character_equipment_item_equipped_status_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put,
+        f"/api/character/{slug}/equipment/2/equip",
+        status_code=status_code,
+    )
+
+
 def test_change_known_spell_prepared_status(client):
     data = assert_status_and_return_data(
         client.get, "/api/character/douglas-mctrickfoot", status_code=200
@@ -226,6 +307,26 @@ def test_change_known_spell_prepared_status(client):
     assert data_after_update["spellbook"][0]["prepared"] is True
 
 
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_change_known_spell_prepared_status_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put,
+        f"/api/character/{slug}/spellbook/12/prepare",
+        status_code=status_code,
+    )
+
+
 def test_learn_spell(client):
     data = assert_status_and_return_data(
         client.get, "/api/character/douglas-mctrickfoot", status_code=200
@@ -239,6 +340,26 @@ def test_learn_spell(client):
     )
     assert len(updated_data["spellbook"]) == 8
     assert updated_data["spellbook"][-1]["spell"]["name"] == "Ceremony"
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_learn_spell_prepared_status_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put,
+        f"/api/character/{slug}/spellbook/30",
+        status_code=status_code,
+    )
 
 
 def test_forget_spell(client):
@@ -259,6 +380,26 @@ def test_forget_spell(client):
     assert updated_data["spellbook"][-1]["id"] != known_spell_id
 
 
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_forget_spell_prepared_status_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.delete,
+        f"/api/character/{slug}/spellbook/30",
+        status_code=status_code,
+    )
+
+
 def test_add_item_to_equipment(client):
     data = assert_status_and_return_data(
         client.get, "/api/character/douglas-mctrickfoot", status_code=200
@@ -272,6 +413,26 @@ def test_add_item_to_equipment(client):
     )
     assert len(updated_data["equipment"]) == 2
     assert updated_data["equipment"][-1]["item"]["name"] == "Club"
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_add_item_to_equipment_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put,
+        f"/api/character/{slug}/equipment/10",
+        status_code=status_code,
+    )
 
 
 def test_remove_item_from_equipment(client):
@@ -289,3 +450,23 @@ def test_remove_item_from_equipment(client):
         client.get, "/api/character/douglas-mctrickfoot", status_code=200
     )
     assert len(updated_data["equipment"]) == 0
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, slug, status_code",
+    [
+        ("mctrickfoot_family_player", "trevor-mctrickfoot", 200),  # owner
+        ("mctrickfoot_family_player", "douglas-mctrickfoot", 403),  # party member
+        ("mctrickfoot_family_gm", "trevor-mctrickfoot", 200),  # gm
+        ("compagnie_des_gourmands_player", "douglas-mctrickfoot", 403),  # outsider
+    ],
+)
+def test_delete_item_from_equipment_security_policy(
+    client_fixture_name, slug, status_code, request
+):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.delete,
+        f"/api/character/{slug}/equipment/2",
+        status_code=status_code,
+    )

--- a/dnd5esheets/tests/test_api_party.py
+++ b/dnd5esheets/tests/test_api_party.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .utils import assert_status_and_return_data
 
 
@@ -16,6 +18,23 @@ def test_describe_party(client):
     assert len(data["members"]) == 4
 
 
+@pytest.mark.parametrize(
+    "client_fixture_name, status_code",
+    [
+        ("mctrickfoot_family_player", 200),  # player
+        ("mctrickfoot_family_gm", 200),  # gm
+        ("compagnie_des_gourmands_player", 403),  # outsider
+    ],
+)
+def test_describe_party_security_policy(client_fixture_name, status_code, request):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.get,
+        f"/api/party/1",
+        status_code=status_code,
+    )
+
+
 def test_update_party(client):
     data = assert_status_and_return_data(client.get, "/api/party/1", status_code=200)
     assert data["name"] == "Famille McTrickfoot"
@@ -27,6 +46,24 @@ def test_update_party(client):
     )
     data = assert_status_and_return_data(client.get, "/api/party/1", status_code=200)
     assert data["name"] == "McTrickfoot Family"
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, status_code",
+    [
+        ("mctrickfoot_family_player", 403),  # player
+        ("mctrickfoot_family_gm", 200),  # gm
+        ("compagnie_des_gourmands_player", 403),  # outsider
+    ],
+)
+def test_describe_party_security_policy(client_fixture_name, status_code, request):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put,
+        f"/api/party/1",
+        status_code=status_code,
+        json={"name": "Le Clan des Semi-Croustillants"},
+    )
 
 
 def test_update_party_invalid_body(client):

--- a/dnd5esheets/tests/test_api_party.py
+++ b/dnd5esheets/tests/test_api_party.py
@@ -30,7 +30,7 @@ def test_describe_party_security_policy(client_fixture_name, status_code, reques
     client = request.getfixturevalue(f"client_as_{client_fixture_name}")
     assert_status_and_return_data(
         client.get,
-        f"/api/party/1",
+        "/api/party/1",
         status_code=status_code,
     )
 
@@ -56,11 +56,11 @@ def test_update_party(client):
         ("compagnie_des_gourmands_player", 403),  # outsider
     ],
 )
-def test_describe_party_security_policy(client_fixture_name, status_code, request):
+def test_update_party_security_policy(client_fixture_name, status_code, request):
     client = request.getfixturevalue(f"client_as_{client_fixture_name}")
     assert_status_and_return_data(
         client.put,
-        f"/api/party/1",
+        "/api/party/1",
         status_code=status_code,
         json={"name": "Le Clan des Semi-Croustillants"},
     )

--- a/dnd5esheets/tests/test_api_player.py
+++ b/dnd5esheets/tests/test_api_player.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .utils import assert_status_and_return_data
 
 
@@ -6,6 +8,22 @@ def test_describe_player(client):
     assert data["id"] == 1
     assert data["name"] == "Balthazar"
     assert len(data["characters"]) == 1  # Douglas
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, status_code",
+    [
+        ("mctrickfoot_family_gm", 200),  # owner
+        ("mctrickfoot_family_player", 403),  # non owner
+    ],
+)
+def test_describe_player_security_policy(client_fixture_name, status_code, request):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.get,
+        f"/api/player/1",
+        status_code=status_code,
+    )
 
 
 def test_update_player(client):
@@ -19,6 +37,20 @@ def test_update_player(client):
     )
     data = assert_status_and_return_data(client.get, "/api/player/1", status_code=200)
     assert data["name"] == "Ronald"
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name, status_code",
+    [
+        ("mctrickfoot_family_gm", 200),  # owner
+        ("mctrickfoot_family_player", 403),  # non owner
+    ],
+)
+def test_update_player_security_policy(client_fixture_name, status_code, request):
+    client = request.getfixturevalue(f"client_as_{client_fixture_name}")
+    assert_status_and_return_data(
+        client.put, f"/api/player/1", status_code=status_code, json={"name": "Gauvain"}
+    )
 
 
 def test_update_player_invalid_body(client):

--- a/dnd5esheets/tests/test_api_player.py
+++ b/dnd5esheets/tests/test_api_player.py
@@ -21,7 +21,7 @@ def test_describe_player_security_policy(client_fixture_name, status_code, reque
     client = request.getfixturevalue(f"client_as_{client_fixture_name}")
     assert_status_and_return_data(
         client.get,
-        f"/api/player/1",
+        "/api/player/1",
         status_code=status_code,
     )
 
@@ -49,7 +49,7 @@ def test_update_player(client):
 def test_update_player_security_policy(client_fixture_name, status_code, request):
     client = request.getfixturevalue(f"client_as_{client_fixture_name}")
     assert_status_and_return_data(
-        client.put, f"/api/player/1", status_code=status_code, json={"name": "Gauvain"}
+        client.put, "/api/player/1", status_code=status_code, json={"name": "Gauvain"}
     )
 
 

--- a/dnd5esheets/tests/test_repository_character.py
+++ b/dnd5esheets/tests/test_repository_character.py
@@ -7,7 +7,7 @@ from dnd5esheets.schemas import CreateCharacterSchema, UpdateCharacterSchema
 
 @pytest.mark.asyncio
 async def test_list_all_no_owner(async_session):
-    assert len(await CharacterRepository.list_all(async_session)) == 4
+    assert len(await CharacterRepository.list_all(async_session)) == 6
 
 
 @pytest.mark.asyncio
@@ -142,9 +142,7 @@ async def test_delete_character(async_session):
         async_session, slug="douglas-mctrickfoot"
     )
     assert douglas is not None
-    await CharacterRepository.delete(
-        async_session, slug="douglas-mctrickfoot", owner_id=1
-    )
+    await CharacterRepository.delete(async_session, slug="douglas-mctrickfoot")
     with pytest.raises(ModelNotFound):
         await CharacterRepository.get_by_slug(async_session, slug="douglas-mctrickfoot")
 
@@ -159,7 +157,6 @@ async def test_change_equipment_item_equipped_status(async_session):
     douglas = await CharacterRepository.change_equipment_item_equipped_status(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         equipped_item_id=douglas.equipment[0].id,
         equipped=True,
     )
@@ -168,7 +165,6 @@ async def test_change_equipment_item_equipped_status(async_session):
     douglas = await CharacterRepository.change_equipment_item_equipped_status(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         equipped_item_id=douglas.equipment[0].id,
         equipped=False,
     )
@@ -185,7 +181,6 @@ async def test_change_known_spell_prepared_status(async_session):
     douglas = await CharacterRepository.change_known_spell_prepared_status(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         known_spell_id=douglas.spellbook[0].id,
         prepared=False,
     )
@@ -194,8 +189,7 @@ async def test_change_known_spell_prepared_status(async_session):
     douglas = await CharacterRepository.change_known_spell_prepared_status(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
-        known_spell_id=douglas.equipment[0].id,
+        known_spell_id=douglas.spellbook[0].id,
         prepared=True,
     )
     assert douglas.spellbook[0].prepared is True
@@ -210,7 +204,6 @@ async def test_learn_spell(async_session):
     await CharacterRepository.learn_spell(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         spell_id=45,
         prepared=True,
     )
@@ -232,7 +225,6 @@ async def test_forget_spell(async_session):
     await CharacterRepository.forget_spell(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         known_spell_id=known_spell_id,
     )
     douglas = await CharacterRepository.get_by_slug(
@@ -250,7 +242,6 @@ async def test_add_item_to_equipment(async_session):
     await CharacterRepository.add_item_to_equipment(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         item_id=30,
     )
     douglas = await CharacterRepository.get_by_slug(
@@ -270,7 +261,6 @@ async def test_from_item_from_equipment(async_session):
     await CharacterRepository.remove_item_from_equipment(
         async_session,
         slug="douglas-mctrickfoot",
-        owner_id=1,
         equipped_item_id=equipped_item_id,
     )
     douglas = await CharacterRepository.get_by_slug(

--- a/dnd5esheets/tests/test_repository_equipped_item.py
+++ b/dnd5esheets/tests/test_repository_equipped_item.py
@@ -1,6 +1,5 @@
 import pytest
 
-from dnd5esheets.exceptions import ModelNotFound
 from dnd5esheets.repositories.equipped_item import EquippedItemRepository
 
 

--- a/dnd5esheets/tests/test_repository_equipped_item.py
+++ b/dnd5esheets/tests/test_repository_equipped_item.py
@@ -7,19 +7,11 @@ from dnd5esheets.repositories.equipped_item import EquippedItemRepository
 @pytest.mark.asyncio
 async def test_change_equipped_item_equipped_status(async_session):
     equipped_item = await EquippedItemRepository.change_equipped_status(
-        async_session, id=1, owner_id=1, equipped=False
+        async_session, id=1, equipped=False
     )
     assert equipped_item.equipped is False
 
     equipped_item = await EquippedItemRepository.change_equipped_status(
-        async_session, id=1, owner_id=1, equipped=True
+        async_session, id=1, equipped=True
     )
     assert equipped_item.equipped is True
-
-
-@pytest.mark.asyncio
-async def test_change_equipped_item_equipped_status_when_not_owner(async_session):
-    with pytest.raises(ModelNotFound):
-        await EquippedItemRepository.change_equipped_status(
-            async_session, id=1, owner_id=2, equipped=False
-        )

--- a/dnd5esheets/tests/test_repository_party.py
+++ b/dnd5esheets/tests/test_repository_party.py
@@ -16,36 +16,10 @@ async def test_list_all_with_owner(async_session):
 
 
 @pytest.mark.asyncio
-async def test_get_by_id_if_member_of_with_righful_owner(async_session):
-    party = await PartyRepository.get_by_id_if_member_of(
-        async_session, id=1, member_id=1
-    )
-    assert len(party.members) == 4
-
-
-@pytest.mark.asyncio
-async def test_get_by_id_if_member_of_with_unrighful_owner(async_session):
-    with pytest.raises(ModelNotFound):
-        await PartyRepository.get_by_id_if_member_of(async_session, id=2, member_id=1)
-
-
-@pytest.mark.asyncio
-async def test_update_if_member_of_with_righful_owner(async_session):
-    party = await PartyRepository.update_if_member_of(
+async def test_update(async_session):
+    party = await PartyRepository.update(
         async_session,
         id=1,
-        member_id=1,
         body=UpdatePartySchema(name="La Famille Adams"),
     )
     assert party.name == "La Famille Adams"
-
-
-@pytest.mark.asyncio
-async def test_update_if_member_of_with_unrighful_owner(async_session):
-    with pytest.raises(ModelNotFound):
-        await PartyRepository.update_if_member_of(
-            async_session,
-            id=2,
-            member_id=1,
-            body=UpdatePartySchema(name="La Famille Adams"),
-        )

--- a/dnd5esheets/tests/test_repository_party.py
+++ b/dnd5esheets/tests/test_repository_party.py
@@ -1,6 +1,5 @@
 import pytest
 
-from dnd5esheets.exceptions import ModelNotFound
 from dnd5esheets.repositories.party import PartyRepository
 from dnd5esheets.schemas import UpdatePartySchema
 

--- a/dnd5esheets/tests/utils.py
+++ b/dnd5esheets/tests/utils.py
@@ -1,6 +1,17 @@
+from fastapi.testclient import TestClient
+
+from dnd5esheets import ExtendedFastAPI
+
+
 def assert_status_and_return_data(client_method, url, status_code, *args, **kwargs):
     response = client_method(url, *args, **kwargs)
     assert (
         response.status_code == status_code
     ), f"Expected: {status_code}, got: {response.status_code}"
     return response.json()
+
+
+def log_as(email: str, app: ExtendedFastAPI) -> TestClient:
+    _client = TestClient(app)
+    _client.post("/api/login/token", data={"username": email, "password": "azerty"})
+    return _client


### PR DESCRIPTION
This PR introduces security policies that we hook onto API routes via [path operation decorator dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/).

This allows to gate the access to the resource by:
- checking that the player is logged in
- checking that the _role_ of the player allows them to access the resource (whether they are the owner, a party member or the party DM) 

Fixes #225
