### PR TITLE
Improve migration readability by replacing json_extract by ->> operator

### DIFF
--- a/dnd5esheets/migrations/versions/2023_08_09_15_45_623e8558c9ba_add_item_full_text_search_table.py
+++ b/dnd5esheets/migrations/versions/2023_08_09_15_45_623e8558c9ba_add_item_full_text_search_table.py
@@ -44,8 +44,8 @@ def upgrade() -> None:
                     cast(hex(json_each.key) as integer) + new.id,
                     new.id,
                     json_each.key,
-                    json_extract(json_each.value, '$.name'),
-                    json_extract(json_each.value, '$.description')
+                    json_each.value ->> '$.name',
+                    json_each.value ->> '$.description'
                 FROM json_each(json_extract(new.json_data, '$.meta.translations'));
         END;
         """,
@@ -66,8 +66,8 @@ def upgrade() -> None:
                 cast(hex(json_each.key) as integer) + item.id,
                 item.id,
                 json_each.key,
-                json_extract(json_each.value, '$.name'),
-                json_extract(json_each.value, '$.description')
+                json_each.value ->> '$.name',
+                json_each.value ->> '$.description'
             FROM item, json_each(json_extract(item.json_data, '$.meta.translations'));
         """,
         # Every time an item is deleted from DB, delete it from the search index
@@ -97,9 +97,9 @@ def upgrade() -> None:
                     cast(hex(json_each.key) as integer) + new.id,
                     new.id,
                     json_each.key,
-                    json_extract(json_each.value, '$.name'),
-                    json_extract(json_each.value, '$.description')
-                FROM json_each(json_extract(new.json_data, '$.meta.translations'));
+                    json_each.value ->> '$.name',
+                    json_each.value ->> '$.description'
+                FROM json_each(new.json_data ->> '$.meta.translations');
         END
         """,
     ]

--- a/dnd5esheets/migrations/versions/2023_08_10_14_15_e3f5418ab972_add_spell_full_text_search_table.py
+++ b/dnd5esheets/migrations/versions/2023_08_10_14_15_e3f5418ab972_add_spell_full_text_search_table.py
@@ -37,16 +37,16 @@ def upgrade() -> None:
                 new.id,
                 'en',
                 new.name,
-                json_extract(new.json_data, '$.meta.description')
+                new.json_data ->>'$.meta.description'
             );
             INSERT INTO spell_search_index (rowid, spell_id, language, name, description)
                 SELECT
                     cast(hex(json_each.key) as integer) + new.id,
                     new.id,
                     json_each.key,
-                    json_extract(json_each.value, '$.name'),
-                    json_extract(json_each.value, '$.description')
-                FROM json_each(json_extract(new.json_data, '$.meta.translations'));
+                    json_each.value ->> '$.name',
+                    json_each.value ->> '$.description'
+                FROM json_each(new.json_data ->> '$.meta.translations');
         END;
         """,
         # Populate the search index with the existing spells
@@ -57,7 +57,7 @@ def upgrade() -> None:
                 id,
                 'en',
                 name,
-                json_extract(json_data, '$.meta.description')
+                json_data ->> '$.meta.description'
             FROM spell;
         """,
         """
@@ -66,9 +66,9 @@ def upgrade() -> None:
                 cast(hex(json_each.key) as integer) + spell.id,
                 spell.id,
                 json_each.key,
-                json_extract(json_each.value, '$.name'),
-                json_extract(json_each.value, '$.description')
-            FROM spell, json_each(json_extract(spell.json_data, '$.meta.translations'));
+                json_each.value ->> '$.name',
+                json_each.value ->> '$.description'
+            FROM spell, json_each(spell.json_data ->> '$.meta.translations');
         """,
         # Every time an spell is deleted from DB, delete it from the search index
         """
@@ -90,16 +90,16 @@ def upgrade() -> None:
                 new.id,
                 'en',
                 new.name,
-                json_extract(new.json_data, '$.meta.description')
+                new.json_data ->> '$.meta.description'
             );
             REPLACE INTO spell_search_index (rowid, spell_id, language, name, description)
                 SELECT
                     cast(hex(json_each.key) as integer) + new.id,
                     new.id,
                     json_each.key,
-                    json_extract(json_each.value, '$.name'),
-                    json_extract(json_each.value, '$.description')
-                FROM json_each(json_extract(new.json_data, '$.meta.translations'));
+                    json_each.value ->> '$.name',
+                    json_each.value ->> '$.description'
+                FROM json_each(new.json_data ->> '$.meta.translations');
         END
         """,
     ]


### PR DESCRIPTION
Now that the sqlite3 version has been pinned, we can now leverage more modern features, such as the `->>` [operator](https://www.sqlite.org/json1.html#jptr)
