### PR TITLE
drop rowid

### DIFF
--- a/dnd5esheets/migrations/versions/2023_08_09_15_45_623e8558c9ba_add_item_full_text_search_table.py
+++ b/dnd5esheets/migrations/versions/2023_08_09_15_45_623e8558c9ba_add_item_full_text_search_table.py
@@ -32,8 +32,7 @@ def upgrade() -> None:
         CREATE TRIGGER item_after_insert
             AFTER INSERT ON item
         BEGIN
-            INSERT INTO item_search_index (rowid, item_id, language, name, description) VALUES (
-                cast(hex('en') as integer) + new.id,
+            INSERT INTO item_search_index (item_id, language, name, description) VALUES (
                 new.id,
                 'en',
                 new.name,


### PR DESCRIPTION
Hi, random guy on the internet here who ran into your code via GitHub search when looking for examples of inserting JSON into FTS5.

I don't think you need to specify `rowid` when inserting into `spell_search_index` (and `item_search_index`). My understanding (which could be wrong) is that you only need to specify `rowid` if your FTS5 index is "contentless" or "external content", neither of which applies here. (And you shouldn't use them, since being contentless/external would require the FTS5 index to be 1:1 with the content table. This is due to the content table sharing the same `rowid` as the FTS5 table. I think. (Being 1:1 is not desirable since the point of indexing the JSON payload is to make the spell->FTS5 relationship 1:many.))

In my own database, if I omit specifying `rowid`, the standard autoincrementing `rowid` is used.

```sql
CREATE VIRTUAL TABLE IF NOT EXISTS noteFtsFv USING fts5 (
    noteId UNINDEXED,
    field,
    value,
  );

INSERT INTO noteFtsFv (noteId, field, value)
	SELECT 
	  'someid',
	  json_each.key,
	  json_each.value
	FROM json_each('{"Front":"x","Back":"x"}');

SELECT rowid, * FROM noteFtsFv;
```
The above yields this table for me

![image](https://github.com/brouberol/5esheets/assets/109672176/e5525922-e5c6-4997-af34-4c517c574e1b)

You should probably reject this PR since I just made it to demonstrate one place that I'm talking about; you use `CAST(HEX(json_each.key) as integer) + new.id` in other places.