### PR TITLE
Add markdown rendering to free-form editable text boxes

### DIFF
--- a/dnd5esheets/front/package-lock.json
+++ b/dnd5esheets/front/package-lock.json
@@ -6,6 +6,10 @@
   "packages": {
     "": {
       "name": "front",
+      "dependencies": {
+        "dompurify": "^3.0.6",
+        "marked": "^9.1.3"
+      },
       "devDependencies": {
         "@solid-primitives/i18n": "^1.4.1",
         "@solid-primitives/resource": "^0.1.0",
@@ -3205,6 +3209,11 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+    },
     "node_modules/domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -5822,6 +5831,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/marked": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.3.tgz",
+      "integrity": "sha512-XPU/J7GzU/n4voCSw1VYggtr3W5C2OeGkwEbe5PIQdA8thaie2Qw+fig6iNidKNDokTNcyR4OE9fMK14P6rqPg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/mdn-data": {

--- a/dnd5esheets/front/package-lock.json
+++ b/dnd5esheets/front/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "front",
       "dependencies": {
+        "@types/dompurify": "^3.0.4",
         "dompurify": "^3.0.6",
         "marked": "^9.1.3"
       },
@@ -1640,6 +1641,14 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.4.tgz",
+      "integrity": "sha512-1Jk8S/IRzNSbwQRbuGuLFHviwxQ8pX81ZEW3INY9432Cwb4VedkBYan8gSIXVLOLHBtimOmUTEYphjRVmo+30g==",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
@@ -1756,6 +1765,11 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.5.tgz",
+      "integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",

--- a/dnd5esheets/front/package.json
+++ b/dnd5esheets/front/package.json
@@ -46,6 +46,7 @@
     "node": ">=16"
   },
   "dependencies": {
+    "@types/dompurify": "^3.0.4",
     "dompurify": "^3.0.6",
     "marked": "^9.1.3"
   }

--- a/dnd5esheets/front/package.json
+++ b/dnd5esheets/front/package.json
@@ -44,5 +44,9 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "dependencies": {
+    "dompurify": "^3.0.6",
+    "marked": "^9.1.3"
   }
 }

--- a/dnd5esheets/front/src/App.tsx
+++ b/dnd5esheets/front/src/App.tsx
@@ -53,7 +53,6 @@ function GlobalStyles() {
       .hidden {
         display: none;
       }
-
     }
   `
   return null

--- a/dnd5esheets/front/src/App.tsx
+++ b/dnd5esheets/front/src/App.tsx
@@ -49,6 +49,11 @@ function GlobalStyles() {
         font-family: 'MrEaves';
         src: url('/assets/font/Mr Eaves Small Caps.otf');
       }
+
+      .hidden {
+        display: none;
+      }
+
     }
   `
   return null

--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -362,12 +362,14 @@ export default function CharacterSheet(props: {
           >
             <MarkdownRenderedEditableBox
               id="languages-proficiencies"
-              text={character.data?.languages_and_proficiencies || ''}
-              onChange={(equipment: string) => {
-                onChange({
-                  data: { languages_and_proficiencies },
-                })
-              }}></MarkdownRenderedEditableBox>
+              text={props.character.data?.languages_and_proficiencies || ''}
+              onChange={(languagesAndProficiencies: string) =>
+                props.updateCharacter(
+                  (character) =>
+                    (character.data.languages_and_proficiencies = languagesAndProficiencies)
+                )
+              }
+            ></MarkdownRenderedEditableBox>
           </LabeledBox>
         </div>
       </section>
@@ -379,44 +381,80 @@ export default function CharacterSheet(props: {
       </section>
       <section class="equipment flex-container">
         <LabeledBox label={t('equipment')}>
-          <MarkdownRenderedEditableBox
+          {/* <MarkdownRenderedEditableBox
             id="equipment"
-            text={character.data?.equipment || ''}
-            onChange={(equipment: string) => {
-              onChange({
-                data: { equipment },
-              })
-            }}>
-          </MarkdownRenderedEditableBox>
+            text={props.character.data.equipment || ''}
+            onChange={(equipment: string) =>
+              props.updateCharacter(
+                (character) =>
+                  (character.data.equipment = character.data.equipment)
+              )
+            }
+          >
+          </MarkdownRenderedEditableBox> */}
         </LabeledBox>
       </section>
       <section class="flavor flex-container">
-        <LabeledBox label={t('personality')}>
-          <MarkdownRenderedEditableBox
-            id="personality"
-            text={character.data?.personality || ''}
-            onChange={(personality: string) => {
-              onChange({
-                data: { personality },
-              })
-            }}>
-          </MarkdownRenderedEditableBox>
-
-        </LabeledBox>
+        <BorderBox>
+          <LabeledBox label={t('personality')}>
+            <MarkdownRenderedEditableBox
+              id="personality"
+              text={props.character.data?.personality || ''}
+              onChange={(personality: string) =>
+                props.updateCharacter(
+                  (character) => character.data.personality = personality
+                )
+              }>
+            </MarkdownRenderedEditableBox>
+          </LabeledBox>
+          <LabeledBox label={t('ideals')}>
+            <MarkdownRenderedEditableBox
+              id="ideals"
+              text={props.character.data?.ideals || ''}
+              onChange={(ideals: string) =>
+                props.updateCharacter(
+                  (character) => character.data.ideals = ideals
+                )
+              }>
+            </MarkdownRenderedEditableBox>
+          </LabeledBox>
+          <LabeledBox label={t('bonds')}>
+            <MarkdownRenderedEditableBox
+              id="bonds"
+              text={props.character.data?.bonds || ''}
+              onChange={(bonds: string) =>
+                props.updateCharacter(
+                  (character) => character.data.bonds = bonds
+                )
+              }>
+            </MarkdownRenderedEditableBox>
+          </LabeledBox>
+          <LabeledBox label={t('flaws')}>
+            <MarkdownRenderedEditableBox
+              id="flaws"
+              text={props.character.data?.flaws || ''}
+              onChange={(flaws: string) =>
+                props.updateCharacter(
+                  (character) => character.data.flaws = flaws
+                )
+              }>
+            </MarkdownRenderedEditableBox>
+          </LabeledBox>
+        </BorderBox>
       </section>
       <section class="features_and_traits flex-container">
         <LabeledBox label={t('features_&_traits')}>
           <MarkdownRenderedEditableBox
             id="features-traits"
-            text={character.data?.features || ''}
-            onChange={(features: string) => {
-              onChange({
-                data: { features },
-              })
-            }}>
+            text={props.character.data?.features || ''}
+            onChange={(features: string) =>
+              props.updateCharacter(
+                (character) => character.data.features = features
+              )
+            }>
           </MarkdownRenderedEditableBox>
         </LabeledBox>
       </section>
-    </section>
+    </section >
   )
 }

--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -10,6 +10,7 @@ import LabeledBox from '~/components/LabeledBox'
 import LabeledInput from '~/components/LabeledInput'
 import TrayBox from '~/components/TrayBox'
 import { ResolvedCharacter, UpdateCharacterFunction } from '~/store'
+import MarkdownRenderedEditableBox from './MarkdownRenderedEditableBox'
 
 export default function CharacterSheet(props: {
   character: ResolvedCharacter
@@ -217,8 +218,8 @@ export default function CharacterSheet(props: {
                       onChange={(score: number) => {
                         props.updateCharacter(
                           (character) =>
-                            (character.data.abilities[ability].score =
-                              Number.isNaN(score) ? 0 : score)
+                          (character.data.abilities[ability].score =
+                            Number.isNaN(score) ? 0 : score)
                         )
                       }}
                     />
@@ -268,8 +269,8 @@ export default function CharacterSheet(props: {
                         onChange={(proficiency: Proficiency) =>
                           props.updateCharacter(
                             (character) =>
-                              (character.data.abilities[ability].proficiency =
-                                proficiency)
+                            (character.data.abilities[ability].proficiency =
+                              proficiency)
                           )
                         }
                       />
@@ -327,8 +328,8 @@ export default function CharacterSheet(props: {
                         onChange={(proficiency: Proficiency) =>
                           props.updateCharacter(
                             (character) =>
-                              (character.data.skills[skill].proficiency =
-                                proficiency)
+                            (character.data.skills[skill].proficiency =
+                              proficiency)
                           )
                         }
                       />
@@ -358,7 +359,16 @@ export default function CharacterSheet(props: {
           />
           <LabeledBox
             label={t('other_proficiencies_and_languages')}
-          ></LabeledBox>
+          >
+            <MarkdownRenderedEditableBox
+              id="languages-proficiencies"
+              text={character.data?.languages_and_proficiencies || ''}
+              onChange={(equipment: string) => {
+                onChange({
+                  data: { languages_and_proficiencies },
+                })
+              }}></MarkdownRenderedEditableBox>
+          </LabeledBox>
         </div>
       </section>
       <section class="combat-stats flex-container">
@@ -368,14 +378,43 @@ export default function CharacterSheet(props: {
         <LabeledBox label={t('attacks')}></LabeledBox>
       </section>
       <section class="equipment flex-container">
-        <LabeledBox label={t('equipment')}></LabeledBox>
+        <LabeledBox label={t('equipment')}>
+          <MarkdownRenderedEditableBox
+            id="equipment"
+            text={character.data?.equipment || ''}
+            onChange={(equipment: string) => {
+              onChange({
+                data: { equipment },
+              })
+            }}>
+          </MarkdownRenderedEditableBox>
+        </LabeledBox>
       </section>
       <section class="flavor flex-container">
-        <LabeledBox label={t('personality')}></LabeledBox>
+        <LabeledBox label={t('personality')}>
+          <MarkdownRenderedEditableBox
+            id="personality"
+            text={character.data?.personality || ''}
+            onChange={(personality: string) => {
+              onChange({
+                data: { personality },
+              })
+            }}>
+          </MarkdownRenderedEditableBox>
+
+        </LabeledBox>
       </section>
       <section class="features_and_traits flex-container">
         <LabeledBox label={t('features_&_traits')}>
-          <div style="height: 100%; width: 100%" contentEditable></div>
+          <MarkdownRenderedEditableBox
+            id="features-traits"
+            text={character.data?.features || ''}
+            onChange={(features: string) => {
+              onChange({
+                data: { features },
+              })
+            }}>
+          </MarkdownRenderedEditableBox>
         </LabeledBox>
       </section>
     </section>

--- a/dnd5esheets/front/src/components/CharacterSheet.tsx
+++ b/dnd5esheets/front/src/components/CharacterSheet.tsx
@@ -4,13 +4,13 @@ import { useI18n } from '@solid-primitives/i18n'
 
 import { Proficiency } from '~/5esheets-client'
 import BorderBox from '~/components/BorderBox'
-import ScoreBox from '~/components/ScoreBox'
-import ProficientAttribute from '~/components/ProficientAttribute'
 import LabeledBox from '~/components/LabeledBox'
 import LabeledInput from '~/components/LabeledInput'
+import MarkdownRenderedEditableBox from '~/components/MarkdownRenderedEditableBox'
+import ProficientAttribute from '~/components/ProficientAttribute'
+import ScoreBox from '~/components/ScoreBox'
 import TrayBox from '~/components/TrayBox'
 import { ResolvedCharacter, UpdateCharacterFunction } from '~/store'
-import MarkdownRenderedEditableBox from './MarkdownRenderedEditableBox'
 
 export default function CharacterSheet(props: {
   character: ResolvedCharacter
@@ -218,8 +218,8 @@ export default function CharacterSheet(props: {
                       onChange={(score: number) => {
                         props.updateCharacter(
                           (character) =>
-                          (character.data.abilities[ability].score =
-                            Number.isNaN(score) ? 0 : score)
+                            (character.data.abilities[ability].score =
+                              Number.isNaN(score) ? 0 : score)
                         )
                       }}
                     />
@@ -269,8 +269,8 @@ export default function CharacterSheet(props: {
                         onChange={(proficiency: Proficiency) =>
                           props.updateCharacter(
                             (character) =>
-                            (character.data.abilities[ability].proficiency =
-                              proficiency)
+                              (character.data.abilities[ability].proficiency =
+                                proficiency)
                           )
                         }
                       />
@@ -328,8 +328,8 @@ export default function CharacterSheet(props: {
                         onChange={(proficiency: Proficiency) =>
                           props.updateCharacter(
                             (character) =>
-                            (character.data.skills[skill].proficiency =
-                              proficiency)
+                              (character.data.skills[skill].proficiency =
+                                proficiency)
                           )
                         }
                       />
@@ -357,16 +357,15 @@ export default function CharacterSheet(props: {
               )
             }
           />
-          <LabeledBox
-            label={t('other_proficiencies_and_languages')}
-          >
+          <LabeledBox label={t('other_proficiencies_and_languages')}>
             <MarkdownRenderedEditableBox
               id="languages-proficiencies"
               text={props.character.data?.languages_and_proficiencies || ''}
               onChange={(languagesAndProficiencies: string) =>
                 props.updateCharacter(
                   (character) =>
-                    (character.data.languages_and_proficiencies = languagesAndProficiencies)
+                    (character.data.languages_and_proficiencies =
+                      languagesAndProficiencies)
                 )
               }
             ></MarkdownRenderedEditableBox>
@@ -402,10 +401,10 @@ export default function CharacterSheet(props: {
               text={props.character.data?.personality || ''}
               onChange={(personality: string) =>
                 props.updateCharacter(
-                  (character) => character.data.personality = personality
+                  (character) => (character.data.personality = personality)
                 )
-              }>
-            </MarkdownRenderedEditableBox>
+              }
+            ></MarkdownRenderedEditableBox>
           </LabeledBox>
           <LabeledBox label={t('ideals')}>
             <MarkdownRenderedEditableBox
@@ -413,10 +412,10 @@ export default function CharacterSheet(props: {
               text={props.character.data?.ideals || ''}
               onChange={(ideals: string) =>
                 props.updateCharacter(
-                  (character) => character.data.ideals = ideals
+                  (character) => (character.data.ideals = ideals)
                 )
-              }>
-            </MarkdownRenderedEditableBox>
+              }
+            ></MarkdownRenderedEditableBox>
           </LabeledBox>
           <LabeledBox label={t('bonds')}>
             <MarkdownRenderedEditableBox
@@ -424,10 +423,10 @@ export default function CharacterSheet(props: {
               text={props.character.data?.bonds || ''}
               onChange={(bonds: string) =>
                 props.updateCharacter(
-                  (character) => character.data.bonds = bonds
+                  (character) => (character.data.bonds = bonds)
                 )
-              }>
-            </MarkdownRenderedEditableBox>
+              }
+            ></MarkdownRenderedEditableBox>
           </LabeledBox>
           <LabeledBox label={t('flaws')}>
             <MarkdownRenderedEditableBox
@@ -435,10 +434,10 @@ export default function CharacterSheet(props: {
               text={props.character.data?.flaws || ''}
               onChange={(flaws: string) =>
                 props.updateCharacter(
-                  (character) => character.data.flaws = flaws
+                  (character) => (character.data.flaws = flaws)
                 )
-              }>
-            </MarkdownRenderedEditableBox>
+              }
+            ></MarkdownRenderedEditableBox>
           </LabeledBox>
         </BorderBox>
       </section>
@@ -449,12 +448,12 @@ export default function CharacterSheet(props: {
             text={props.character.data?.features || ''}
             onChange={(features: string) =>
               props.updateCharacter(
-                (character) => character.data.features = features
+                (character) => (character.data.features = features)
               )
-            }>
-          </MarkdownRenderedEditableBox>
+            }
+          ></MarkdownRenderedEditableBox>
         </LabeledBox>
       </section>
-    </section >
+    </section>
   )
 }

--- a/dnd5esheets/front/src/components/MarkdownRenderedEditableBox.tsx
+++ b/dnd5esheets/front/src/components/MarkdownRenderedEditableBox.tsx
@@ -1,16 +1,14 @@
 import { Component, createEffect } from 'solid-js'
 import { css } from 'solid-styled'
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 const MarkdownRenderedEditableBox: Component<{
-  id: string,
+  id: string
   text: string
   onChange: (update: string) => void
 }> = (props) => {
-
   css`
-
     .markdown-rendered-editable-box-wrapper {
       padding: 1em;
       height: 100%;
@@ -19,93 +17,96 @@ const MarkdownRenderedEditableBox: Component<{
     .markdown-raw {
       width: 100%;
     }
+  `
 
-  `;
-
-  const hiddenClass = "hidden";
-  const markdownRenderer = new marked.Renderer();
-  const linkRenderer = markdownRenderer.link;
-  marked.setOptions({
-    mangle: false,
-    headerIds: false,
-  });
+  const hiddenClass = 'hidden'
+  const markdownRenderer = new marked.Renderer()
+  const linkRenderer = markdownRenderer.link
 
   // always render links so they open in a new tab
-  markdownRenderer.link = (href: string, title: string, text: string): string => {
-    const html = linkRenderer.call(markdownRenderer, href, title, text);
-    return html.replace(/^<a /, '<a target="_blank" ');
-  };
+  markdownRenderer.link = (
+    href: string,
+    title: string,
+    text: string
+  ): string => {
+    const html = linkRenderer.call(markdownRenderer, href, title, text)
+    return html.replace(/^<a /, '<a target="_blank" ')
+  }
 
   // DOMPurify sees target blank links as a security issue, so massage it
   // into accepting then.
   // Source: https://github.com/cure53/DOMPurify/issues/317#issuecomment-698800327
-  DOMPurify.addHook("afterSanitizeAttributes", function (node: HTMLElement) {
+  DOMPurify.addHook('afterSanitizeAttributes', function (node: Element) {
     // set all elements owning target to target=_blank
-    if ("target" in node) {
-      node.setAttribute("target", "_blank");
-      node.setAttribute("rel", "noopener");
+    if ('target' in node) {
+      node.setAttribute('target', '_blank')
+      node.setAttribute('rel', 'noopener')
     }
-  });
+  })
 
   const hideRawTextareaShowRenderedDiv = () => {
-    props.text;
-    const textarea = document.getElementById(`${props.id}-raw`);
+    props.text
+    const textarea = document.getElementById(
+      `${props.id}-raw`
+    ) as HTMLTextAreaElement
     if (!textarea) {
-      return;
+      return
     }
-    const neighbourDiv = document.getElementById(`${props.id}-rendered`);
+    const neighbourDiv = document.getElementById(`${props.id}-rendered`)
     if (!neighbourDiv) {
-      return;
+      return
     }
     if (textarea.value) {
-      textarea.textContent = textarea.value;
+      textarea.textContent = textarea.value
 
       const rendered: string = marked.parse(textarea.textContent, {
         renderer: markdownRenderer,
-      });
-      neighbourDiv.innerHTML = DOMPurify.sanitize(rendered);
-      textarea.classList.add(hiddenClass);
-      neighbourDiv.classList.remove(hiddenClass);
+      })
+      neighbourDiv.innerHTML = DOMPurify.sanitize(rendered)
+      textarea.classList.add(hiddenClass)
+      neighbourDiv.classList.remove(hiddenClass)
     } else {
       // The textarea does not contain any text, so hiding it would prevent us from
       // writing in it in the first place.
-      textarea.classList.remove(hiddenClass);
-      neighbourDiv.classList.add(hiddenClass);
+      textarea.classList.remove(hiddenClass)
+      neighbourDiv.classList.add(hiddenClass)
     }
   }
 
   const showRawTextareHideRenderedDiv = () => {
-    props.text;
-    const textarea = document.getElementById(`${props.id}-raw`);
+    props.text
+    const textarea = document.getElementById(`${props.id}-raw`)
     if (!textarea) {
       return
     }
-    const neighbourDiv = document.getElementById(`${props.id}-rendered`);
+    const neighbourDiv = document.getElementById(`${props.id}-rendered`)
     if (!neighbourDiv) {
       return
     }
-    textarea.classList.remove(hiddenClass);
-    textarea.focus({ preventScroll: true });
-    neighbourDiv.classList.add(hiddenClass);
-  };
+    textarea.classList.remove(hiddenClass)
+    textarea.focus({ preventScroll: true })
+    neighbourDiv.classList.add(hiddenClass)
+  }
 
-  createEffect(() => hideRawTextareaShowRenderedDiv());
+  createEffect(() => hideRawTextareaShowRenderedDiv())
 
   return (
     <div class="markdown-rendered-editable-box-wrapper">
       <textarea
-        id={props.id + "-raw"}
+        id={props.id + '-raw'}
         class="markdown-raw hidden"
         onfocusout={() => hideRawTextareaShowRenderedDiv()}
-        onChange={() => props.onChange(props.text)}>{props.text}
+        onChange={() => props.onChange(props.text)}
+      >
+        {props.text}
       </textarea>
       <div
         class="markdown-rendered"
-        id={props.id + "-rendered"}
-        onclick={() => showRawTextareHideRenderedDiv()}>
-      </div>
+        id={props.id + '-rendered'}
+        onclick={() => showRawTextareHideRenderedDiv()}
+      ></div>
     </div>
   )
 }
 
-export default MarkdownRenderedEditableBox;
+export default MarkdownRenderedEditableBox

--- a/dnd5esheets/front/src/components/MarkdownRenderedEditableBox.tsx
+++ b/dnd5esheets/front/src/components/MarkdownRenderedEditableBox.tsx
@@ -1,0 +1,111 @@
+import { Component, createEffect } from 'solid-js'
+import { css } from 'solid-styled'
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+const MarkdownRenderedEditableBox: Component<{
+  id: string,
+  text: string
+  onChange: (update: string) => void
+}> = (props) => {
+
+  css`
+
+    .markdown-rendered-editable-box-wrapper {
+      padding: 1em;
+      height: 100%;
+    }
+
+    .markdown-raw {
+      width: 100%;
+    }
+
+  `;
+
+  const hiddenClass = "hidden";
+  const markdownRenderer = new marked.Renderer();
+  const linkRenderer = markdownRenderer.link;
+  marked.setOptions({
+    mangle: false,
+    headerIds: false,
+  });
+
+  // always render links so they open in a new tab
+  markdownRenderer.link = (href: string, title: string, text: string): string => {
+    const html = linkRenderer.call(markdownRenderer, href, title, text);
+    return html.replace(/^<a /, '<a target="_blank" ');
+  };
+
+  // DOMPurify sees target blank links as a security issue, so massage it
+  // into accepting then.
+  // Source: https://github.com/cure53/DOMPurify/issues/317#issuecomment-698800327
+  DOMPurify.addHook("afterSanitizeAttributes", function (node: HTMLElement) {
+    // set all elements owning target to target=_blank
+    if ("target" in node) {
+      node.setAttribute("target", "_blank");
+      node.setAttribute("rel", "noopener");
+    }
+  });
+
+  const hideRawTextareaShowRenderedDiv = () => {
+    props.text;
+    const textarea = document.getElementById(`${props.id}-raw`);
+    if (!textarea) {
+      return;
+    }
+    const neighbourDiv = document.getElementById(`${props.id}-rendered`);
+    if (!neighbourDiv) {
+      return;
+    }
+    if (textarea.value) {
+      textarea.textContent = textarea.value;
+
+      const rendered: string = marked.parse(textarea.textContent, {
+        renderer: markdownRenderer,
+      });
+      neighbourDiv.innerHTML = DOMPurify.sanitize(rendered);
+      textarea.classList.add(hiddenClass);
+      neighbourDiv.classList.remove(hiddenClass);
+    } else {
+      // The textarea does not contain any text, so hiding it would prevent us from
+      // writing in it in the first place.
+      textarea.classList.remove(hiddenClass);
+      neighbourDiv.classList.add(hiddenClass);
+    }
+  }
+
+  const showRawTextareHideRenderedDiv = () => {
+    props.text;
+    const textarea = document.getElementById(`${props.id}-raw`);
+    if (!textarea) {
+      return
+    }
+    const neighbourDiv = document.getElementById(`${props.id}-rendered`);
+    if (!neighbourDiv) {
+      return
+    }
+    textarea.classList.remove(hiddenClass);
+    textarea.focus({ preventScroll: true });
+    neighbourDiv.classList.add(hiddenClass);
+  };
+
+  createEffect(() => hideRawTextareaShowRenderedDiv());
+
+  return (
+    <div class="markdown-rendered-editable-box-wrapper">
+      <textarea
+        id={props.id + "-raw"}
+        class="markdown-raw hidden"
+        onfocusout={() => hideRawTextareaShowRenderedDiv()}
+        onChange={() => props.onChange(props.text)}>{props.text}
+      </textarea>
+      <div
+        class="markdown-rendered"
+        id={props.id + "-rendered"}
+        onclick={() => showRawTextareHideRenderedDiv()}>
+      </div>
+    </div>
+  )
+}
+
+export default MarkdownRenderedEditableBox;


### PR DESCRIPTION
This is imperfect but works as-is. 

| Before | Markdown edition | Rendered |
| -- | -- | -- |
| <img width="301" alt="Screenshot 2023-10-30 at 15 41 06" src="https://github.com/brouberol/5esheets/assets/480131/4af4d50b-af3e-4f95-88f8-c903bc0cdb29">|<img width="336" alt="Screenshot 2023-10-30 at 15 41 20" src="https://github.com/brouberol/5esheets/assets/480131/e6052abc-5f5f-48af-bee6-7932adea62a5"> |<img width="306" alt="Screenshot 2023-10-30 at 15 41 24" src="https://github.com/brouberol/5esheets/assets/480131/cfc30dea-9ddc-43e5-8302-64348c41ef28">|

⚠️ The layout jumps all over the place when we add long text. To be fixed in another PR.
