### PR TITLE
Pin the sqlite version when running the app in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
 # -- Build step, in charge of compiling the frontend app
-FROM node:20.2.0-bullseye-slim AS build
+FROM node:20.2.0-bullseye-slim AS front-build
 
-WORKDIR /app
+WORKDIR /app/src/build
 
 COPY dnd5esheets/front/package.json ./
 COPY dnd5esheets/front/package-lock.json ./
 RUN npm install
 COPY dnd5esheets/front/ ./
 RUN npm run build
+
+
+# -- Build the libsqlite3.so shared object for the appropriate architecture
+FROM python:3.11.4-slim AS sqlite-build
+
+WORKDIR /app/src/build
+
+COPY scripts/compile-libsqlite-linux.sh ./
+RUN apt-get update && \
+    apt-get install -y build-essential wget tcl && \
+    ./compile-libsqlite-linux.sh && \
+    apt-get remove -y build-essential wget tcl && \
+    apt clean
 
 
 # -- Main build combining the FastAPI and compiled frontend apps
@@ -22,6 +35,7 @@ COPY dnd5esheets ./dnd5esheets
 COPY alembic.ini .
 COPY scripts/start-app.sh .
 RUN rm -r ./dnd5esheets/front/*
-COPY --from=build /app/dist ./dnd5esheets/front/dist
+COPY --from=front-build /app/src/build/dist ./dnd5esheets/front/dist
+COPY --from=sqlite-build /app/src/build/libsqlite3.so ./lib/libsqlite3.so
 
 CMD ["./start-app.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint global ignore=DL3008
 # -- Build step, in charge of compiling the frontend app
 FROM node:20.2.0-bullseye-slim AS front-build
 
@@ -17,10 +18,10 @@ WORKDIR /app/src/build
 
 COPY scripts/compile-libsqlite-linux.sh ./
 RUN apt-get update && \
-    apt-get install -y build-essential wget tcl && \
+    apt-get install --no-install-recommends -y build-essential wget tcl && \
     ./compile-libsqlite-linux.sh && \
     apt-get remove -y build-essential wget tcl && \
-    apt clean
+    apt-get auto-clean
 
 
 # -- Main build combining the FastAPI and compiled frontend apps

--- a/scripts/compile-libsqlite-linux.sh
+++ b/scripts/compile-libsqlite-linux.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-apt-get install -y build-essential wget
+apt-get install -y build-essential wget tcl
 
 # link associated with sqlite 3.42.0, found on https://www.sqlite.org/src/timeline?t=version-3.42.0 -> https://www.sqlite.org/src/info/831d0fb2836b71c9
-cd /tmp
 wget https://www.sqlite.org/src/tarball/831d0fb2/SQLite-831d0fb2.tar.gz
 tar -xzvf SQLite-831d0fb2.tar.gz
 cd SQLite-831d0fb2
 
 CPPFLAGS="-DSQLITE_ENABLE_FTS5" ./configure
 make
+cp .libs/libsqlite3.so ./..

--- a/scripts/start-app.sh
+++ b/scripts/start-app.sh
@@ -3,4 +3,6 @@
 set -e
 
 alembic upgrade head
-exec uvicorn --factory dnd5esheets.app:create_app --host "0.0.0.0" --port 8000
+exec \
+    env LD_PRELOAD=./lib/libsqlite3.so \
+    uvicorn --factory dnd5esheets.app:create_app --host "0.0.0.0" --port 8000


### PR DESCRIPTION
We compile `libsqlite3.so` as part of the `docker build` process, in a build step,
copy it into the final image, and hook it into the app via `LD_PRELOAD`.

```console
% make docker-run
...
2023-08-24 11:20:13.685774 [info     ] Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
```

```console
% curl localhost:8000/api/debug/sqlite-version
{"version":"3.42.0"}
```