### PR TITLE
Import lucide icons directly

### DIFF
--- a/dnd5esheets/front/src/components/icons/icon.tsx
+++ b/dnd5esheets/front/src/components/icons/icon.tsx
@@ -1,0 +1,79 @@
+import { For, splitProps } from 'solid-js'
+import { Dynamic } from 'solid-js/web'
+
+const defaultAttributes = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  width: 24,
+  height: 24,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  'stroke-width': 2,
+  'stroke-linecap': 'round',
+  'stroke-linejoin': 'round',
+} as const
+
+export interface IconProps {
+  color?: string
+  size?: string
+  strokeWidth?: string
+  children?: string
+  class?: string
+  name?: string
+  iconNode?: IconNode
+  absoluteStrokeWidth?: string
+}
+
+export type IconNode = [string, { d: string; key: string }][]
+
+/**
+ * Converts string to KebabCase
+ * Copied from scripts/helper. If anyone knows how to properly import it here
+ * then please fix it.
+ *
+ * @param {string} string
+ * @returns {string} A kebabized string
+ */
+export const toKebabCase = (string: string) =>
+  string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+
+const Icon = (props: IconProps) => {
+  const [localProps, rest] = splitProps(props, [
+    'color',
+    'size',
+    'strokeWidth',
+    'children',
+    'class',
+    'name',
+    'iconNode',
+    'absoluteStrokeWidth',
+  ])
+  return (
+    <svg
+      {...defaultAttributes}
+      width={localProps.size ?? defaultAttributes.width}
+      height={localProps.size ?? defaultAttributes.height}
+      stroke={localProps.color ?? defaultAttributes.stroke}
+      stroke-width={
+        localProps.absoluteStrokeWidth
+          ? (Number(
+              localProps.strokeWidth ?? defaultAttributes['stroke-width']
+            ) *
+              24) /
+            Number(localProps.size)
+          : Number(localProps.strokeWidth ?? defaultAttributes['stroke-width'])
+      }
+      class={`lucide lucide-${toKebabCase(localProps?.name ?? 'icon')} ${
+        localProps.class != null ? localProps.class : ''
+      }`}
+      {...rest}
+    >
+      <For each={localProps.iconNode}>
+        {([elementName, attrs]) => {
+          return <Dynamic component={elementName} {...attrs} />
+        }}
+      </For>
+    </svg>
+  )
+}
+export default Icon

--- a/dnd5esheets/front/src/components/icons/minus.tsx
+++ b/dnd5esheets/front/src/components/icons/minus.tsx
@@ -1,0 +1,7 @@
+import Icon, { IconNode, IconProps } from './icon'
+
+const iconNode: IconNode = [['path', { d: 'M5 12h14', key: '1ays0h' }]]
+const Minus = (props: IconProps) => (
+  <Icon {...props} name="Minus" iconNode={iconNode} />
+)
+export { Minus }

--- a/dnd5esheets/front/src/components/icons/plus.tsx
+++ b/dnd5esheets/front/src/components/icons/plus.tsx
@@ -1,0 +1,9 @@
+import Icon, { IconNode, IconProps } from './icon'
+const iconNode: IconNode = [
+  ['path', { d: 'M5 12h14', key: '1ays0h' }],
+  ['path', { d: 'M12 5v14', key: 's699le' }],
+]
+const Plus = (props: IconProps) => (
+  <Icon {...props} name="Plus" iconNode={iconNode} />
+)
+export { Plus }

--- a/dnd5esheets/front/src/components/number-input/index.tsx
+++ b/dnd5esheets/front/src/components/number-input/index.tsx
@@ -4,7 +4,9 @@ import * as hoverCard from '@zag-js/hover-card'
 import { normalizeProps, useMachine } from '@zag-js/solid'
 import { Show, createEffect, createMemo, createUniqueId } from 'solid-js'
 import { Portal } from 'solid-js/web'
-import { Minus, Plus } from 'lucide-solid'
+
+import { Minus } from '~/components/icons/minus'
+import { Plus } from '~/components/icons/plus'
 
 export default function NumberInput(props: {
   iconSize?: string
@@ -87,12 +89,12 @@ export default function NumberInput(props: {
 
     button[data-part='increment-trigger'] {
       top: calc(50% - var(--button-size) / 2);
-      right: calc(100% - min(var(--button-size) * 0.7, 20%));
+      left: calc(100% - min(var(--button-size) * 0.7, 20%));
     }
 
     button[data-part='decrement-trigger'] {
       top: calc(50% - var(--button-size) / 2);
-      left: calc(100% - min(var(--button-size) * 0.7, 20%));
+      right: calc(100% - min(var(--button-size) * 0.7, 20%));
     }
 
     [data-part='positioner'] {


### PR DESCRIPTION
Not sure why, but storybook fails to load the lucide icons from the package, so this PR copies the two we use directly in the src/components.